### PR TITLE
Fixed locale typings.

### DIFF
--- a/src/soho/datagrid/soho-datagrid.d.ts
+++ b/src/soho/datagrid/soho-datagrid.d.ts
@@ -358,19 +358,7 @@ type SohoDataGridColumnEditorFunction = (
   item?: any
 ) => SohoDataGridCellEditor;
 
-declare var Editors: {
-  // Supports, Text, Numeric, Integer via mask
-  Input: SohoDataGridColumnEditorFunction;
-  Textarea: SohoDataGridColumnEditorFunction;
-  Checkbox: SohoDataGridColumnEditorFunction;
-  Dropdown: SohoDataGridColumnEditorFunction;
-  Date: SohoDataGridColumnEditorFunction;
-  Lookup: SohoDataGridColumnEditorFunction;
-  Autocomplete: SohoDataGridColumnEditorFunction;
-  Favorite: SohoDataGridColumnEditorFunction;
-};
-
-declare var Soho: {
+interface SohoStatic {
   Formatters: {
     Text: SohoDataGridColumnFormatterFunction;
     Input: SohoDataGridColumnFormatterFunction;
@@ -411,8 +399,7 @@ declare var Soho: {
     Favorite: SohoDataGridColumnFormatterFunction;
     Status: SohoDataGridColumnFormatterFunction;
     TargetedAchievement: SohoDataGridColumnFormatterFunction;
-  };
-
+  },
   Editors: {
     // Supports, Text, Numeric, Integer via mask
     Input: SohoDataGridColumnEditorFunction;
@@ -423,10 +410,8 @@ declare var Soho: {
     Lookup: SohoDataGridColumnEditorFunction;
     Autocomplete: SohoDataGridColumnEditorFunction;
     Favorite: SohoDataGridColumnEditorFunction;
-  };
-
-  Locale: SohoLocaleStatic;
-};
+  }
+}
 
 type SohoDataGridColumnFormatterFunction = (
   /** Row number. */

--- a/src/soho/locale/soho-locale.d.ts
+++ b/src/soho/locale/soho-locale.d.ts
@@ -40,11 +40,25 @@ interface SohoLocaleStatic {
   cultures: any;
   culturesPath: string;
   currentLocale: { name: string, data: any };
+
+  /**
+   * Internally stores a new culture file for future use.
+   *
+   * @param {string} locale the 4-character Locale ID
+   * @param {object} data translation data and locale-specific functions, such as calendars.
+   * @returns {void}
+   */
   addCulture(locale: string, data: any): void;
   calendar(): {dateFormat: any, timeFormat: string};
   cultureInHead(): boolean;
   formatDate(value: string | Date, attribs: any): string;
   formatNumber(number: number | string, options: any): string;
+
+  /**
+   * Get the path to the directory with the cultures
+   *
+   * @returns {string} path containing culture files.
+   */
   getCulturesPath(): string;
   isRTL(): boolean;
   numbers(): any;
@@ -52,11 +66,28 @@ interface SohoLocaleStatic {
   parseNumber(input: string): number;
   set(locale: string): any;
   setCurrentLocale(name: string, data: any): void;
-  translate(key: string): string;
+
+  /**
+   * Overridable culture messages
+   *
+   * @param {string} key  The key to search for on the string.
+   * @param {boolean} [showAsUndefined] causes a translated phrase to be
+    instead of defaulting to the default locale's version of the string.
+   * @returns {string|undefined} a translated string, or nothing, depending on configuration
+   */
+  translate(key: string, showAsUndefined?: string): string;
+
+  /**
+   * Translate Day Period
+   * @param {string} period should be "am", "pm", "AM", "PM", or "i"
+   * @returns {string} the translated day period.
+   */
   translateDayPeriod(period: string): string;
 }
 
-declare var Locale: SohoLocaleStatic;
+interface SohoStatic {
+  Locale: SohoLocaleStatic;
+}
 
 interface JQuery {
   initialize(locale: string): JQuery;

--- a/src/soho/soho.d.ts
+++ b/src/soho/soho.d.ts
@@ -10,3 +10,8 @@ interface JQueryStatic {
 
 interface JQuery {
 }
+
+interface SohoStatic {
+}
+
+declare var Soho: SohoStatic;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When adding internationalisation support to an application, the typings for the widget library define a global `Locale` object which is not defined at runtime.  Removal of this old declaration will realign the typings to the widget library, and reduce coding errors.

I have also taken the opportunity to move the `Soho` global into `soho.d.ts` making it more extensible.

**Related github/jira issue (required)**:

Closes #122.

**Steps necessary to review your pull request (required)**:

The following, compiles, but breaks at runtime:
```
Locale.translate('OK')
```

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
