### PR TITLE
Added support for disabled tooltips on buttons

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `[DataGrid]` Fixed event arguments `BTHH` ([#156](https://github.com/infor-design/enterprise-ng/issues/156))
 - `[DataGrid]` Refactored datagrid to use `ngZone`. This effects the constructor so may effect those using AOT. `BTHH` ([#90](https://github.com/infor-design/enterprise-ng/issues/90))
 - `[DataGrid]` Added typings for `addRow`, this may be a breaking change should incorrect arguments currently be passed. `BTHH`
-- `[Button]` Support for tooltips on disabled button added. `BTHH` ([Pull Request x](https://github.com/infor-design/enterprise-ng/issues/90))
+- `[Button]` Support for tooltips on disabled buttons. `BTHH` ([Pull Request 199](https://github.com/infor-design/enterprise-ng/pull/199))
 
 ### Chore & Maintenance
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[DataGrid]` Fixed event arguments `BTHH` ([#156](https://github.com/infor-design/enterprise-ng/issues/156))
 - `[DataGrid]` Refactored datagrid to use `ngZone`. This effects the constructor so may effect those using AOT. `BTHH` ([#90](https://github.com/infor-design/enterprise-ng/issues/90))
 - `[DataGrid]` Added typings for `addRow`, this may be a breaking change should incorrect arguments currently be passed. `BTHH`
+- `[Button]` Support for tooltips on disabled button added. `BTHH` ([Pull Request x](https://github.com/infor-design/enterprise-ng/issues/90))
 
 ### Chore & Maintenance
 

--- a/projects/ids-enterprise-ng/src/lib/button/soho-button.component.html
+++ b/projects/ids-enterprise-ng/src/lib/button/soho-button.component.html
@@ -2,3 +2,4 @@
 <span>
   <ng-content></ng-content>
 </span>
+<ng-content select="div.disabled-tooltip"></ng-content>

--- a/projects/ids-enterprise-ng/src/lib/button/soho-button.component.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/button/soho-button.component.spec.ts
@@ -1,0 +1,69 @@
+/// <reference path="soho-button.d.ts" />
+
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import { By } from '@angular/platform-browser';
+
+import {
+  Component,
+  DebugElement,
+  ViewChild
+} from '@angular/core';
+
+import {
+  FormsModule,
+  FormGroup,
+  FormBuilder
+} from '@angular/forms';
+
+import { SohoButtonModule } from './soho-button.module';
+import { SohoTooltipModule } from '../tooltip/soho-tooltip.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { SohoButtonComponent } from './soho-button.component';
+
+@Component({
+  template: `
+  <div>
+    <button soho-button="icon" icon="bullet-list" disabled soho-tooltip title="DATAGRID_VIEW">
+      <div class="disabled-tooltip" title="DATAGRID_VIEW"></div>
+    </button>
+  </siv>`
+})
+class SohoButtonTestComponent {
+  @ViewChild(SohoButtonComponent) button: SohoButtonComponent;
+
+  constructor() {
+  }
+}
+
+describe('Soho Button Unit Tests', () => {
+  let button: SohoButtonComponent;
+  let component: SohoButtonTestComponent;
+  let fixture: ComponentFixture<SohoButtonTestComponent>;
+  let de: DebugElement;
+  let el: HTMLDivElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SohoButtonTestComponent],
+      imports: [ReactiveFormsModule, FormsModule, SohoButtonModule, SohoTooltipModule]
+    });
+
+    fixture = TestBed.createComponent(SohoButtonTestComponent);
+    component = fixture.componentInstance;
+    button = component.button;
+
+    de = fixture.debugElement;
+    el = de.query(By.css('button[soho-button]')).nativeElement;
+
+    fixture.detectChanges();
+  });
+
+  it('is created', () => {
+    expect(component).toBeTruthy();
+  });
+
+});

--- a/src/app/button/button.demo.html
+++ b/src/app/button/button.demo.html
@@ -37,11 +37,13 @@
         <br>
         <br>
         <br>
-        <button soho-button icon="settings">Secondary Button</button>
+        <button soho-button icon="settings">
+          <div class="disabled-tooltip" title="DISABLED"></div>
+        </button>
         <br>
         <br>
         <br>
-        <button soho-button icon="user-profile" toggle="refresh" (click)="toggleHello()">{{shouldSayHi ? "Goodbye" : "Say Hello"}}</button> (deprecated in 4.3.x)
+        <button soho-button icon="user-profile" toggle="refresh"  (click)="toggleHello()">{{shouldSayHi ? "Goodbye" : "Say Hello"}}</button> (deprecated in 4.3.x)
       </div>
 
       <div class="three columns">
@@ -63,7 +65,9 @@
         <br>
         <br>
         <br>
-        <button soho-button="icon" icon="calendar" disabled>Date</button>
+        <button soho-button="icon" icon="calendar" disabled soho-tooltip>Date</button>
+        <button soho-button="icon" icon="bullet-list" disabled soho-tooltip title="DATAGRID_VIEW"><div class="disabled-tooltip" title="DATAGRID_VIEW"></div></button>
+        <button soho-button="icon" icon="bullet-list" soho-tooltip title="DATAGRID_VIEW"><div class="disabled-tooltip" title="DATAGRID_VIEW"></div></button>
       </div>
 
     </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added support for disabled tooltips in `soho-button`.

**Related github/jira issue (required)**:

Closes #195.

**Steps necessary to review your pull request (required)**:

Build `ids-enterprise-ng`
Build and Server demo app.
Navigate to http://localhost/4200/buttons
Check the disabled icon button `calendar`.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
