### PR TITLE
203 - Added support to export custom dataset with Datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise-NG
 
+### Features
+
+- `[DataGrid]` Added support for excel utilities to export custom dataset without Datagrid `DV`
+
 ## v4.11.0
 
 ### 4.11.0 Fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,14 @@
 # What's New with Enterprise-NG
 
-### Features
+## v4.12.0
+
+### 4.12.0 Features
 
 - `[DataGrid]` Added support for excel utilities to export custom dataset without Datagrid `DV`
+
+### 4.12.0 Fixes
+
+### 4.12.0 Chore & Maintenance
 
 ## v4.11.0
 

--- a/projects/ids-enterprise-ng/src/lib/utils/soho-utils.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/utils/soho-utils.d.ts
@@ -2,3 +2,29 @@ interface JQueryStatic {
   createIcon(options: any): string;
   createIconPath(options: any): string;
 }
+
+interface SohoUtilsExcelStatic {
+  /**
+   * Export the grid contents to csv
+   * @param fileName The desired export filename in the download.
+   * @param customDs An optional customized version of the data to use.
+   * @param self The grid api to use (if customDs is not used)
+   * @returns void
+   */
+  exportToCsv(fileName?: string, customDs?: any, self?: any): void;
+
+  /**
+   * Export the grid contents to xls format. This may give a warning when opening the file.
+   * exportToCsv may be prefered.
+   * @param fileName The desired export filename in the download.
+   * @param worksheetName A name to give the excel worksheet tab.
+   * @param customDs An optional customized version of the data to use.
+   * @param self The grid api if customDS is not used
+   * @returns void
+   */
+  exportToExcel(fileName?: string, worksheetName?: string, customDs?: any, self?: any): void;
+}
+
+interface SohoStatic {
+  excel: SohoUtilsExcelStatic;
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -85,6 +85,7 @@ import { DataGridCustomFormatterServiceDemoComponent } from './datagrid/datagrid
 import { DataGridDynamicDemoComponent } from './datagrid/datagrid-dynamic.demo';
 import { DataGridEditorsDemoComponent } from './datagrid/datagrid-editors.demo';
 import { DataGridEmptyMessageDemoComponent } from './datagrid/datagrid-empty-message.demo';
+import { DataGridExportWithoutDataGridDemoComponent } from './datagrid/datagrid-export-without-datagrid.demo';
 import { DataGridFixedHeaderDemoComponent } from './datagrid/datagrid-fixedheader.demo';
 import { DataGridGroupableDemoComponent } from './datagrid/datagrid-groupable.demo';
 import { DataGridGroupedHeaderDemoComponent } from './datagrid/datagrid-grouped-header.demo';
@@ -255,6 +256,7 @@ import { TestTabsBasicComponent } from './tabs/test-tabs-basic.demo';
     DataGridDynamicDemoComponent,
     DataGridEditorsDemoComponent,
     DataGridEmptyMessageDemoComponent,
+    DataGridExportWithoutDataGridDemoComponent,
     DataGridFixedHeaderDemoComponent,
     DataGridGroupedHeaderDemoComponent,
     DataGridLookupDialogDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -47,6 +47,7 @@ import { DataGridLookupDialogDemoComponent } from './datagrid/datagrid-lookup-di
 import { DataGridRowReorderDemoComponent } from './datagrid/datagrid-rowreorder.demo';
 import { DataGridDynamicDemoComponent } from './datagrid/datagrid-dynamic.demo';
 import { DataGridEditorsDemoComponent } from './datagrid/datagrid-editors.demo';
+import { DataGridExportWithoutDataGridDemoComponent } from './datagrid/datagrid-export-without-datagrid.demo';
 import { DataGridFixedHeaderDemoComponent } from './datagrid/datagrid-fixedheader.demo';
 import { DataGridGroupableDemoComponent } from './datagrid/datagrid-groupable.demo';
 import { DataGridGroupedHeaderDemoComponent } from './datagrid/datagrid-grouped-header.demo';
@@ -193,6 +194,7 @@ export const routes: Routes = [
   { path: 'datagrid-empty-message',                 component: DataGridEmptyMessageDemoComponent },
   { path: 'datagrid-editors',                       component: DataGridEditorsDemoComponent },
   { path: 'datagrid-editors',                       component: DataGridEditorsDemoComponent },
+  { path: 'datagrid-export-without-datagrid',       component: DataGridExportWithoutDataGridDemoComponent },
   { path: 'datagrid-fixedheader',                   component: DataGridFixedHeaderDemoComponent },
   { path: 'datagrid-groupedheader',                 component: DataGridGroupedHeaderDemoComponent },
   { path: 'datagrid-groupable',                     component: DataGridGroupableDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -58,6 +58,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-dynamic']"><span>DataGrid - Dynamic</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-editors']"><span>DataGrid - Editors</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-empty-message']"><span>DataGrid - Empty Message</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['datagrid-export-without-datagrid']"><span>DataGrid - Export without Datagrid</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-fixedheader']"><span>DataGrid - Fixed Header</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-groupedheader']"><span>DataGrid - Grouped Header</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-groupable']"><span>DataGrid - Groups</span></a></div>

--- a/src/app/datagrid/datagrid-export-without-datagrid.demo.html
+++ b/src/app/datagrid/datagrid-export-without-datagrid.demo.html
@@ -1,0 +1,14 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Soho Data Grid - Export without Datagrid</h2>
+  </div>
+</div>
+
+<br>
+<div class="row top-padding">
+  <div class="twelve columns demo" role="main">
+    <button soho-button (click)="exportToCsv()">Export To Csv</button>
+    <button soho-button (click)="exportToExcel()">Export To Excel</button>
+  </div>
+</div>

--- a/src/app/datagrid/datagrid-export-without-datagrid.demo.ts
+++ b/src/app/datagrid/datagrid-export-without-datagrid.demo.ts
@@ -1,0 +1,40 @@
+import {
+  Component,
+  ChangeDetectionStrategy
+} from '@angular/core';
+
+@Component({
+  selector: 'app-datagrid-export-without-datagrid-demo',
+  templateUrl: './datagrid-export-without-datagrid.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DataGridExportWithoutDataGridDemoComponent {
+
+  // Some Sample Data
+  private dataset = [
+    { id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>',
+    quantity: 1, price: 210.99, status: 'OK', orderDate:  '', portable: false, action: 1,
+    description: 'Compressor comes with various air compressor accessories, to help you with a variety' },
+    { id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair',
+    quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false,
+    action: 1, description: 'The kit has an air blow gun that can be used for cleaning' },
+    { id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  '', portable: true,
+    quantity: null, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 2 },
+    { id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint',
+    portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3),
+    action: 3, description: 'Compressor comes with with air tool kit' },
+    { id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair',
+    portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 1 },
+    { id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair',
+    portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2 },
+    { id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair',
+    portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2 }
+  ];
+
+  exportToCsv() {
+    Soho.excel.exportToCsv('MyExport', this.dataset);
+  }
+  exportToExcel() {
+    Soho.excel.exportToExcel('MyExport', 'Worksheet1', this.dataset);
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The export custom dataset to excel (excel utilities) were not working with angular. This PR will add support to export custom dataset with Datagrid.

**Related github/jira issue (required)**:
Closes #203

**Steps necessary to review your pull request (required)**:
http://localhost:4200/datagrid-export-without-datagrid
- Run demo app
- Open above link
- Click on buttons to download custom dataset (Export To Csv, Export To Excel)