### PR TITLE
Add @types/jquery to dependencies

### DIFF
--- a/publish/package.json
+++ b/publish/package.json
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@angular/cli": "6.0.7",
+    "@types/jquery": "3.3.1",
     "classlist.js": "^1.1.20150312",
     "ids-enterprise": "^4.8.0-dev.20180621",
-    "jquery": "3.3.1",
-    "@types/jquery": "3.3.1"
+    "jquery": "3.3.1"
   }
 }

--- a/publish/package.json
+++ b/publish/package.json
@@ -27,6 +27,7 @@
     "@angular/cli": "6.0.7",
     "classlist.js": "^1.1.20150312",
     "ids-enterprise": "^4.8.0-dev.20180621",
-    "jquery": "3.3.1"
+    "jquery": "3.3.1",
+    "@types/jquery": "~3.2.16"
   }
 }

--- a/publish/package.json
+++ b/publish/package.json
@@ -28,6 +28,6 @@
     "classlist.js": "^1.1.20150312",
     "ids-enterprise": "^4.8.0-dev.20180621",
     "jquery": "3.3.1",
-    "@types/jquery": "~3.2.16"
+    "@types/jquery": "3.3.1"
   }
 }


### PR DESCRIPTION
This is just a temporary workaround for this issue. It helps the developers to setup easier from scratch.
This also automatically installs `@types/jquery` whenever the users install `ids-enterprise-ng` so they don't have to worry about missing dependencies, increasing the convenience.

**Related github/jira issue (required)**:
Close #115

**Steps necessary to review your pull request (required)**:
Follow the steps describing in #115
