### PR TITLE
allow for the next button to be called on the last panel, save and cl…

### DIFF
--- a/src/app/stepprocess/stepprocess.demo.html
+++ b/src/app/stepprocess/stepprocess.demo.html
@@ -1,4 +1,6 @@
-<div soho-stepprocess>
+<div soho-stepprocess
+     (onSaveClose)="onSaveClose($event)"
+>
 
   <div soho-step-list-title>
     Steps to complete

--- a/src/app/stepprocess/stepprocess.demo.ts
+++ b/src/app/stepprocess/stepprocess.demo.ts
@@ -4,4 +4,9 @@ import { Component } from '@angular/core';
   selector: 'soho-stepprocess-demo',
   templateUrl: './stepprocess.demo.html'
 })
-export class StepProcessDemoComponent {}
+export class StepProcessDemoComponent {
+  onSaveClose(event: SohoStepSaveCloseEvent) {
+    console.log('onSaveClose fired');
+    console.log('currentStepId: ' + event.currentStepId);
+  }
+}

--- a/src/soho/stepprocess/soho-stepprocess.component.ts
+++ b/src/soho/stepprocess/soho-stepprocess.component.ts
@@ -1,11 +1,4 @@
-import {
-  AfterViewInit,
-  Component,
-  ElementRef,
-  HostBinding,
-  Input,
-  OnDestroy, Output, EventEmitter,
-} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, EventEmitter, HostBinding, Input, OnDestroy, Output } from '@angular/core';
 
 /**************************************************************
  * STEP LIST TITLE
@@ -161,6 +154,12 @@ export class SohoStepProcessComponent implements AfterViewInit, OnDestroy {
     }
   }
 
+  @Input() set nextButtonLabel(label: string) {
+    if (this.jQueryElement) {
+      this.jQueryElement.find('.js-step-link-next').html(label);
+    }
+  }
+
   @Input() set nextButtonEnable(enabled: boolean) {
     if (this.jQueryElement) {
       this.jQueryElement.find('.js-step-link-next').prop('disabled', !enabled);
@@ -173,11 +172,18 @@ export class SohoStepProcessComponent implements AfterViewInit, OnDestroy {
     }
   }
 
+  @Input() set saveCloseButtonEnable(enabled: boolean) {
+    if (this.jQueryElement) {
+      this.jQueryElement.find('.js-btn-save-changes').prop('disabled', !enabled);
+    }
+  }
+
   // ------------------------------------------------------------------------
   // @Outputs
   // ------------------------------------------------------------------------
 
   @Output() beforeSelectStep = new EventEmitter<BeforeSelectStepEvent>();
+  @Output() onSaveClose: EventEmitter<SohoStepSaveCloseEvent> = new EventEmitter<SohoStepSaveCloseEvent>();
 
   // ------------------------------------------------------------------------
 
@@ -202,6 +208,8 @@ export class SohoStepProcessComponent implements AfterViewInit, OnDestroy {
     this.jQueryElement = jQuery(this.element.nativeElement);
     this.jQueryElement.stepprocess(this.stepProcessOptions);
     this.stepprocess = this.jQueryElement.data('stepprocess');
+    this.jQueryElement.find('.js-btn-save-changes').
+    on('click', (e: JQuery.Event) => { this.fireOnSaveClose(); });
   }
 
   private beforeSelectStepPromise = (args: { stepLink: JQuery, isStepping: StepDirection }): JQueryPromise<boolean> => {
@@ -226,7 +234,12 @@ export class SohoStepProcessComponent implements AfterViewInit, OnDestroy {
         beforeSelectStepEvent.currentStepId = $selectedStep.children('a').attr('href').substring(1);
       }
 
-      beforeSelectStepEvent.targetStepId = $(args.stepLink).attr('href').substring(1);
+      if (args.stepLink) {
+        beforeSelectStepEvent.targetStepId = $(args.stepLink).attr('href').substring(1);
+      } else {
+        beforeSelectStepEvent.targetStepId = beforeSelectStepEvent.currentStepId;
+      }
+
       beforeSelectStepEvent.isStepping = args.isStepping;
       beforeSelectStepEvent.response = this.beforeSelectStepResponse;
       this.beforeSelectStep.emit(beforeSelectStepEvent);
@@ -243,6 +256,13 @@ export class SohoStepProcessComponent implements AfterViewInit, OnDestroy {
     } else {
       this.beforeSelectStepDeferred.resolve(response.continue);
     }
+  }
+
+  private fireOnSaveClose(): void {
+    const $selectedStep = this.stepprocess.getSelectedStep();
+    const currentStepId = $selectedStep.children('a').attr('href').substring(1);
+    const event: SohoStepSaveCloseEvent = {currentStepId: currentStepId};
+    this.onSaveClose.emit(event);
   }
 
   ngOnDestroy() {

--- a/src/soho/stepprocess/soho-stepprocess.component.ts
+++ b/src/soho/stepprocess/soho-stepprocess.component.ts
@@ -1,4 +1,12 @@
-import {AfterViewInit, Component, ElementRef, EventEmitter, HostBinding, Input, OnDestroy, Output } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostBinding,
+  Input,
+  OnDestroy,
+  Output } from '@angular/core';
 
 /**************************************************************
  * STEP LIST TITLE

--- a/src/soho/stepprocess/soho-stepprocess.d.ts
+++ b/src/soho/stepprocess/soho-stepprocess.d.ts
@@ -73,6 +73,10 @@ interface BeforeSelectStepResult {
   overrideTargetStepId?: string;
 }
 
+interface SohoStepSaveCloseEvent {
+  currentStepId?: string;
+}
+
 type StepDirection = 'prev' | 'next' | 'none';
 
 interface BeforeSelectStepEvent {


### PR DESCRIPTION
Explain the details for making this change:
1. Implement the Landmark feature 'LastPanelNavigation',  the is feature requires that the last step run an action then navigate to another page.  Current impl , didn't fire the onbeforeselect event if on the last step.

2. Implement Save and Close for mobile apps.  Pressing this button should fire an event for consumers of the control to handle.

3. Ability to rename the Next Button, part of the feature for 'LastPanelNavigation' feature.
Steps necessary to review your pull request (required) 

Related issue:  
https://jira.infor.com/browse/SOHO-7950Changes needed too..

Steps necessary to review your pull request 
Use the stepprocessdemo click the close button the the Console should print out a debug statement
