### PR TITLE
144 - Re-enabled base tag with href `/`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>SohoXI - Angular Components</title>
-  <!-- <base href="/"> -->
+  <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR simply uncomments the base tag on [this line](https://github.com/infor-design/enterprise-ng/blob/master/src/index.html#L6) in `src/index.html`.  infor-design/enterprise#977 fixes the problems when using SVG icons with `<base href="/">` or `<base href="">`.  While testing those changes, using the branch attached to this PR demonstrates the fix, and also appears to be safe for general use.

**Related github/jira issue (required)**:
- infor-design/enterprise#977
- #144 

**Steps necessary to review your pull request (required)**:
See infor-design/enterprise#977 for testing procedure

paging @dubde
