### PR TITLE
Adding optional arguments to openMenu function of soho-application-menu

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.component.ts
@@ -169,8 +169,8 @@ export class SohoApplicationMenuComponent implements AfterViewInit, AfterViewChe
   }
 
   /** Open the menu. */
-  public openMenu() {
-    this.ngZone.runOutsideAngular(() => this.applicationmenu.openMenu());
+  public openMenu(noFocus?: boolean, userOpened?: boolean, openedByClass?: boolean) {
+    this.ngZone.runOutsideAngular(() => this.applicationmenu.openMenu(noFocus, userOpened, openedByClass));
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.d.ts
@@ -46,7 +46,7 @@ interface SohoApplicationMenuStatic {
    *
    * param noFocus - if set the current focus is not modified.
    */
-  openMenu(noFocus?: boolean): void;
+  openMenu(noFocus?: boolean, userOpened?: boolean, openedByClass?: boolean): void;
 
   /**
    * Closes the application menu.

--- a/src/app/application-menu/application-menu-lazy.demo.html
+++ b/src/app/application-menu/application-menu-lazy.demo.html
@@ -1,4 +1,5 @@
 <button soho-button id="application-lazy-menu-trigger">Open Lazy App Menu</button>
+<button soho-button id="manual-trigger" (click)="openMenu()">Open Lazy App Menu Manual</button>
 
 <nav id="applicationMenuLazy" soho-application-menu [triggers]="triggers">
   <div class="accordion panel inverse" data-options="{'allowOnePane': true}">

--- a/src/app/application-menu/application-menu-lazy.demo.ts
+++ b/src/app/application-menu/application-menu-lazy.demo.ts
@@ -54,4 +54,7 @@ export class ApplicationMenuLazyDemoComponent implements AfterViewInit, OnInit {
       this.applicationMenu.updated();
     }
   }
+  public openMenu() {
+    this.applicationMenu.openMenu(undefined, true, undefined);
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adding optional parameters: userOpened and openedByClass to the openMenu function in soho-application-menu and adjusted application-menu-lazy-demo to test this function.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/255

**Steps necessary to review your pull request (required)**:
Create a component calling the openMenu on soho-application-menu, passing true for userOpened argument.

Make sure the menu stays opened on a mobile device.