### PR TITLE
Fix for #264

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
@@ -93,7 +93,7 @@ export class SohoFieldFilterDirective implements AfterViewChecked, AfterViewInit
     this.ngZone.runOutsideAngular(() => {
       this.jQueryElement = jQuery(this.element.nativeElement);
       this.jQueryElement.fieldfilter(this._settings);
-      this.fieldFilter = this.jQueryElement.data('field-filter');
+      this.fieldFilter = this.jQueryElement.data('fieldfilter');
 
       this.jQueryElement.on('filtered', (event: SohoFieldFilteredEvent, args: any) => this.onFiltered(event, args));
     });

--- a/projects/ids-enterprise-ng/src/lib/input/soho-input.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/input/soho-input.component.ts
@@ -81,6 +81,8 @@ export class SohoInputComponent extends BaseControlValueAccessor<string> impleme
 
   ngOnDestroy() {
     // No jQuery control.
+    this.jQueryElement.off();
+    this.jQueryElement.remove();
   }
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Enable proper destroy of soho-field-filter & soho-input

**Related github/jira issue (required)**:
closes #264

**Steps necessary to review your pull request (required)**:
1. break on ngAfterViewInit of soho-field-filter to see that it's fieldFilter property is set
2. break on ngOnDestroy of both soho-field-filter & soho-input to see procedure to destroy are being called.
