### PR TITLE
Fixed ordering issue in QUICKSTART

### DIFF
--- a/docs/ASPNETCORE.md
+++ b/docs/ASPNETCORE.md
@@ -36,25 +36,7 @@ Open a terminal / command prompt inside the ClientApp folder.
 npm i @angular/cli@latest
 ng update @angular/cli
 ng update @angular/core
-
-```
-
-You may get some error on upgrading due to missing or invalid peer dependencies, you can update these manually as follows:
-
-```sh
-
-ng update @angular-devkit/build-angular
-ng update codelyzer
-npm install tsickle@latest --save-dev
-
-```
-
-Ignore this error: (if it is still displayed - it will be fixed in @angular/compile-cli@6.1.1)
-
-```sh
-
-npm WARN tsickle@0.30.0 requires a peer of typescript@>=2.4.2 <2.9 but none is installed. You must install peer dependencies yourself.
-
+ng update
 ```
 
 ## Adding the IDS Enterprise Controls

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -124,15 +124,6 @@ The link in the following to the `src/index.html` file would be the output folde
 </head>
 ```
 
-Set the locale path in `app.component.ts`:
-
-```typescript
-constructor() {
-    Soho.Locale.culturesPath = '/assets/ids-enterprise/js/cultures/';
-    Soho.Locale.set('en-US');
-  }
-```
-
 ## Step 5 : Making Sure it Works
 
 Run the app to test it.
@@ -220,6 +211,15 @@ Add the clicked handler to `app.component.ts`, as follows:
 public clicked() {
     alert('Clicked me!');
 }
+```
+
+Set the locale path in `app.component.ts`:
+
+```typescript
+constructor() {
+    Soho.Locale.culturesPath = '/assets/ids-enterprise/js/cultures/';
+    Soho.Locale.set('en-US');
+  }
 ```
 
 Then from a command line run (you can use `ng serve`):


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The QUICKSTART guide suggested adding references to Soho.Locale before the library had been imported, giving errors.

This step has been moved to after the *SohoComponentLibrary* has been imported.

**Related github/jira issue (required)**:

#143

**Steps necessary to review your pull request (required)**:

Follow the steps in the QUICKSTART.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
