### PR TITLE
Rendering events not firing on component creation

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1948,33 +1948,6 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
         this.onEditCell(editor);
       };
 
-      // Initialise the SohoXi control.
-      this.jQueryElement.datagrid(this._gridOptions);
-
-      // Once the control is initialised, extract the control
-      // plug-in from the element.  The element name is
-      // defined by the plug-in, but in this case is 'datagrid'.
-      this.datagrid = this.jQueryElement.data('datagrid');
-
-      // If "auto" and there's a service, get the columns from it.
-      // (may want to check if columns have already been set? Error?)
-      if (this.datagridType === SohoDataGridComponent.AUTO && this.datagridService) {
-        // Bootstrap from service, note this is not async.
-        this.columns = this.datagridService.getColumns();
-        // Once the columns are set, request the data (paging?)
-        this.datagridService.getData(null)
-          .subscribe((data: any[]) => {
-            this.ngZone.runOutsideAngular(() => {
-              this.datagrid.loadData(data);
-            });
-          });
-      } else if (this.gridData) {
-        // Not using a service, so use the pre-loaded data.
-        this.ngZone.runOutsideAngular(() => {
-          this.datagrid.loadData(this.gridData);
-        });
-      }
-
       // Initialise any event handlers.
       this.jQueryElement
         .on('addrow', (e: any, args: SohoDataGridAddRowEvent) => { this.onRowAdd(args); })
@@ -1996,7 +1969,34 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
         .on('selected', (e: any, args: SohoDataGridSelectedRow[]) => this.onSelected({ e, rows: args }))
         .on('settingschanged', (e: any, args: SohoDataGridSettingsChangedEvent) => { this.onSettingsChanged(args); })
         .on('sorted', (e: any, args: SohoDataGridSortedEvent) => { this.onSorted(args); });
-    });
+      });
+
+      // Initialise the SohoXi control.
+      this.jQueryElement.datagrid(this._gridOptions);
+
+      // Once the control is initialised, extract the control
+      // plug-in from the element.  The element name is
+      // defined by the plug-in, but in this case is 'datagrid'.
+      this.datagrid = this.jQueryElement.data('datagrid');
+
+    // If "auto" and there's a service, get the columns from it.
+    // (may want to check if columns have already been set? Error?)
+    if (this.datagridType === SohoDataGridComponent.AUTO && this.datagridService) {
+      // Bootstrap from service, note this is not async.
+      this.columns = this.datagridService.getColumns();
+      // Once the columns are set, request the data (paging?)
+      this.datagridService.getData(null)
+        .subscribe((data: any[]) => {
+          this.ngZone.runOutsideAngular(() => {
+            this.datagrid.loadData(data);
+          });
+        });
+    } else if (this.gridData) {
+      // Not using a service, so use the pre-loaded data.
+      this.ngZone.runOutsideAngular(() => {
+        this.datagrid.loadData(this.gridData);
+      });
+    }
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -710,6 +710,9 @@ interface SohoDataGridColumn {
 
   /** Enforce a max length when editing this column */
   maxLength?: boolean;
+
+  /** Validators to assign to any editable columns. */
+  validate?: string;
 }
 
 interface SohoDataGridColumnNumberFormat {

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
@@ -315,6 +315,32 @@ describe('Soho DataGrid Render', () => {
     fixture.detectChanges();
   });
 
+  it('check rendered', (done) => {
+    component.datagrid.rendered.subscribe((renderedEvent: SohoDataGridRenderedEvent) => {
+      expect(renderedEvent).not.toBeNull();
+      done();
+    });
+
+    fixture.detectChanges();
+
+    component.datagrid.setSortColumn('desc', true);
+
+    fixture.detectChanges();
+  });
+
+  it('check afterrender', (done) => {
+    component.datagrid.afterRender.subscribe((afterRenderEvent: SohoDataGridAfterRenderEvent) => {
+      expect(afterRenderEvent).not.toBeNull();
+      done();
+    });
+
+    fixture.detectChanges();
+
+    component.datagrid.setSortColumn('desc', true);
+
+    fixture.detectChanges();
+  });
+
   it('check setColumnSort(id, ascending)', (done) => {
 
     component.datagrid.sorted.subscribe((sortedEvent: SohoDataGridSortedEvent) => {

--- a/src/app/datagrid/datagrid-angular-editor.demo.ts
+++ b/src/app/datagrid/datagrid-angular-editor.demo.ts
@@ -1,13 +1,8 @@
 import {
   Component,
-  ContentChild,
   ViewChild,
   AfterViewInit,
-  ComponentRef,
-  ElementRef,
-  Input,
   Inject,
-  OnDestroy
 } from '@angular/core';
 
 import {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adding `(rendered)="onRendered($event)` and `(afterRender)="onAfterRender($event)" to a `soho-datagrid` does not fire either event when the component is created, subsequent rendering events are fired.

**Related github/jira issue (required)**:

Closes #251.

**Steps necessary to review your pull request (required)**:

Create a component, containing events handlers for the `rendered` and `afterRender` outputs.

Display the component and check to see if the events are fires.

