### PR TITLE
Added double click event handling back to soho-datagrid

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/chart/soho-chart.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/chart/soho-chart.component.ts
@@ -121,7 +121,7 @@ export class SohoChartComponent implements AfterViewInit, OnDestroy {
       this.unselected.emit({ event, ui, data });
     }).on('rendered', (event: JQuery.Event, ui: any, data: any) => {
       this.rendered.emit({ event, ui, data });
-    }).on('contextmenu', (event, ui, data) => {
+    }).on('contextmenu', (event: JQuery.Event, ui: any, data: any) => {
       this.contextmenu.emit({ event, ui, data });
     });
   }

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1663,6 +1663,15 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   /**
+   * Event fired when a context menu is is clicked.
+   */
+  private onDoubleClick(args: SohoDataGridRowClicked) {
+    this.ngZone.run(() => {
+      this.rowDoubleClicked.next(args);
+    });
+  }
+
+  /**
    * Event fired when the data is filtered.
    */
   private onFiltered(args: SohoDataGridFilteredEvent) {
@@ -1974,6 +1983,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
         .on('closefilterrow', (e: any, args: SohoDataGridCloseFilterRowEvent) => { this.onCloseFilterRow(args); })
         .on('collapserow', (e: any, args: SohoDataGridRowCollapseEvent) => { this.onCollapseRow(args); })
         .on('contextmenu', (e: any, args: SohoDataGridRowClicked) => { this.onContextMenu(args); })
+        .on('dblclick', (e: JQuery.Event, args: SohoDataGridRowClicked) => { this.onDoubleClick(args); })
         .on('expandrow', (e: any, args: SohoDataGridRowExpandEvent) => { this.onExpandRow(args); })
         .on('filtered', (e: any, args: SohoDataGridFilteredEvent) => { this.onFiltered(args); })
         .on('openfilterrow', (e: any, args: SohoDataGridOpenFilterRowEvent) => { this.onOpenFilterRow(args); })
@@ -1986,7 +1996,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
         .on('selected', (e: any, args: SohoDataGridSelectedRow[]) => this.onSelected({ e, rows: args }))
         .on('settingschanged', (e: any, args: SohoDataGridSettingsChangedEvent) => { this.onSettingsChanged(args); })
         .on('sorted', (e: any, args: SohoDataGridSortedEvent) => { this.onSorted(args); });
-    });
+  });
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1996,7 +1996,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
         .on('selected', (e: any, args: SohoDataGridSelectedRow[]) => this.onSelected({ e, rows: args }))
         .on('settingschanged', (e: any, args: SohoDataGridSettingsChangedEvent) => { this.onSettingsChanged(args); })
         .on('sorted', (e: any, args: SohoDataGridSortedEvent) => { this.onSorted(args); });
-  });
+    });
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -1050,8 +1050,9 @@ interface JQuery {
   on(events: 'addrow', handler: JQuery.EventHandlerBase<any, SohoDataGridAddRowEvent>): this;
   on(events: 'click', handler: JQuery.EventHandlerBase<any, SohoDataGridRowClicked>): this;
   on(events: 'collapserow', handler: JQuery.EventHandlerBase<any, SohoDataGridRowCollapseEvent>): this;
+  on(events: 'dblclick', handler: JQuery.EventHandlerBase<any, SohoDataGridRowClicked>): this;
   on(events: 'expandrow', handler: JQuery.EventHandlerBase<any, SohoDataGridRowExpandEvent>): this;
-  on(events: 'contextmenu' | 'dblclick', handler: JQuery.EventHandlerBase<any, SohoDataGridRowClicked>): this;
+  on(events: 'contextmenu', handler: JQuery.EventHandlerBase<any, SohoDataGridRowClicked>): this;
   on(events: 'filtered', handler: JQuery.EventHandlerBase<any, SohoDataGridFilteredEvent>): this;
   on(events: 'removerow', handler: JQuery.EventHandlerBase<any, SohoDataGridRowRemoveEvent>): this;
   on(events: 'rowreorder', handler: JQuery.EventHandlerBase<any, SohoDataGridRowReorderedEvent>): this;

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -1048,13 +1048,10 @@ interface JQuery {
   on(events: 'settingschanged', handler: JQuery.EventHandlerBase<any, SohoDataGridSettingsChangedEvent>): this;
   on(events: 'rendered', handler: JQuery.EventHandlerBase<any, SohoDataGridRenderedEvent>): this;
   on(events: 'addrow', handler: JQuery.EventHandlerBase<any, SohoDataGridAddRowEvent>): this;
-  on(events: 'click', handler: JQuery.EventHandlerBase<any, SohoDataGridRowClicked>): this;
   on(events: 'collapserow', handler: JQuery.EventHandlerBase<any, SohoDataGridRowCollapseEvent>): this;
-  on(events: 'dblclick', handler: JQuery.EventHandlerBase<any, SohoDataGridRowClicked>): this;
   on(events: 'expandrow', handler: JQuery.EventHandlerBase<any, SohoDataGridRowExpandEvent>): this;
-  on(events: 'contextmenu', handler: JQuery.EventHandlerBase<any, SohoDataGridRowClicked>): this;
+  on(events: 'click | dblclick | contextmenu', handler: JQuery.EventHandlerBase<any, SohoDataGridRowClicked>): this;
   on(events: 'filtered', handler: JQuery.EventHandlerBase<any, SohoDataGridFilteredEvent>): this;
-  on(events: 'removerow', handler: JQuery.EventHandlerBase<any, SohoDataGridRowRemoveEvent>): this;
   on(events: 'rowreorder', handler: JQuery.EventHandlerBase<any, SohoDataGridRowReorderedEvent>): this;
   on(events: 'sorted', handler: JQuery.EventHandlerBase<any, SohoDataGridSortedEvent>): this;
   on(events: 'expandrow', handler: JQuery.EventHandlerBase<any, SohoDataGridRowExpandEvent>): this;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
double click was removed in #186, this PR is adding it back

**Related github/jira issue (required)**:
Fixes dblClick issue caused by #186 

**Steps necessary to review your pull request (required)**:
Open datagrid-dynamic demo, double click a row, console message should be printed showing dbl click event was received.
