### PR TITLE
Fix for step control footer buttons font weight issue.

### DIFF
--- a/src/soho/stepprocess/soho-stepprocess.component.html
+++ b/src/soho/stepprocess/soho-stepprocess.component.html
@@ -26,7 +26,7 @@
   <!-- STEP CONTROL PHONE CONTROLS -->
   <ng-content select="div[soho-step-content]"></ng-content>
     <div class="phone-action-bar phone-visible">
-      <button soho-button="secondary" class="btn js-btn-save-changes">Save &amp; Close</button>
-      <button soho-button="primary" class="btn-primary js-step-link-next">Next</button>
+      <button soho-button="secondary" class="btn btn-secondary js-btn-save-changes">Save &amp; Close</button>
+      <button soho-button="primary" class="btn btn-primary js-step-link-next">Next</button>
     </div>
 </div>


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

Fix for step control footer buttons font weight issue.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> **Related issue (required)**:

<!-- Provide a link to the related issue to this Pull Request. ***Please do not open a PR without a related issue.*** -->

https://github.com/infor-design/enterprise-ng/issues/88

> **Steps necessary to review your pull request (required)**:

1. Follow steps in related issue link.
2. Apply change to see it fixed.

<!-- What does someone need to do to confirm that this PR is ready to merge? Please include the exact commands you ran and their output, screenshots / videos if the pull request changes UI. You can skip this if you're fixing a typo or the change is very obvious in the diff. -->

> Other Details:

The underlying issue here is that the `soho-button` directive adds the class ` btn-secondary` after the class `js-btn-save-changes`. And in order for the button to style properly the `btn-secondary` class needs to be the first class on the element.

<!-- Please add `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if exists). -->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
