### PR TITLE
Added setTheme and setColor to PersonaliseDirective

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See the [list of features](docs/FEATURES.md) for details about the included and 
 ## Strategy
 
 - Will use Typescript 3.1.x
-- Will wrap Soho XI controls
+- Will wrap Infor Design System Enterprise controls
 - Two Tracks: Track 1: Wrap Current Controls, Track 2: Es6 refactor of core controls keeping directives updated
 - Will be supported by the H&L team in collaboration with multiple teams
 - Will use <https://cli.angular.io/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 5.0.0 Fixes
 
- - `[Personalize]` - Added `setTheme` and `setColors` to `SohoPersonaliseDirtective`
+ - `[Personalize]` - Added `setTheme` and `setColors` to `SohoPersonalizeDirtective`
    - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request 262](https://github.com/infor-design/enterprise-ng/pull/262))).
 
 ### 5.0.0 Chore & Maintenance

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,19 +1,22 @@
 # What's New with Enterprise-NG
 
-## v4.13.0
+## v5.0.0
 
-### 4.13.0 Features
-
-### 4.13.0 Fixes
-
-### 4.13.0 Chore & Maintenance
+### 5.0.0 Features
 
 - `[General]` Upgraded @angular/cli (to 7.0.x) and @angular/core (to 7.0.x).  `BTHH` ([Pull Request 227](https://github.com/infor-design/enterprise-ng/pull/227))
     - support for Node 10
     - support for TypeScript 3.x
-    - `UPGRADING.md` has been upated with details on upgrading your application to angular 7.
-- `[General]` Upgraded typeScript (to 3.1.x). `BTHH`
+    - `UPGRADING.md` has been updated with details on upgrading your application to angular 7.
+- `[General]` Upgraded Typescript (to 3.1.x). `BTHH`
     - `@types/jquery` has been updated to 3.3.21.
+
+### 5.0.0 Fixes
+
+ - `[Personalize]` - Added `setTheme` and `setColors` to `SohoPersonaliseDirtective`
+   - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))).
+
+### 5.0.0 Chore & Maintenance
 
 ## v4.12.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,14 @@
 
 ### 5.0.0 Chore & Maintenance
 
+## v4.13.0
+
+### 4.13.0 Features
+
+### 4.13.0 Fixes
+
+### 4.13.0 Chore & Maintenance
+
 ## v4.12.0
 
 ### 4.12.0 Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,8 +13,8 @@
 
 ### 5.0.0 Fixes
 
- - `[Personalize]` - Added `setTheme` and `setColors` to `SohoPersonalizeDirtective`
-   - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request 262](https://github.com/infor-design/enterprise-ng/pull/262))).
+- `[Personalize]` - Added `setTheme` and `setColors` to `SohoPersonalizeDirtective`
+    - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request 262](https://github.com/infor-design/enterprise-ng/pull/262))).
 
 ### 5.0.0 Chore & Maintenance
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### 5.0.0 Fixes
 
  - `[Personalize]` - Added `setTheme` and `setColors` to `SohoPersonaliseDirtective`
-   - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))).
+   - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request 262](https://github.com/infor-design/enterprise-ng/pull/262))).
 
 ### 5.0.0 Chore & Maintenance
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -10,7 +10,7 @@ Consuming the `ids-enterprise-ng` package will require changes to any projects r
 
 ### Upgrade Angular and Angular/CLI
 
-These instructions assume you will be running the latest versions of `@angular/cli` and `@angular/core`. It is recommended that you review the information on <http://update.anguar.com> before updating.
+These instructions assume you will be running the latest versions of `@angular/cli` and `@angular/core`. It is recommended that you review the information on <https://update.angular.io> before updating.
 
 Note: The libraries are currently compiled using angular 7, and so require all consumers to use the same major version.
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "classlist.js": "^1.1.20150312",
     "core-js": "^2.5.4",
     "d3": "4.13.0",
-    "ids-enterprise": "^4.13.0-dev.20181024",
+    "ids-enterprise": "4.13.0-dev.20181105",
     "jquery": "3.3.1",
     "lscache": "^1.2.0",
     "rxjs": "~6.3.3",

--- a/projects/ids-enterprise-ng/package.json
+++ b/projects/ids-enterprise-ng/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@types/jquery": "3.3.21",
     "@types/d3": "4.13.0",
-    "ids-enterprise": "4.13.0-dev.20181024",
+    "ids-enterprise": "4.13.0-dev",
     "jquery": "3.3.1",
     "d3": "4.13.0"
   },

--- a/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.d.ts
@@ -57,7 +57,7 @@ interface SohoApplicationMenuStatic {
    * Add and remove application nav menu triggers.
    *
    * @param triggers - list of triggers
-   * @param remove - if set the the triggers will be removed.
+   * @param remove - if set the triggers will be removed.
    * @param norebuild - if set this control's events won't automatically be rebound to include
    *                    the new triggers.
    */

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
@@ -122,7 +122,7 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
 
   @HostListener('keyup', ['$event'])
   onKeyUp(event: KeyboardEvent) {
-    // This is required, otherwise the the form binding does not see updates.
+    // This is required, otherwise the form binding does not see updates.
     this.internalValue = this.jQueryElement.val() as string;
   }
 

--- a/projects/ids-enterprise-ng/src/lib/mask/soho-mask.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/mask/soho-mask.spec.ts
@@ -13,7 +13,7 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { FormsModule, FormControl, FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 
 import { SohoMaskDirective } from './soho-mask.directive';
 import { SohoMaskModule } from './soho-mask.module';

--- a/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.d.ts
@@ -66,7 +66,7 @@ interface SohoPersonalizeStatic {
  * JQuery Integration
  */
 interface JQueryStatic {
-  // personalization: SohoPersonalizeStatic;
+  personalize: SohoPersonalizeStatic;
 }
 
 interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {

--- a/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.d.ts
@@ -8,18 +8,65 @@
  * Configuration options.
  */
 interface SohoPersonalizeOptions {
-  colors?: string,
-  theme?: string
+  colors?: string | SohoPersonalizeColors;
+  theme?: string;
+
+  /** Font is only accessible via the initial settings, and cannot be modified. */
+  font?: string;
 }
 
 interface SohoPersonalizeEvent extends JQuery.Event {
   data: any;
 }
 
+interface SohoChangeThemePersonalizeEvent extends SohoPersonalizeEvent {
+  theme?: string;
+}
+
+interface SohoChangeColorsPersonalizeEvent extends SohoPersonalizeEvent {
+  colors?: SohoPersonalizeColors;
+}
+
+interface SohoPersonalizeColors {
+  header?: string;
+  subheader?: string,
+  text?: string,
+  verticalBorder?: string,
+  horizontalBorder?: string,
+  inactive?: string,
+  hover?: string,
+  btnColorHeader?: string,
+  btnColorSubheader?: string
+}
+
+interface SohoPersonalizeStatic {
+  /**
+   * Sets the current theme, blocking the ui during the change.
+   *
+   * @param theme  Represents the file name of a color
+   * scheme (can be dark, light or high-contrast)
+   */
+  setTheme(theme: string): void;
+
+ /**
+  * Sets the personalization color(s)
+  *
+  * @param colors The original hex color as a string or an object with all the Colors
+  */
+  setColors(colors: SohoPersonalizeColors | string);
+
+  /**
+   * Teardown - Remove added markup and events
+   * @returns {void}
+   */
+  destroy(): void;
+}
+
 /**
  * JQuery Integration
  */
 interface JQueryStatic {
+  // personalization: SohoPersonalizeStatic;
 }
 
 interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {

--- a/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.directive.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 
 /**
- * Angular Wrapper for the the enterprise personalise widget.
+ * Angular Wrapper for the enterprise personalise widget.
  *
  * This component searches for an element with the attribute
  * 'soho-personalize'.

--- a/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.directive.ts
@@ -7,6 +7,8 @@ import {
   EventEmitter,
   Input,
   Output,
+  NgZone,
+  OnDestroy,
 } from '@angular/core';
 
 /**
@@ -18,29 +20,47 @@ import {
 @Directive({
   selector: '[soho-personalize]',
 })
-export class SohoPersonalizeDirective implements AfterViewInit {
+export class SohoPersonalizeDirective implements AfterViewInit, OnDestroy {
+
+  /** EP api */
+  private personalize: SohoPersonalizeStatic;
+
+  /** jQuery Widget */
+  private jQueryElement: JQuery<HTMLElement>;
 
   /** Options. */
   @Input() options: SohoPersonalizeOptions = {};
 
   /** The starting colour. */
-  @Input() set colors(colors: string) {
+  @Input() set colors(colors: string | SohoPersonalizeColors) {
     this.options.colors = colors;
+    if (this.personalize) {
+      this.ngZone.runOutsideAngular(() => {
+        this.personalize.setColors(colors);
+       });
+    }
   }
 
   /** The starting theme. */
   @Input() set theme(theme: string) {
     this.options.theme = theme;
+    if (this.personalize) {
+      this.ngZone.runOutsideAngular(() => {
+        this.personalize.setTheme(theme);
+       });
+    }
   }
 
-  @Output() changetheme: EventEmitter<Object> = new EventEmitter<Object>();
+  @Output() changetheme = new EventEmitter<SohoChangeThemePersonalizeEvent>();
 
-  @Output() changecolors: EventEmitter<Object> = new EventEmitter<Object>();
+  @Output() changecolors = new EventEmitter<SohoChangeColorsPersonalizeEvent>();
 
   /**
    * Constructor.
    */
-  constructor(private el: ElementRef) {
+  constructor(
+    private element: ElementRef,
+    private ngZone: NgZone) {
   }
 
   /**
@@ -48,8 +68,61 @@ export class SohoPersonalizeDirective implements AfterViewInit {
    * get the SoHoXi controls to apply any renderings.
    */
   ngAfterViewInit() {
-    jQuery('body').personalize(this.options)
-      .on('changetheme.personalize', (ev, data) => { ev.data = data; this.changetheme.emit(ev); })
-      .on('changecolors.personalize', (ev, data) => { ev.data = data; this.changecolors.emit(ev); });
+    // call outside the angular zone so change detection
+    // isn't triggered by the soho component.
+    this.ngZone.runOutsideAngular(() => {
+      // assign element to local variable - not this must attach to a root#
+      // element in this case 'body'
+      this.jQueryElement = jQuery('body');
+
+      // initialise the colorpicker control
+      const api = this.jQueryElement.personalize(this.options);
+      /**
+       * Bind to jQueryElement's events
+       */
+      this.jQueryElement
+        .on('changetheme.personalize',
+          (ev: JQuery.Event, theme: string) => { console.log(`changetheme.personalize`); this.onChangeTheme(ev, theme); })
+        .on('changecolors.personalize',
+          (ev: JQuery.Event, colors: any) => { console.log(`changecolors.personalize`); this.onChangeColors(ev, colors); });
+
+      // extract the api
+      this.personalize = this.jQueryElement.data('personalize');
+    });
+
+  }
+
+  onChangeTheme(e: JQuery.Event, theme: string) {
+    this.ngZone.run(() => {
+      const event = e as SohoChangeThemePersonalizeEvent;
+      event.theme = theme;
+      // Set the legacy property
+      event.data = theme;
+      this.changetheme.emit(event);
+    });
+  }
+
+  onChangeColors(e: JQuery.Event, colors: any) {
+    this.ngZone.run(() => {
+      const event = e as SohoChangeColorsPersonalizeEvent;
+      event.colors = colors;
+      // Set the legacy property
+      event.data = colors;
+      this.changecolors.emit(event);
+    });
+  }
+
+  ngOnDestroy() {
+    this.ngZone.runOutsideAngular(() => {
+
+      if (this.jQueryElement) {
+        this.jQueryElement.off();
+      }
+
+      if (this.personalize) {
+        this.personalize.destroy();
+        this.personalize = null;
+      }
+    });
   }
 }

--- a/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.directive.ts
@@ -71,7 +71,7 @@ export class SohoPersonalizeDirective implements AfterViewInit, OnDestroy {
     // call outside the angular zone so change detection
     // isn't triggered by the soho component.
     this.ngZone.runOutsideAngular(() => {
-      // assign element to local variable - not this must attach to a root#
+      // assign element to local variable - not this must attach to a root
       // element in this case 'body'
       this.jQueryElement = jQuery('body');
 
@@ -82,9 +82,9 @@ export class SohoPersonalizeDirective implements AfterViewInit, OnDestroy {
        */
       this.jQueryElement
         .on('changetheme.personalize',
-          (ev: JQuery.Event, theme: string) => { console.log(`changetheme.personalize`); this.onChangeTheme(ev, theme); })
+          (ev: JQuery.Event, theme: string) => { this.onChangeTheme(ev, theme); })
         .on('changecolors.personalize',
-          (ev: JQuery.Event, colors: any) => { console.log(`changecolors.personalize`); this.onChangeColors(ev, colors); });
+          (ev: JQuery.Event, colors: any) => { this.onChangeColors(ev, colors); });
 
       // extract the api
       this.personalize = this.jQueryElement.data('personalize');

--- a/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.directive.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 
 /**
- * Angular Wrapper for the SoHo Personalise Directive.
+ * Angular Wrapper for the the enterprise personalise widget.
  *
  * This component searches for an element with the attribute
  * 'soho-personalize'.
@@ -29,7 +29,7 @@ export class SohoPersonalizeDirective implements AfterViewInit, OnDestroy {
   private jQueryElement: JQuery<HTMLElement>;
 
   /** Options. */
-  @Input() options: SohoPersonalizeOptions = {};
+  @Input() public options: SohoPersonalizeOptions = {};
 
   /** The starting colour. */
   @Input() set colors(colors: string | SohoPersonalizeColors) {
@@ -59,7 +59,6 @@ export class SohoPersonalizeDirective implements AfterViewInit, OnDestroy {
    * Constructor.
    */
   constructor(
-    private element: ElementRef,
     private ngZone: NgZone) {
   }
 
@@ -75,7 +74,12 @@ export class SohoPersonalizeDirective implements AfterViewInit, OnDestroy {
       // element in this case 'body'
       this.jQueryElement = jQuery('body');
 
-      // initialise the colorpicker control
+      // Check the element has attached to the body.
+      if (this.jQueryElement.length === 0) {
+        throw Error('No body found');
+      }
+
+      // initialise the control
       const api = this.jQueryElement.personalize(this.options);
       /**
        * Bind to jQueryElement's events

--- a/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.spec.ts
@@ -1,0 +1,145 @@
+/// <reference path="soho-personalize.d.ts" />
+
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import { By } from '@angular/platform-browser';
+
+import {
+  Component,
+  DebugElement,
+  ViewChild
+} from '@angular/core';
+
+import { FormsModule, FormControl, FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+
+import { SohoPersonalizeDirective } from './soho-personalize.directive';
+import { SohoPersonalizeModule } from './soho-personalize.module';
+
+@Component({
+  template: `
+  <div soho-personalize (onChangeTheme)="onChangeTheme" (onChangeColours)="onChangeTheme" >
+    <input soho-input soho-mask [sohoPattern]="'UUU'" [definitions]="definitions" />
+  </div>`
+})
+class SohoCustomMaskTestComponent {
+  @ViewChild(SohoMaskDirective) input: SohoMaskDirective;
+
+  public definitions: SohoMaskDefinitions = {'U': /[A-Z]/};
+}
+
+@Component({
+  template: `
+  <div>
+    <form [formGroup]="demoForm">
+      <input soho-mask formControlName="ctrl" [integerLimit]="3" [process]="'number'"/>
+    </form>
+  </div>`
+})
+class SohoMaskTestComponent {
+  @ViewChild(SohoMaskDirective) input: SohoMaskDirective;
+
+  public value: string;
+
+  public demoForm: FormGroup;
+
+  constructor(public formBuilder: FormBuilder) {
+    this.createForm();
+  }
+
+  createForm() {
+    // note - both controls have the .required validator.
+    this.demoForm = this.formBuilder.group({
+      ctrl: ['111', [Validators.required, Validators.minLength(2), Validators.maxLength(5)]],
+    });
+  }
+}
+
+describe('Soho Mask Render', () => {
+  let input:     SohoMaskDirective;
+  let component: SohoMaskTestComponent;
+  let fixture:   ComponentFixture<SohoMaskTestComponent>;
+  let de:        DebugElement;
+  let el:        HTMLElement;
+
+  beforeEach( () => {
+    TestBed.configureTestingModule({
+      declarations: [ SohoMaskTestComponent ],
+      imports: [ FormsModule, ReactiveFormsModule, SohoMaskModule, SohoInputModule ]
+    });
+
+    fixture = TestBed.createComponent(SohoMaskTestComponent);
+    component = fixture.componentInstance;
+    input = component.input;
+
+    de = fixture.debugElement;
+    el = de.query(By.css('input[soho-mask]')).nativeElement;
+
+    fixture.detectChanges();
+  });
+
+  it('Check HTML content', () => {
+    fixture.detectChanges();
+
+  });
+
+  it('should update control with new input', () => {
+    const inp = fixture.debugElement.query(By.css('input'));
+    expect(inp.nativeElement.value).toEqual('111');
+
+    component.demoForm.controls['ctrl'].setValue('222');
+    inp.nativeElement.value = '222';
+
+    expect(inp.nativeElement.value).toEqual('222');
+
+    expect(component.demoForm.controls['ctrl'].value).toBe('222');
+    expect(component.demoForm.controls['ctrl'].valid).toBeTruthy();
+  });
+
+  it('should update control with new input invalid', () => {
+    const inp = fixture.debugElement.query(By.css('input'));
+    expect(inp.nativeElement.value).toEqual('111');
+    expect(component.demoForm.controls['ctrl'].valid).toBeTruthy();
+
+    component.demoForm.controls['ctrl'].setValue('555555');
+
+    expect(inp.nativeElement.value).toEqual('555555');
+
+    expect(component.demoForm.controls['ctrl'].value).toBe('555555');
+    expect(component.demoForm.controls['ctrl'].valid).toBeFalsy();
+  });
+});
+
+describe('Soho Custom Mask Render', () => {
+  let input:     SohoMaskDirective;
+  let component: SohoCustomMaskTestComponent;
+  let fixture:   ComponentFixture<SohoCustomMaskTestComponent>;
+  let de:        DebugElement;
+  let el:        HTMLElement;
+
+  beforeEach( () => {
+    TestBed.configureTestingModule({
+      declarations: [ SohoCustomMaskTestComponent ],
+      imports: [ FormsModule, ReactiveFormsModule, SohoMaskModule, SohoInputModule ]
+    });
+
+    fixture = TestBed.createComponent(SohoCustomMaskTestComponent);
+    component = fixture.componentInstance;
+    input = component.input;
+
+    de = fixture.debugElement;
+    el = de.query(By.css('input[soho-mask]')).nativeElement;
+
+    fixture.detectChanges();
+  });
+
+  it('Check HTML content', () => {
+    fixture.detectChanges();
+    input.definitions = {'U': /[A-Z]/};
+
+    // TODO - interact
+  });
+
+});

--- a/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/personalize/soho-personalize.spec.ts
@@ -13,69 +13,38 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { FormsModule, FormControl, FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-
 import { SohoPersonalizeDirective } from './soho-personalize.directive';
 import { SohoPersonalizeModule } from './soho-personalize.module';
 
 @Component({
   template: `
-  <div soho-personalize (onChangeTheme)="onChangeTheme" (onChangeColours)="onChangeTheme" >
-    <input soho-input soho-mask [sohoPattern]="'UUU'" [definitions]="definitions" />
-  </div>`
+  <html>
+    <body>
+      <div soho-personalize></div>
+    </body>
+  </html>`
 })
-class SohoCustomMaskTestComponent {
-  @ViewChild(SohoMaskDirective) input: SohoMaskDirective;
-
-  public definitions: SohoMaskDefinitions = {'U': /[A-Z]/};
+class SohoPersonalizeTestComponent {
+  @ViewChild(SohoPersonalizeDirective) personalize: SohoPersonalizeDirective;
 }
 
-@Component({
-  template: `
-  <div>
-    <form [formGroup]="demoForm">
-      <input soho-mask formControlName="ctrl" [integerLimit]="3" [process]="'number'"/>
-    </form>
-  </div>`
-})
-class SohoMaskTestComponent {
-  @ViewChild(SohoMaskDirective) input: SohoMaskDirective;
+describe('Soho Personalize Render', () => {
+  let component: SohoPersonalizeTestComponent;
+  let fixture: ComponentFixture<SohoPersonalizeTestComponent>;
+  let de: DebugElement;
+  let el: HTMLElement;
 
-  public value: string;
-
-  public demoForm: FormGroup;
-
-  constructor(public formBuilder: FormBuilder) {
-    this.createForm();
-  }
-
-  createForm() {
-    // note - both controls have the .required validator.
-    this.demoForm = this.formBuilder.group({
-      ctrl: ['111', [Validators.required, Validators.minLength(2), Validators.maxLength(5)]],
-    });
-  }
-}
-
-describe('Soho Mask Render', () => {
-  let input:     SohoMaskDirective;
-  let component: SohoMaskTestComponent;
-  let fixture:   ComponentFixture<SohoMaskTestComponent>;
-  let de:        DebugElement;
-  let el:        HTMLElement;
-
-  beforeEach( () => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ SohoMaskTestComponent ],
-      imports: [ FormsModule, ReactiveFormsModule, SohoMaskModule, SohoInputModule ]
+      declarations: [SohoPersonalizeTestComponent],
+      imports: [SohoPersonalizeModule]
     });
 
-    fixture = TestBed.createComponent(SohoMaskTestComponent);
+    fixture = TestBed.createComponent(SohoPersonalizeTestComponent);
     component = fixture.componentInstance;
-    input = component.input;
 
     de = fixture.debugElement;
-    el = de.query(By.css('input[soho-mask]')).nativeElement;
+    el = de.query(By.css('div[soho-personalize]')).nativeElement;
 
     fixture.detectChanges();
   });
@@ -83,63 +52,33 @@ describe('Soho Mask Render', () => {
   it('Check HTML content', () => {
     fixture.detectChanges();
 
+    expect(component.personalize).not.toBeNull();
   });
 
-  it('should update control with new input', () => {
-    const inp = fixture.debugElement.query(By.css('input'));
-    expect(inp.nativeElement.value).toEqual('111');
+  it('Check setting theme updates the component', () => {
+    fixture.detectChanges();
 
-    component.demoForm.controls['ctrl'].setValue('222');
-    inp.nativeElement.value = '222';
-
-    expect(inp.nativeElement.value).toEqual('222');
-
-    expect(component.demoForm.controls['ctrl'].value).toBe('222');
-    expect(component.demoForm.controls['ctrl'].valid).toBeTruthy();
-  });
-
-  it('should update control with new input invalid', () => {
-    const inp = fixture.debugElement.query(By.css('input'));
-    expect(inp.nativeElement.value).toEqual('111');
-    expect(component.demoForm.controls['ctrl'].valid).toBeTruthy();
-
-    component.demoForm.controls['ctrl'].setValue('555555');
-
-    expect(inp.nativeElement.value).toEqual('555555');
-
-    expect(component.demoForm.controls['ctrl'].value).toBe('555555');
-    expect(component.demoForm.controls['ctrl'].valid).toBeFalsy();
-  });
-});
-
-describe('Soho Custom Mask Render', () => {
-  let input:     SohoMaskDirective;
-  let component: SohoCustomMaskTestComponent;
-  let fixture:   ComponentFixture<SohoCustomMaskTestComponent>;
-  let de:        DebugElement;
-  let el:        HTMLElement;
-
-  beforeEach( () => {
-    TestBed.configureTestingModule({
-      declarations: [ SohoCustomMaskTestComponent ],
-      imports: [ FormsModule, ReactiveFormsModule, SohoMaskModule, SohoInputModule ]
-    });
-
-    fixture = TestBed.createComponent(SohoCustomMaskTestComponent);
-    component = fixture.componentInstance;
-    input = component.input;
-
-    de = fixture.debugElement;
-    el = de.query(By.css('input[soho-mask]')).nativeElement;
+    component.personalize.theme = 'dark';
 
     fixture.detectChanges();
+
+    expect(component.personalize.options.theme).toEqual('dark');
   });
 
-  it('Check HTML content', () => {
-    fixture.detectChanges();
-    input.definitions = {'U': /[A-Z]/};
+  it('Check seetting colors updates the component', () => {
+    component.personalize.colors = 'FF0000';
 
-    // TODO - interact
+    fixture.detectChanges();
+
+    expect(component.personalize.options.colors).toEqual('FF0000');
+  });
+
+  it('Check event handler when theme changed', () => {
+    const eventEmitterSpy = spyOn<any>(component.personalize, 'onChangeTheme');
+    $('body').trigger('changetheme', 'dark');
+
+    // Interestingly this is called three times!
+    expect(eventEmitterSpy).toHaveBeenCalled();
   });
 
 });

--- a/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
@@ -638,7 +638,7 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
   }
 
   /**
-   * Return the the currenlty active/selected tab.
+   * Return the currenlty active/selected tab.
    * @return  A JQuery object of the active tab element.
    */
   getActiveTab(): JQuery {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,13 +1,15 @@
+<div soho-personalize [options]="personalizeOptions" (changetheme)="onChangeTheme($event)" (changecolors)="onChangeColors($event)">
+
 <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
 <soho-icons></soho-icons>
 <soho-icons-ext></soho-icons-ext>
 <soho-icons-empty></soho-icons-empty>
 <app-masthead-demo></app-masthead-demo>
 
-<nav *ngIf="initialised" soho-application-menu class="is-pesonalizable" [filterable]="true" [openOnLarge]="true" [dismissOnClickMobile]="true">
+<nav *ngIf="initialised" soho-application-menu class="is-personalizable" [filterable]="true" [openOnLarge]="true" [dismissOnClickMobile]="true">
   <div soho-searchfield-wrapper>
     <label class="audible" for="application-menu-searchfield">Search</label>
-    <input soho-searchfield id="application-menu-searchfield" [clearable]=true />
+    <input soho-searchfield id="application-menu-searchfield" [clearable]="true" />
   </div>
   <application-menu-demo></application-menu-demo>
 </nav>
@@ -18,4 +20,4 @@
   </div>
 </div>
 
-<div soho-personalize [options]="personalizeOptions" (changetheme)="onChangeTheme($event)" (changecolors)="onChangeColors($event)"></div>
+</div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,3 @@
-<div soho-personalize [options]="personalizeOptions" (changetheme)="onChangeTheme($event)" (changecolors)="onChangeColors($event)">
-
 <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
 <soho-icons></soho-icons>
 <soho-icons-ext></soho-icons-ext>
@@ -19,5 +17,5 @@
       <router-outlet></router-outlet>
   </div>
 </div>
-
+<div soho-personalize [options]="personalizeOptions" (changetheme)="onChangeTheme($event)" (changecolors)="onChangeColors($event)">
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,6 +4,7 @@ import {
   ViewEncapsulation,
   ViewChild,
   AfterViewInit,
+  OnInit,
 } from '@angular/core';
 
 import { HeaderDynamicDemoRefService } from './header/header-dynamic-demo-ref.service';
@@ -33,25 +34,41 @@ export class AppComponent implements AfterViewInit {
       this.initialised = true;
     });
 
+    // this.setInitialPersonalization();
+  }
+  ngAfterViewInit(): void {
+    // Has to run after the view has been initialised otherwise
+    // the personalise component is not ready.
     this.setInitialPersonalization();
   }
+
   setInitialPersonalization() {
     const theme = localStorage.getItem('soho_theme');
-    const colors = JSON.parse(localStorage.getItem('soho_color'));
+    let colors = localStorage.getItem('soho_color');
     if (theme) {
-      this.personalizeOptions = {
-        theme
-      };
+      this.personalize.theme = theme;
     }
     if (colors) {
-      if (this.personalizeOptions) {
-        this.personalizeOptions.colors = colors;
-      } else {
-        this.personalizeOptions = {
-          colors
-        };
-      }
+      colors = JSON.parse(colors);
+      this.personalize.colors = colors;
     }
+
+    // const theme = localStorage.getItem('soho_theme');
+    // const colors = localStorage.getItem('soho_color');
+    // if (theme) {
+    //   this.personalizeOptions = {
+    //     theme
+    //   };
+    // }
+    // if (colors) {
+    //   if (this.personalizeOptions) {
+    //     this.personalizeOptions.colors = colors;
+    //   } else {
+    //     this.personalizeOptions = {
+    //       colors
+    //     };
+    //   }
+    // }
   }
   onChangeTheme(ev: SohoChangeThemePersonalizeEvent) {
     console.log('Theme changed: ', ev);
@@ -61,11 +78,4 @@ export class AppComponent implements AfterViewInit {
     console.log('Colors changed: ', ev);
     localStorage.setItem('soho_color', JSON.stringify(ev.colors));
   }
-
-  ngAfterViewInit(): void {
-    // this.personalize.theme = 'dark';
-    // this.personalize.colors = '80000';;
-    // this.personalize.font = 'source-sans';
-  }
-
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,9 +2,12 @@ import {
   Component,
   HostBinding,
   ViewEncapsulation,
+  ViewChild,
+  AfterViewInit,
 } from '@angular/core';
 
 import { HeaderDynamicDemoRefService } from './header/header-dynamic-demo-ref.service';
+import { SohoPersonalizeDirective } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'body', // tslint:disable-line
@@ -13,7 +16,9 @@ import { HeaderDynamicDemoRefService } from './header/header-dynamic-demo-ref.se
   providers: [ HeaderDynamicDemoRefService ],
   encapsulation: ViewEncapsulation.None
 })
-export class AppComponent {
+export class AppComponent implements AfterViewInit {
+
+  @ViewChild(SohoPersonalizeDirective) personalize: SohoPersonalizeDirective;
 
   public initialised = false;
 
@@ -27,14 +32,15 @@ export class AppComponent {
       console.log('Locale set');
       this.initialised = true;
     });
+
     this.setInitialPersonalization();
   }
   setInitialPersonalization() {
     const theme = localStorage.getItem('soho_theme');
-    const colors = localStorage.getItem('soho_color');
+    const colors = JSON.parse(localStorage.getItem('soho_color'));
     if (theme) {
       this.personalizeOptions = {
-        theme,
+        theme
       };
     }
     if (colors) {
@@ -42,17 +48,24 @@ export class AppComponent {
         this.personalizeOptions.colors = colors;
       } else {
         this.personalizeOptions = {
-          colors,
+          colors
         };
       }
     }
   }
-  onChangeTheme(ev: SohoPersonalizeEvent) {
+  onChangeTheme(ev: SohoChangeThemePersonalizeEvent) {
     console.log('Theme changed: ', ev);
-    localStorage.setItem('soho_theme', ev.data);
+    localStorage.setItem('soho_theme', ev.theme);
   }
-  onChangeColors(ev: SohoPersonalizeEvent) {
+  onChangeColors(ev: SohoChangeColorsPersonalizeEvent) {
     console.log('Colors changed: ', ev);
-    localStorage.setItem('soho_color', ev.data);
+    localStorage.setItem('soho_color', JSON.stringify(ev.colors));
   }
+
+  ngAfterViewInit(): void {
+    // this.personalize.theme = 'dark';
+    // this.personalize.colors = '80000';;
+    // this.personalize.font = 'source-sans';
+  }
+
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" soho-personalize>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>IDS Enterprise - Angular Components</title>

--- a/src/index.html
+++ b/src/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" soho-personalize>
 <head>
   <meta charset="utf-8">
-  <title>SohoXI - Angular Components</title>
+  <title>IDS Enterprise - Angular Components</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The `PersonalizeDirective` does not expose the set methods from the personalization support in the enterprise controls. 

**Related github/jira issue (required)**:

Closes #253.

**Steps necessary to review your pull request (required)**:

Checkout `ids-enterprise-ng`
```
Install packages
npm run build:lib
ng s
```

The application will remember the theme and colour last set, using the setTheme and setColors methods.

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
