### PR TITLE
Render loop demo changes

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/button/soho-button.component.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/button/soho-button.component.spec.ts
@@ -13,11 +13,7 @@ import {
   ViewChild
 } from '@angular/core';
 
-import {
-  FormsModule,
-  FormGroup,
-  FormBuilder
-} from '@angular/forms';
+import { FormsModule } from '@angular/forms';
 
 import { SohoButtonModule } from './soho-button.module';
 import { SohoTooltipModule } from '../tooltip/soho-tooltip.module';
@@ -64,6 +60,30 @@ describe('Soho Button Unit Tests', () => {
 
   it('is created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('can get and set replaceText', () => {
+    expect(button.replaceText).toBeUndefined();
+
+    button.replaceText = true;
+    expect((button as any)._buttonOptions.replaceText).toBeTruthy();
+
+    button.replaceText = false;
+    expect((button as any)._buttonOptions.replaceText).toBeFalsy();
+  });
+
+  it('can get and set toggleOffIcon', () => {
+    expect(button.toggleOffIcon).toBeUndefined();
+    button.toggleOffIcon = 'heart';
+
+    expect((button as any)._buttonOptions.toggleOffIcon).toEqual('heart');
+  });
+
+  it('can get and set toggleOnIcon', () => {
+    expect(button.toggleOnIcon).toBeUndefined();
+    button.toggleOnIcon = 'heart';
+
+    expect((button as any)._buttonOptions.toggleOnIcon).toEqual('heart');
   });
 
 });

--- a/projects/ids-enterprise-ng/src/lib/button/soho-button.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/button/soho-button.component.ts
@@ -81,14 +81,22 @@ export class SohoButtonComponent implements AfterViewInit, OnDestroy, OnInit {
   @Input() set toggleOnIcon(toggleOnIcon: string) {
     this._buttonOptions.toggleOnIcon = toggleOnIcon;
     if (this.jQueryElement) {
-      // todo: how to update the button when toggleOnIcon change?
+      // todo: how to update the button when toggleOnIcon changes?
     }
   }
 
   @Input() set toggleOffIcon(toggleOffIcon: string) {
     this._buttonOptions.toggleOffIcon = toggleOffIcon;
     if (this.jQueryElement) {
-      // todo: how to update the button when toggleOffIcon change?
+      // todo: how to update the button when toggleOffIcon changes?
+    }
+  }
+
+  @Input() set replaceText(replaceText: boolean) {
+    this._buttonOptions.replaceText = replaceText;
+    if (this.jQueryElement) {
+      this.button.settings.replaceText = replaceText;
+      // todo: how to update the button replaceText changes?
     }
   }
 
@@ -279,7 +287,7 @@ export class SohoButtonComponent implements AfterViewInit, OnDestroy, OnInit {
       }
     });
 
-    // There are no 'extra' event handler for button.
+    // There are no 'extra' event handlers for button.
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/button/soho-button.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/button/soho-button.d.ts
@@ -11,6 +11,7 @@
 interface SohoButtonOptions {
   toggleOnIcon?: string;
   toggleOffIcon?: string;
+  replaceText?: boolean;
 }
 
 /**
@@ -18,6 +19,7 @@ interface SohoButtonOptions {
  * button.
  */
 interface SohoButtonStatic {
+  settings: SohoButtonOptions;
   destroy(): void;
 }
 

--- a/projects/ids-enterprise-ng/src/lib/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/index.ts
@@ -52,6 +52,7 @@ export * from './progress/index';
 export * from './radar/index';
 export * from './rating/index';
 export * from './radiobutton/index';
+export * from './renderLoop/index';
 export * from './searchfield/index';
 export * from './slider/index';
 export * from './sparkline/index';

--- a/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
@@ -53,6 +53,7 @@ import { SohoPopupMenuModule } from './popupmenu/soho-popupmenu.module';
 import { SohoRadarModule } from './radar/soho-radar.module';
 import { SohoRadioButtonModule } from './radiobutton/soho-radiobutton.module';
 import { SohoRatingModule } from './rating/soho-rating.module';
+import { SohoRenderLoopModule } from './renderLoop/soho-render-loop.module';
 import { SohoSearchFieldModule } from './searchfield/soho-searchfield.module';
 import { SohoSliderModule } from './slider/soho-slider.module';
 import { SohoSparklineModule } from './sparkline/soho-sparkline.module';
@@ -128,6 +129,7 @@ import { SohoWizardModule } from './wizard/soho-wizard.module';
     SohoRadarModule,
     SohoRadioButtonModule,
     SohoRatingModule,
+    SohoRenderLoopModule,
     SohoSearchFieldModule,
     SohoSparklineModule,
     SohoSplitterModule,
@@ -202,6 +204,7 @@ import { SohoWizardModule } from './wizard/soho-wizard.module';
     SohoRadarModule,
     SohoRadioButtonModule,
     SohoRatingModule,
+    SohoRenderLoopModule,
     SohoSearchFieldModule,
     SohoSliderModule,
     SohoSparklineModule,

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -14,11 +14,6 @@
 <div *ngIf="initialised" class="page-container no-scroll">
   <app-header-dynamic-demo></app-header-dynamic-demo>
   <div id="maincontent" class="page-container scrollable" role="main">
-      <div class="row render-row">
-        <p>Render loop count is: {{renderLoopCount}}</p>
-        <button class="btn" (click)="onStartRenderLoop()">Start RenderLoop</button>
-        <button class="btn" (click)="onStopRenderLoop()">Stop RenderLoop</button>
-      </div>
       <router-outlet></router-outlet>
   </div>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,16 +1,13 @@
 import {
-  AfterViewChecked,
   Component,
   HostBinding,
   ViewEncapsulation,
   ViewChild,
-  AfterViewInit,
-  OnInit
+  AfterViewInit
 } from '@angular/core';
 
 import { HeaderDynamicDemoRefService } from './header/header-dynamic-demo-ref.service';
 import { SohoPersonalizeDirective } from 'ids-enterprise-ng';
-import { SohoRenderLoopService } from '../../projects/ids-enterprise-ng/src/lib/renderLoop';
 
 @Component({
   selector: 'body', // tslint:disable-line
@@ -19,44 +16,28 @@ import { SohoRenderLoopService } from '../../projects/ids-enterprise-ng/src/lib/
   providers: [ HeaderDynamicDemoRefService ],
   encapsulation: ViewEncapsulation.None
 })
-export class AppComponent implements OnInit, AfterViewInit, AfterViewChecked {
+export class AppComponent implements AfterViewInit {
 
   @ViewChild(SohoPersonalizeDirective) personalize: SohoPersonalizeDirective;
 
   public initialised = false;
-  public renderLoopCount = 0;
 
   @HostBinding('class.no-scroll') get isNoScroll() { return true; }
 
   public personalizeOptions: SohoPersonalizeOptions = {};
 
-  constructor(private renderLoop: SohoRenderLoopService) {
+  constructor() {
     Soho.Locale.culturesPath = '/assets/ids-enterprise/js/cultures/';
     Soho.Locale.set('en-US').done(() => {
       console.log('Locale set');
       this.initialised = true;
     });
-
-    // this.setInitialPersonalization();
-  }
-
-  ngOnInit() {
-    // Init render loop manually for Angular applications
-    // Ensures requestAnimationFrame is running outside of Angular Zone
-    this.renderLoop.start();
   }
 
   ngAfterViewInit(): void {
     // Has to run after the view has been initialised otherwise
     // the personalise component is not ready.
     this.setInitialPersonalization();
-  }
-
-  ngAfterViewChecked() {
-    // Display the current render loop in real time
-    setTimeout(() => {
-      this.renderLoopCount = this.renderLoop.getCurrentCount();
-    });
   }
 
   setInitialPersonalization() {
@@ -69,23 +50,6 @@ export class AppComponent implements OnInit, AfterViewInit, AfterViewChecked {
       colors = JSON.parse(colors);
       this.personalize.colors = colors;
     }
-
-    // const theme = localStorage.getItem('soho_theme');
-    // const colors = localStorage.getItem('soho_color');
-    // if (theme) {
-    //   this.personalizeOptions = {
-    //     theme
-    //   };
-    // }
-    // if (colors) {
-    //   if (this.personalizeOptions) {
-    //     this.personalizeOptions.colors = colors;
-    //   } else {
-    //     this.personalizeOptions = {
-    //       colors
-    //     };
-    //   }
-    // }
   }
 
   onChangeTheme(ev: SohoChangeThemePersonalizeEvent) {
@@ -95,13 +59,5 @@ export class AppComponent implements OnInit, AfterViewInit, AfterViewChecked {
   onChangeColors(ev: SohoChangeColorsPersonalizeEvent) {
     console.log('Colors changed: ', ev);
     localStorage.setItem('soho_color', JSON.stringify(ev.colors));
-  }
-
-  onStartRenderLoop() {
-    this.renderLoop.start();
-  }
-
-  onStopRenderLoop() {
-    this.renderLoop.stop();
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,7 +7,10 @@ import {
 } from '@angular/core';
 
 import { HeaderDynamicDemoRefService } from './header/header-dynamic-demo-ref.service';
-import { SohoPersonalizeDirective } from 'ids-enterprise-ng';
+import {
+  SohoPersonalizeDirective,
+  SohoRenderLoopService
+} from 'ids-enterprise-ng';
 
 @Component({
   selector: 'body', // tslint:disable-line
@@ -26,12 +29,16 @@ export class AppComponent implements AfterViewInit {
 
   public personalizeOptions: SohoPersonalizeOptions = {};
 
-  constructor() {
+  constructor(private readonly renderLoop: SohoRenderLoopService) {
     Soho.Locale.culturesPath = '/assets/ids-enterprise/js/cultures/';
     Soho.Locale.set('en-US').done(() => {
       console.log('Locale set');
       this.initialised = true;
     });
+
+    // Init render loop manually for Angular applications
+    // Ensures requestAnimationFrame is running outside of Angular Zone
+    this.renderLoop.start();
   }
 
   ngAfterViewInit(): void {

--- a/src/app/button/button.demo.html
+++ b/src/app/button/button.demo.html
@@ -106,16 +106,16 @@
       <br>
       <br>
       <br>
-      <button soho-button="tertiary" isToggle="true" toggleOnIcon="heart-filled" toggleOffIcon="heart-outlined" title="Love It">Love It</button>
+      <button soho-button="tertiary" [isTogglePressed]="true" isToggle="true" toggleOnIcon="heart-filled" toggleOffIcon="heart-outlined" title="Love It">Love It</button>
     </div>
 
     <div class="three columns">
       <span class="label">Icon</span>
-      <button soho-button="icon" isToggle="true" icon="heart-filled">Action</button>
+      <button soho-button="icon" isToggle="true" icon="heart-filled">Love It</button>
       <br>
       <br>
       <br>
-      <button soho-button="icon" isToggle="true" toggleOnIcon="heart-filled" toggleOffIcon="heart-outlined" title="Love It">Love It</button>
+      <button soho-button="icon" [isTogglePressed]="false" isToggle="true" toggleOnIcon="heart-filled" toggleOffIcon="heart-outlined" title="Love It">Love It</button>
     </div>
 
   </div>

--- a/src/app/header/header-dynamic.demo.html
+++ b/src/app/header/header-dynamic.demo.html
@@ -47,6 +47,8 @@
         </ng-template>
       </ng-template>
 
+
+
     </soho-toolbar-button-set>
 
     <!-- If the currentToolbarOptions are null/undefined then display the "default" toolbar buttons

--- a/src/app/masthead/masthead.demo.html
+++ b/src/app/masthead/masthead.demo.html
@@ -9,6 +9,9 @@
 
   <soho-toolbar-button-set>
 
+    <button soho-button [isToggle]="true" toggleOnIcon="heart-filled" toggleOffIcon="heart-outlined"
+      [isTogglePressed]="running" (click)="toggleRenderLoop()">{{renderLoopCount}}</button>
+
     <button soho-button="icon" icon="user">
       <span class="audible">User</span>
     </button>

--- a/src/app/masthead/masthead.demo.ts
+++ b/src/app/masthead/masthead.demo.ts
@@ -1,10 +1,45 @@
-import { Component, HostBinding } from '@angular/core';
+import { Component, HostBinding, OnInit, AfterViewChecked } from '@angular/core';
+
+import { SohoRenderLoopService } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'app-masthead-demo',
   templateUrl: './masthead.demo.html',
 })
-export class SohoMastheadDemoComponent {
+export class SohoMastheadDemoComponent implements OnInit, AfterViewChecked {
+
+  public renderLoopCount = 0;
+
+  public running = true;
+
   @HostBinding('class.masthead') get isMasthead() { return true; }
   @HostBinding('style.display') get isDisplayBlock() { return 'block'; }
+
+  constructor(
+    private readonly renderLoop: SohoRenderLoopService) { }
+
+  ngOnInit() {
+    // Init render loop manually for Angular applications
+    // Ensures requestAnimationFrame is running outside of Angular Zone
+    this.renderLoop.start();
+  }
+
+  ngAfterViewChecked() {
+    // Display the current render loop in real time
+    setTimeout(() => {
+      // This forces a view refresh.
+      this.renderLoopCount = this.renderLoop.getCurrentCount();
+    });
+  }
+
+  toggleRenderLoop() {
+    if (this.running) {
+      this.renderLoop.stop();
+    } else {
+      this.renderLoop.start();
+    }
+    this.running = !this.running;
+
+    console.log(`${this.running}`);
+  }
 }

--- a/src/app/masthead/masthead.demo.ts
+++ b/src/app/masthead/masthead.demo.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, OnInit, AfterViewChecked } from '@angular/core';
+import { Component, HostBinding, OnInit, AfterViewChecked, AfterViewInit } from '@angular/core';
 
 import { SohoRenderLoopService } from 'ids-enterprise-ng';
 
@@ -15,13 +15,9 @@ export class SohoMastheadDemoComponent implements OnInit, AfterViewChecked {
   @HostBinding('class.masthead') get isMasthead() { return true; }
   @HostBinding('style.display') get isDisplayBlock() { return 'block'; }
 
-  constructor(
-    private readonly renderLoop: SohoRenderLoopService) { }
+  constructor(private readonly renderLoop: SohoRenderLoopService) { }
 
   ngOnInit() {
-    // Init render loop manually for Angular applications
-    // Ensures requestAnimationFrame is running outside of Angular Zone
-    this.renderLoop.start();
   }
 
   ngAfterViewChecked() {
@@ -39,7 +35,5 @@ export class SohoMastheadDemoComponent implements OnInit, AfterViewChecked {
       this.renderLoop.start();
     }
     this.running = !this.running;
-
-    console.log(`${this.running}`);
   }
 }

--- a/src/app/menu-button/menu-button.demo.html
+++ b/src/app/menu-button/menu-button.demo.html
@@ -1,7 +1,9 @@
 <div class="row top-padding">
   <div class="twelve columns">
 
-    <button soho-menu-button menu="action-popupmenu"
+    <button soho-button (click)="toggleBtn()">Toggle</button>
+
+    <button soho-menu-button *ngIf="toggle" menu="action-popupmenu"
             (selected)="onSelected($event)"
             (beforeopen)="onBeforeOpen($event)"
             (close)="onClose($event)"

--- a/src/app/menu-button/menu-button.demo.ts
+++ b/src/app/menu-button/menu-button.demo.ts
@@ -9,11 +9,17 @@ export class MenuButtonDemoComponent implements OnInit, AfterViewInit {
   @ViewChild('ajax')ajaxMenuButton: SohoMenuButtonComponent;
   public menuButtons: Array<any>;
 
+  public toggle: boolean;
+
   private SUBMENU_RESPONSE_HTML = `
     <li><a href="#" id="SubOptionOne" data-action="AJAX sub-option 1">AJAX sub-option 1</a></li>
     <li><a href="#" id="SubOptionTwo" data-action="AJAX sub-option 2">AJAX sub-option 2</a></li>
     <li><a href="#" id="SubOptionThree" data-action="AJAX sub-option 3">AJAX sub-option 3</a></li>
   `;
+
+  toggleBtn() {
+    this.toggle = !this.toggle;
+  }
 
   disabledEntryClicked() {
     alert('Should not be Allowed');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added the `SohoRenderLoopService` into the `SohoComponentModule` (and hence library) so it could be included from the APF rather than directly from `node_modules`.

Also tidied the render loop count, by moving the counter to the masthead, as it was impacting the display of the other components.

**Related github/jira issue (required)**:

Closes #269.

**Steps necessary to review your pull request (required)**:

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
