### PR TITLE
Expanded type definition for chart select to include needed options

### DIFF
--- a/src/app/area/area.demo.ts
+++ b/src/app/area/area.demo.ts
@@ -13,7 +13,10 @@ export class AreaDemoComponent implements OnInit {
 
   @ViewChild(SohoLineComponent) sohoLineComponent: SohoLineComponent;
 
-  private selection: SohoLineSelected  = {groupIndex: 0, fieldName: 'name', fieldValue: 'Category B'};
+  // private selection: SohoLineSelected  = {groupIndex: 1};
+  // private selection: SohoLineSelected  = {groupName: 'name', groupValue: 'Component A'};
+  private selection: SohoLineSelected  = {groupName: 'id', groupValue: '3'};
+
   public areaData = [{
     data: [
       {name: 'Jan', value: 12, depth: 4},

--- a/src/app/area/area.demo.ts
+++ b/src/app/area/area.demo.ts
@@ -13,6 +13,7 @@ export class AreaDemoComponent implements OnInit {
 
   @ViewChild(SohoLineComponent) sohoLineComponent: SohoLineComponent;
 
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
   // private selection: SohoLineSelected  = {groupIndex: 1};
   // private selection: SohoLineSelected  = {groupName: 'name', groupValue: 'Component A'};
   private selection: SohoLineSelected  = {groupName: 'id', groupValue: '3'};

--- a/src/app/bar-grouped/bar-grouped.demo.ts
+++ b/src/app/bar-grouped/bar-grouped.demo.ts
@@ -13,6 +13,7 @@ export class BarGroupedDemoComponent implements OnInit {
 
   @ViewChild(SohoBarComponent) sohoBarComponent: SohoBarComponent;
 
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
   // private selection: SohoBarSelected  = {groupName: 'name', groupValue: 'Component B'};
   private selection: SohoBarSelected  = {groupIndex: 2};
 

--- a/src/app/bar-grouped/bar-grouped.demo.ts
+++ b/src/app/bar-grouped/bar-grouped.demo.ts
@@ -13,7 +13,9 @@ export class BarGroupedDemoComponent implements OnInit {
 
   @ViewChild(SohoBarComponent) sohoBarComponent: SohoBarComponent;
 
-  private selection: SohoBarSelected  = {groupName: 'name', groupValue: 'Component B'};
+  // private selection: SohoBarSelected  = {groupName: 'name', groupValue: 'Component B'};
+  private selection: SohoBarSelected  = {groupIndex: 2};
+
   public barGroupedData = [{
     data: [{
       name: 'Jan', value: 12,

--- a/src/app/bar-stacked/bar-stacked.demo.ts
+++ b/src/app/bar-stacked/bar-stacked.demo.ts
@@ -13,7 +13,9 @@ export class BarStackedDemoComponent implements OnInit {
 
   @ViewChild(SohoBarComponent) sohoBarComponent: SohoBarComponent;
 
-  private selection: SohoBarSelected  = {fieldName: 'name', fieldValue: '2009'};
+//  private selection: SohoBarSelected  = {fieldName: 'name', fieldValue: '2009'};
+  private selection: SohoBarSelected  = {index: 0};
+
   public barStackedData = [{
     data: [{
       name: '2008',

--- a/src/app/bar-stacked/bar-stacked.demo.ts
+++ b/src/app/bar-stacked/bar-stacked.demo.ts
@@ -13,7 +13,8 @@ export class BarStackedDemoComponent implements OnInit {
 
   @ViewChild(SohoBarComponent) sohoBarComponent: SohoBarComponent;
 
-//  private selection: SohoBarSelected  = {fieldName: 'name', fieldValue: '2009'};
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
+  // private selection: SohoBarSelected  = {fieldName: 'name', fieldValue: '2009'};
   private selection: SohoBarSelected  = {index: 0};
 
   public barStackedData = [{

--- a/src/app/bar/bar.demo.ts
+++ b/src/app/bar/bar.demo.ts
@@ -13,8 +13,9 @@ export class BarDemoComponent implements OnInit {
 
   @ViewChild(SohoBarComponent) sohoBarComponent: SohoBarComponent;
 
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
   private selection: SohoBarSelected  = {fieldName: 'name', fieldValue: 'Category B'};
-//  private selection: SohoBarSelected  = {index: 0};
+  // private selection: SohoBarSelected  = {index: 0};
 
   public barData = [{
     data: [{

--- a/src/app/bar/bar.demo.ts
+++ b/src/app/bar/bar.demo.ts
@@ -14,6 +14,8 @@ export class BarDemoComponent implements OnInit {
   @ViewChild(SohoBarComponent) sohoBarComponent: SohoBarComponent;
 
   private selection: SohoBarSelected  = {fieldName: 'name', fieldValue: 'Category B'};
+//  private selection: SohoBarSelected  = {index: 0};
+
   public barData = [{
     data: [{
       name: 'Category A',

--- a/src/app/bubble/bubble.demo.ts
+++ b/src/app/bubble/bubble.demo.ts
@@ -13,7 +13,9 @@ export class BubbleDemoComponent implements OnInit {
 
   @ViewChild(SohoLineComponent) sohoLineComponent: SohoLineComponent;
 
-  private selection: SohoLineSelected  = {groupIndex: 0, fieldName: 'name', fieldValue: 'Series 02'};
+  private selection: SohoLineSelected  = {groupIndex: 0};
+//  private selection: SohoLineSelected  = {groupName: 'name', groupValue: 'Series 02'};
+
   public bubbleData = [{
     data: [{
       name: 'January',

--- a/src/app/bubble/bubble.demo.ts
+++ b/src/app/bubble/bubble.demo.ts
@@ -13,8 +13,9 @@ export class BubbleDemoComponent implements OnInit {
 
   @ViewChild(SohoLineComponent) sohoLineComponent: SohoLineComponent;
 
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
   private selection: SohoLineSelected  = {groupIndex: 0};
-//  private selection: SohoLineSelected  = {groupName: 'name', groupValue: 'Series 02'};
+  // private selection: SohoLineSelected  = {groupName: 'name', groupValue: 'Series 02'};
 
   public bubbleData = [{
     data: [{

--- a/src/app/column-grouped/column-grouped.demo.ts
+++ b/src/app/column-grouped/column-grouped.demo.ts
@@ -4,9 +4,6 @@ import {
   ViewChild
 } from '@angular/core';
 
-import {
-  SohoRadarComponent
-} from 'ids-enterprise-ng';
 import {SohoColumnComponent} from '../../soho/column';
 
 @Component({
@@ -17,7 +14,9 @@ export class ColumnGroupedDemoComponent implements OnInit {
 
   @ViewChild(SohoColumnComponent) sohoColumnComponent: SohoColumnComponent;
 
-  private selection: SohoColumnSelected  = {groupName: 'name', groupValue: 'Component B'};
+//  private selection: SohoColumnSelected  = {groupName: 'name', groupValue: 'Component C'};
+  private selection: SohoColumnSelected  = {groupIndex: 1};
+
   public columnGroupedData = [{
     data: [{
       name: 'Jan', value: 12

--- a/src/app/column-grouped/column-grouped.demo.ts
+++ b/src/app/column-grouped/column-grouped.demo.ts
@@ -14,7 +14,8 @@ export class ColumnGroupedDemoComponent implements OnInit {
 
   @ViewChild(SohoColumnComponent) sohoColumnComponent: SohoColumnComponent;
 
-//  private selection: SohoColumnSelected  = {groupName: 'name', groupValue: 'Component C'};
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
+  // private selection: SohoColumnSelected  = {groupName: 'name', groupValue: 'Component C'};
   private selection: SohoColumnSelected  = {groupIndex: 1};
 
   public columnGroupedData = [{

--- a/src/app/column-stacked/column-stacked.demo.ts
+++ b/src/app/column-stacked/column-stacked.demo.ts
@@ -14,8 +14,9 @@ export class ColumnStackedDemoComponent implements OnInit {
 
   @ViewChild(SohoColumnComponent) sohoColumnComponent: SohoColumnComponent;
 
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
   private selection: SohoColumnSelected  = {fieldName: 'name', fieldValue: 'Mar'};
-//  private selection: SohoColumnSelected  = {index: 8};
+  // private selection: SohoColumnSelected  = {index: 8};
 
   public columnStackedData = [{
     data: [{

--- a/src/app/column-stacked/column-stacked.demo.ts
+++ b/src/app/column-stacked/column-stacked.demo.ts
@@ -4,9 +4,6 @@ import {
   ViewChild
 } from '@angular/core';
 
-import {
-  SohoRadarComponent
-} from 'ids-enterprise-ng';
 import {SohoColumnComponent} from '../../soho/column';
 
 @Component({
@@ -17,7 +14,9 @@ export class ColumnStackedDemoComponent implements OnInit {
 
   @ViewChild(SohoColumnComponent) sohoColumnComponent: SohoColumnComponent;
 
-  private selection: SohoColumnSelected  = {fieldName: 'name', fieldValue: 'Jul'};
+  private selection: SohoColumnSelected  = {fieldName: 'name', fieldValue: 'Mar'};
+//  private selection: SohoColumnSelected  = {index: 8};
+
   public columnStackedData = [{
     data: [{
       name: 'Jan', value: 12,

--- a/src/app/column/column.demo.ts
+++ b/src/app/column/column.demo.ts
@@ -4,9 +4,6 @@ import {
   ViewChild
 } from '@angular/core';
 
-import {
-  SohoRadarComponent
-} from 'ids-enterprise-ng';
 import {SohoColumnComponent} from '../../soho/column';
 
 @Component({
@@ -18,6 +15,8 @@ export class ColumnDemoComponent implements OnInit {
   @ViewChild(SohoColumnComponent) sohoColumnComponent: SohoColumnComponent;
 
   private selection: SohoColumnSelected  = {fieldName: 'name', fieldValue: 'Equipment'};
+//  private selection: SohoColumnSelected  = {index: 6};
+
   public columnData = [{
     data: [{
       name: 'Automotive',

--- a/src/app/column/column.demo.ts
+++ b/src/app/column/column.demo.ts
@@ -14,8 +14,9 @@ export class ColumnDemoComponent implements OnInit {
 
   @ViewChild(SohoColumnComponent) sohoColumnComponent: SohoColumnComponent;
 
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
   private selection: SohoColumnSelected  = {fieldName: 'name', fieldValue: 'Equipment'};
-//  private selection: SohoColumnSelected  = {index: 6};
+  // private selection: SohoColumnSelected  = {index: 6};
 
   public columnData = [{
     data: [{

--- a/src/app/donut/donut.demo.ts
+++ b/src/app/donut/donut.demo.ts
@@ -13,8 +13,9 @@ export class DonutDemoComponent implements OnInit {
 
   @ViewChild(SohoPieComponent) sohoPieComponent: SohoPieComponent;
 
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
   private selection: SohoPieSelected  = {fieldName: 'name', fieldValue: 'Component A'};
-//  private selection: SohoPieSelected  = {index: 1};
+  // private selection: SohoPieSelected  = {index: 1};
 
   public donutData = [{
     data: [{

--- a/src/app/donut/donut.demo.ts
+++ b/src/app/donut/donut.demo.ts
@@ -13,7 +13,9 @@ export class DonutDemoComponent implements OnInit {
 
   @ViewChild(SohoPieComponent) sohoPieComponent: SohoPieComponent;
 
-  private selection: SohoPieSelected  = {fieldName: 'name', fieldValue: 'Component B'};
+  private selection: SohoPieSelected  = {fieldName: 'name', fieldValue: 'Component A'};
+//  private selection: SohoPieSelected  = {index: 1};
+
   public donutData = [{
     data: [{
       name: 'Component A',

--- a/src/app/line/line.demo.ts
+++ b/src/app/line/line.demo.ts
@@ -13,9 +13,11 @@ export class LineDemoComponent implements OnInit {
 
   @ViewChild(SohoLineComponent) sohoLineComponent: SohoLineComponent;
 
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
   private selection: SohoLineSelected  = {groupIndex: 2};
-  // private selection: SohoLineSelected  = {groupName: 'name', groupValue: 'Component A'};
+  // private selection: SohoLineSelected  = {groupName: 'name', groupValue: 'Coponent A'};
   // private selection: SohoLineSelected  = {groupName: 'id', groupValue: '1'};
+
   public lineData = [{
     data: [
       {name: 'Jan | 2018', value: 12, depth: 4},

--- a/src/app/line/line.demo.ts
+++ b/src/app/line/line.demo.ts
@@ -13,7 +13,9 @@ export class LineDemoComponent implements OnInit {
 
   @ViewChild(SohoLineComponent) sohoLineComponent: SohoLineComponent;
 
-  private selection: SohoLineSelected  = {groupIndex: 0, fieldName: 'name', fieldValue: 'Category B'};
+  private selection: SohoLineSelected  = {groupIndex: 2};
+  // private selection: SohoLineSelected  = {groupName: 'name', groupValue: 'Component A'};
+  // private selection: SohoLineSelected  = {groupName: 'id', groupValue: '1'};
   public lineData = [{
     data: [
       {name: 'Jan | 2018', value: 12, depth: 4},

--- a/src/app/pie/pie.demo.ts
+++ b/src/app/pie/pie.demo.ts
@@ -13,7 +13,8 @@ export class PieDemoComponent implements OnInit {
 
   @ViewChild(SohoPieComponent) sohoPieComponent: SohoPieComponent;
 
-  private selection: SohoPieSelected  = {fieldName: 'name', fieldValue: 'Item C'};
+//  private selection: SohoPieSelected  = {fieldName: 'name', fieldValue: 'Item D'};
+  private selection: SohoPieSelected  = {index: 1};
   public pieData = [{
     data: [{
       name: 'Item A',

--- a/src/app/pie/pie.demo.ts
+++ b/src/app/pie/pie.demo.ts
@@ -13,8 +13,10 @@ export class PieDemoComponent implements OnInit {
 
   @ViewChild(SohoPieComponent) sohoPieComponent: SohoPieComponent;
 
-//  private selection: SohoPieSelected  = {fieldName: 'name', fieldValue: 'Item D'};
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
+  // private selection: SohoPieSelected  = {fieldName: 'name', fieldValue: 'Item D'};
   private selection: SohoPieSelected  = {index: 1};
+
   public pieData = [{
     data: [{
       name: 'Item A',

--- a/src/app/radar/radar.demo.ts
+++ b/src/app/radar/radar.demo.ts
@@ -14,7 +14,9 @@ export class RadarDemoComponent implements OnInit {
 
   @ViewChild(SohoRadarComponent) sohoRadarComponent: SohoRadarComponent;
 
-  private selection: SohoRadarSelected  = {fieldName: 'name', fieldValue: 'Samsung'};
+//  private selection: SohoRadarSelected  = {fieldName: 'name', fieldValue: 'Samsung'};
+  private selection: SohoRadarSelected  = {index: 1};
+
   public radarData = [{
     data: [
       {name: 'Battery Life', value: 0.22},

--- a/src/app/radar/radar.demo.ts
+++ b/src/app/radar/radar.demo.ts
@@ -14,7 +14,8 @@ export class RadarDemoComponent implements OnInit {
 
   @ViewChild(SohoRadarComponent) sohoRadarComponent: SohoRadarComponent;
 
-//  private selection: SohoRadarSelected  = {fieldName: 'name', fieldValue: 'Samsung'};
+  // The following multiple "private selection" definitions are all examples of ways to set the selection on the chart
+  // private selection: SohoRadarSelected  = {fieldName: 'name', fieldValue: 'Samsung'};
   private selection: SohoRadarSelected  = {index: 1};
 
   public radarData = [{

--- a/src/soho/bar/soho-bar.d.ts
+++ b/src/soho/bar/soho-bar.d.ts
@@ -95,13 +95,17 @@ interface SohoBar {
 type SohoBarSelected = SohoBarFieldSelected | SohoBarGroupSelected;
 
 interface SohoBarFieldSelected {
-  fieldName: string;
-  fieldValue: any;
+  // use either index or fieldName and fieldValue
+  fieldName?: string;
+  fieldValue?: any;
+  index?: number;
 }
 
 interface SohoBarGroupSelected {
-  groupName: string;
-  groupValue: any;
+  // use either groupIndex or groupName and groupValue
+  groupIndex?: number;
+  groupName?: string;
+  groupValue?: any;
 }
 
 interface JQuery {

--- a/src/soho/column/soho-column.d.ts
+++ b/src/soho/column/soho-column.d.ts
@@ -75,13 +75,17 @@ interface SohoColumn {
 type SohoColumnSelected = SohoColumnFieldSelected | SohoColumnGroupSelected;
 
 interface SohoColumnFieldSelected {
-  fieldName: string;
-  fieldValue: any;
+  // USe either index or fieldName and fieldValue;
+  fieldName?: string;
+  fieldValue?: any;
+  index?: number;
 }
 
 interface SohoColumnGroupSelected {
-  groupName: string;
-  groupValue: any;
+  // USe either index or groupName and groupValue;
+  groupName?: string;
+  groupValue?: any;
+  groupIndex?: number;
 }
 
 interface JQuery {

--- a/src/soho/column/soho-column.d.ts
+++ b/src/soho/column/soho-column.d.ts
@@ -75,14 +75,14 @@ interface SohoColumn {
 type SohoColumnSelected = SohoColumnFieldSelected | SohoColumnGroupSelected;
 
 interface SohoColumnFieldSelected {
-  // USe either index or fieldName and fieldValue;
+  // Use either index or fieldName and fieldValue;
   fieldName?: string;
   fieldValue?: any;
   index?: number;
 }
 
 interface SohoColumnGroupSelected {
-  // USe either index or groupName and groupValue;
+  // Use either index or groupName and groupValue;
   groupName?: string;
   groupValue?: any;
   groupIndex?: number;

--- a/src/soho/line/soho-line.d.ts
+++ b/src/soho/line/soho-line.d.ts
@@ -90,9 +90,10 @@ interface SohoLine {
 }
 
 interface SohoLineSelected {
-  groupIndex: number;
-  fieldName: string;
-  fieldValue: any;
+  // Use either groupIndex or groupName and groupValue
+  groupIndex?: number;
+  groupName?: string;
+  groupValue?: any;
 }
 
 interface JQuery {

--- a/src/soho/pie/soho-pie.d.ts
+++ b/src/soho/pie/soho-pie.d.ts
@@ -110,8 +110,10 @@ interface SohoPie {
 }
 
 interface SohoPieSelected {
-  fieldName: string;
-  fieldValue: any;
+  // Use either index or fieldName and fieldValue
+  fieldName?: string;
+  fieldValue?: any;
+  index?: number;
 }
 
 interface JQuery {

--- a/src/soho/radar/soho-radar.d.ts
+++ b/src/soho/radar/soho-radar.d.ts
@@ -119,8 +119,10 @@ interface SohoRadar {
 }
 
 interface SohoRadarSelected {
-  fieldName: string;
-  fieldValue: any;
+  // Use either index or fieldName and fieldValue
+  fieldName?: string;
+  fieldValue?: any;
+  index?: number;
 }
 
 interface JQuery {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
It allows for different types of selection option (index, field or group value)

**Related github/jira issue (required)**:
#119 

**Steps necessary to review your pull request (required)**:
 API calling setChartSelection

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
