### PR TITLE
Fix the definition of maskOptions

### DIFF
--- a/src/soho/datagrid/soho-datagrid.d.ts
+++ b/src/soho/datagrid/soho-datagrid.d.ts
@@ -659,7 +659,7 @@ interface SohoDataGridColumn {
   mask?: string;
 
   /** The newer style object pattern mask for the column*/
-  maskOptions?: any[];
+  maskOptions?: SohoMaskOptions;
 
   /** Call the grids `onPostRenderCell` function for cells in this column after they are rendered. */
   postRender?: boolean;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The angular component's definition of maskOptions is an any[], but the datagrid's usage of the maskOptions is using it as SohoMaskOptions.  I currently can't compile my angular project to make use of maskOptions.

**Related github/jira issue (required)**:

https://jira.infor.com/browse/SOHO-8131

**Steps necessary to review your pull request (required)**:
Create a datagrid column that uses maskOptions.

**Closing issues**
