### PR TITLE
Upgrade cli to fix npm ng-cli issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,19 +96,19 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.6.3.tgz",
-      "integrity": "sha512-dXlyVNuFRhiOnhAk0NojEUThLrZBpVZmWvEQ4h/pnyHS0P9CfnHqJ8DCcCrjOwYkzdBwBrYchXOCYfo8zuxYGw==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.6.7.tgz",
+      "integrity": "sha512-DdVYUJls09w+efSZAN96WdcwrAZ6dnJGcUeep7TvImCTu26UPmckEw/yy0HvfM1rSZZsu/VN8r1PoaQTbGc2vw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.6.3",
+        "@angular-devkit/core": "0.6.7",
         "rxjs": "6.1.0"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.6.3.tgz",
-          "integrity": "sha512-97hFVW6in8oYJUEqjmUP0Tb/mPlTG3sc0THpe5MCGEkDPjlp2cObt9rUCAVOjugBlScV8rzTpVQ+95PT60Py8A==",
+          "version": "0.6.7",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.6.7.tgz",
+          "integrity": "sha512-kzNI95g3of8C0an2U/lUa2ixqABFKQt06VfzSz6pUCl/RJblLnxua9dgsSb8jc0eDQ5ZmekXN0UgkED0JDYXsQ==",
           "dev": true,
           "requires": {
             "ajv": "6.4.0",
@@ -128,16 +128,16 @@
       }
     },
     "@angular/cli": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-6.0.3.tgz",
-      "integrity": "sha512-G8jfgJublsRjveX1P+F5awHvpC07mKAF7f5lebowIs+QAHSOD6HxQ/JhMbJTwz/aj20iWgZOygA5LhkP0Wr+UQ==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-6.0.7.tgz",
+      "integrity": "sha512-rPFhPjT6TegRV5qENEgg0MwQKFDuqbF+OoEqgE5QjTQC2gQhnG/sHOgyqixHtvdLOaPfZczCjEltGQj/ELArqw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.6.3",
-        "@angular-devkit/core": "0.6.3",
-        "@angular-devkit/schematics": "0.6.3",
-        "@schematics/angular": "0.6.3",
-        "@schematics/update": "0.6.3",
+        "@angular-devkit/architect": "0.6.7",
+        "@angular-devkit/core": "0.6.7",
+        "@angular-devkit/schematics": "0.6.7",
+        "@schematics/angular": "0.6.7",
+        "@schematics/update": "0.6.7",
         "opn": "5.3.0",
         "resolve": "1.7.1",
         "rxjs": "6.1.0",
@@ -148,19 +148,19 @@
       },
       "dependencies": {
         "@angular-devkit/architect": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.6.3.tgz",
-          "integrity": "sha512-w9tK3VACU+CnOQQZT6o7QO2brn/OVNDf2Y11rI+ZQH7UIn6N0ZFoMl9WyFB//K2Gkoa7hAobykhRTtP8lrTF1g==",
+          "version": "0.6.7",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.6.7.tgz",
+          "integrity": "sha512-ULn46EmEJ9/AD9LJ9DwFtT1CcujpC3x1FSYjpPWqmyv1CH0vsjtMSgUCBUPIonqM4jRjDvIuxclpWJrsH/t9og==",
           "dev": true,
           "requires": {
-            "@angular-devkit/core": "0.6.3",
+            "@angular-devkit/core": "0.6.7",
             "rxjs": "6.1.0"
           }
         },
         "@angular-devkit/core": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.6.3.tgz",
-          "integrity": "sha512-97hFVW6in8oYJUEqjmUP0Tb/mPlTG3sc0THpe5MCGEkDPjlp2cObt9rUCAVOjugBlScV8rzTpVQ+95PT60Py8A==",
+          "version": "0.6.7",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.6.7.tgz",
+          "integrity": "sha512-kzNI95g3of8C0an2U/lUa2ixqABFKQt06VfzSz6pUCl/RJblLnxua9dgsSb8jc0eDQ5ZmekXN0UgkED0JDYXsQ==",
           "dev": true,
           "requires": {
             "ajv": "6.4.0",
@@ -413,20 +413,20 @@
       }
     },
     "@schematics/angular": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.6.3.tgz",
-      "integrity": "sha512-YhldE1K6x/8D0PxFusjtB32iOAayyD1PSxPCx/q7I7T6x/lG7l35ZDV6ZZE6bDvIaxQBsjhIm8ACy2n+xwFxTA==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.6.7.tgz",
+      "integrity": "sha512-gO7xSSzBQhj1t8aD3qBd03rj3hJ1XIWJ9rzLsPpC5hVfmMCpsc6cBnwm2asJ+eZlZUah46ZDhwlnMFEu8Sfczw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.6.3",
-        "@angular-devkit/schematics": "0.6.3",
+        "@angular-devkit/core": "0.6.7",
+        "@angular-devkit/schematics": "0.6.7",
         "typescript": "2.7.2"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.6.3.tgz",
-          "integrity": "sha512-97hFVW6in8oYJUEqjmUP0Tb/mPlTG3sc0THpe5MCGEkDPjlp2cObt9rUCAVOjugBlScV8rzTpVQ+95PT60Py8A==",
+          "version": "0.6.7",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.6.7.tgz",
+          "integrity": "sha512-kzNI95g3of8C0an2U/lUa2ixqABFKQt06VfzSz6pUCl/RJblLnxua9dgsSb8jc0eDQ5ZmekXN0UgkED0JDYXsQ==",
           "dev": true,
           "requires": {
             "ajv": "6.4.0",
@@ -438,13 +438,13 @@
       }
     },
     "@schematics/update": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.6.3.tgz",
-      "integrity": "sha512-UsKrg02+jwdsz9BdMVxDMeAZCF+c+dvHRWww4D2RcNzWdCTVWeBqRAmlreJJ0TGE54r7PEBnmQe0t5mS4F3d4w==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.6.7.tgz",
+      "integrity": "sha512-uogLzGy3+/VlbQdevn/7WFTfs2Utl5ffwN17eCNayRuXmNyHlytKtz7cx8m1w9oj/VYxZXPbWTDVM1Hlnd/mqQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.6.3",
-        "@angular-devkit/schematics": "0.6.3",
+        "@angular-devkit/core": "0.6.7",
+        "@angular-devkit/schematics": "0.6.7",
         "npm-registry-client": "8.5.1",
         "rxjs": "6.1.0",
         "semver": "5.5.0",
@@ -452,9 +452,9 @@
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.6.3.tgz",
-          "integrity": "sha512-97hFVW6in8oYJUEqjmUP0Tb/mPlTG3sc0THpe5MCGEkDPjlp2cObt9rUCAVOjugBlScV8rzTpVQ+95PT60Py8A==",
+          "version": "0.6.7",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.6.7.tgz",
+          "integrity": "sha512-kzNI95g3of8C0an2U/lUa2ixqABFKQt06VfzSz6pUCl/RJblLnxua9dgsSb8jc0eDQ5ZmekXN0UgkED0JDYXsQ==",
           "dev": true,
           "requires": {
             "ajv": "6.4.0",
@@ -4106,6 +4106,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "nan": "2.10.0",
         "node-pre-gyp": "0.10.0"
@@ -4114,7 +4115,8 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -4124,12 +4126,14 @@
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.3.6"
@@ -4152,7 +4156,8 @@
         "chownr": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -4172,12 +4177,14 @@
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -4185,22 +4192,26 @@
         "deep-extend": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "2.2.4"
           }
@@ -4208,12 +4219,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
@@ -4229,6 +4242,7 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -4241,12 +4255,14 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": "2.1.2"
           }
@@ -4255,6 +4271,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "3.0.4"
           }
@@ -4263,6 +4280,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -4276,7 +4294,8 @@
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -4289,7 +4308,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -4317,6 +4337,7 @@
           "version": "1.1.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "2.2.4"
           }
@@ -4332,12 +4353,14 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "needle": {
           "version": "2.2.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "iconv-lite": "0.4.21",
@@ -4348,6 +4371,7 @@
           "version": "0.10.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
@@ -4365,6 +4389,7 @@
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
@@ -4373,12 +4398,14 @@
         "npm-bundled": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.3"
@@ -4388,6 +4415,7 @@
           "version": "4.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -4403,7 +4431,8 @@
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
@@ -4416,17 +4445,20 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -4435,17 +4467,20 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "0.5.1",
             "ini": "1.3.5",
@@ -4456,7 +4491,8 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4464,6 +4500,7 @@
           "version": "2.3.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -4478,6 +4515,7 @@
           "version": "2.6.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "7.1.2"
           }
@@ -4490,27 +4528,32 @@
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.5.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -4526,6 +4569,7 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -4541,12 +4585,14 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
@@ -4560,12 +4606,14 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "1.0.2"
           }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.6.0",
-    "@angular/cli": "6.0.3",
+    "@angular/cli": "^6.0.7",
     "@angular/compiler-cli": "6.0.2",
     "@angular/language-service": "6.0.2",
     "@types/jasmine": "~2.8.3",


### PR DESCRIPTION
## Explain the **details** for making this change. What existing problem does the pull request solve?

When the CI tries to do a build, it gets an error:
```
npm ERR! notsup Unsupported platform for fsevents@1.2.4: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
```
After googling, it seems related to this issue https://github.com/angular/angular/issues/24175

## Steps necessary to review your pull request (required):

Push to NG master and watch the build fail on travis.
