### PR TITLE
Soho-datepicker isn't updating the jQuery control on an update

### DIFF
--- a/src/soho/datepicker/soho-datepicker.component.ts
+++ b/src/soho/datepicker/soho-datepicker.component.ts
@@ -399,7 +399,7 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<any> imple
         // execute updated after angular has generated
         // the model and the view markup.
         if (this.datepicker) {
-          this.datepicker.updated();
+          this.datepicker.updated(this._options);
         }
         this.runUpdatedOnCheck = false;
       });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixing issue where updates to the soho-datepicker.component.ts weren't being passed to the jQuery control.

**Related github/jira issue (required)**:
"Closes #150"

**Steps necessary to review your pull request (required)**:
1. Go to the field filter example
2. Click on the "date picker with range" (with the filter type set to anything but "In Range")
3. Datepicker popup closes after a date is selected
4. Change the filter type for "date picker with range" to "In Range"
5. Open the date picker. Can now select a range of dates

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
