### PR TITLE
Cleanup the root pkgjson

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ gulp.task("copy-assets", gulp.series('clean', function () {
 
 /**
  * Generate a folder with just the needed files for an npm publish.
- * The publish action is in the npm scripts (npm run publish)
+ * The publish action is in the npm scripts (npm run publish-setup)
  */
 gulp.task('publish-clean', function() {
  return del(['publish/**/*', '!publish/package.json']);

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "publish": "gulp publish",
     "publish-dev": "gulp publish && npm publish publish --tag dev",
     "publish-prod": "gulp publish && npm publish publish",
-    "publish-nightly": "gulp publish && npm publish publish --tag nightly",
-    "prepublishOnly": "tsc -p ./ --outDir dist/"
+    "publish-nightly": "gulp publish && npm publish publish --tag nightly"
   },
   "dependencies": {
     "@angular/animations": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "test": "ng test --browsers=PhantomJS --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "publish-setup": "gulp publish",
-    "publish-dev": "gulp publish && npm publish publish --tag dev",
-    "publish-prod": "gulp publish && npm publish publish"
+    "publish-setup": "cd ./publish && npm run prepublishOnly && cd ../",
+    "publish-dev": "npm publish publish/ --tag dev",
+    "publish-prod": "npm publish publish/"
   },
   "dependencies": {
     "@angular/animations": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "e2e": "ng e2e",
     "publish": "gulp publish",
     "publish-dev": "gulp publish && npm publish publish --tag dev",
-    "publish-prod": "gulp publish && npm publish publish",
-    "publish-nightly": "gulp publish && npm publish publish --tag nightly"
+    "publish-prod": "gulp publish && npm publish publish"
   },
   "dependencies": {
     "@angular/animations": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "ng test --browsers=PhantomJS --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "publish": "gulp publish",
+    "publish-setup": "gulp publish",
     "publish-dev": "gulp publish && npm publish publish --tag dev",
     "publish-prod": "gulp publish && npm publish publish"
   },

--- a/publish/package.json
+++ b/publish/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/infor-design/enterprise-ng",
   "scripts": {
+    "prepublishOnly": "cd ../ && npx gulp publish && cd ./publish",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

- [x] This moves the actual `prepublishOnly` npm script cmd to the true package.json file used for publishing.
- [x] I also removed some deprecated command and renamed `npm run publish` so that we don't confuse that with the native `npm publish`