### PR TITLE
Expose all the editors from enterprise in enterprise-ng

### DIFF
--- a/src/soho/datagrid/soho-datagrid.d.ts
+++ b/src/soho/datagrid/soho-datagrid.d.ts
@@ -411,11 +411,16 @@ interface SohoStatic {
     // Supports, Text, Numeric, Integer via mask
     Input: SohoDataGridColumnEditorFunction;
     Textarea: SohoDataGridColumnEditorFunction;
+    Editor: SohoDataGridColumnEditorFunction;
     Checkbox: SohoDataGridColumnEditorFunction;
+    Colorpicker: SohoDataGridColumnEditorFunction;
     Dropdown: SohoDataGridColumnEditorFunction;
     Date: SohoDataGridColumnEditorFunction;
+    Fileupload: SohoDataGridColumnEditorFunction;
+    Time: SohoDataGridColumnEditorFunction;
     Lookup: SohoDataGridColumnEditorFunction;
     Autocomplete: SohoDataGridColumnEditorFunction;
+    Spinbox: SohoDataGridColumnEditorFunction;
     Favorite: SohoDataGridColumnEditorFunction;
   };
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Exposing all the enterprise datagrid editors in enterprise-ng.

**Related github/jira issue (required)**:
("Closes #140 ")

**Steps necessary to review your pull request (required)**:
Ensure all the editors in [enterprise](https://github.com/infor-design/enterprise/blob/master/src/components/datagrid/datagrid.editors.js) are represented in the changes I made.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
