### PR TITLE
293 - Added support for clear dirty cells with datagrid

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1285,6 +1285,47 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   /**
+   * Returns an array of the dirty cells in the grid.
+   *
+   * @return an array of the dirty cells in the grid.
+   */
+  dirtyCells(): Array<any> {
+    return this.ngZone.runOutsideAngular(() => {
+      return this.datagrid.dirtyCells();
+    });
+  }
+
+  /**
+   * Clear all dirty cells.
+   */
+  clearDirty(): void {
+    return this.ngZone.runOutsideAngular(() => {
+      this.datagrid.clearDirty();
+    });
+  }
+
+  /**
+   * Clear all dirty cells in given row.
+   * @param row - the row number (idx) of the row.
+   */
+  clearDirtyRow(row: number): void {
+    return this.ngZone.runOutsideAngular(() => {
+      this.datagrid.clearDirtyRow(row);
+    });
+  }
+
+  /**
+   * Clear dirty on given cell.
+   * @param row - the row number (idx) of the row
+   * @param cell - the cell number (idx) of the cell
+   */
+  clearDirtyCell(row: number, cell: number): void {
+    return this.ngZone.runOutsideAngular(() => {
+      this.datagrid.clearDirtyCell(row, cell);
+    });
+  }
+
+  /**
    * Sets the status of a given row in the grid.
    *
    * @param idx - the row number (idx) of the row

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -864,7 +864,7 @@ interface SohoDataGridStatic {
 
   /**
   * Toggle the current selection state from on to off.
-  * @param {number} idx The row to select/unselect
+  * @param number idx The row to select/unselect
   */
   toggleRowSelection(idx: number): void;
 
@@ -889,6 +889,31 @@ interface SohoDataGridStatic {
    * @return an array of all the rows in the grid marked as dirty.
    */
   dirtyRows(): Array<any>;
+
+  /**
+   * Returns an array of all the cells in the grid marked as dirty.
+   *
+   * @return an array of all the cells in the grid marked as dirty.
+   */
+  dirtyCells(): Array<any>;
+
+  /**
+   * Clear all dirty cells.
+   */
+  clearDirty(): void;
+
+  /**
+   * Clear all dirty cells in given row.
+   * @param row - the row number (idx) of the row.
+   */
+  clearDirtyRow(row: number): void;
+
+  /**
+   * Clear dirty on given cell.
+   * @param row - the row number (idx) of the row
+   * @param cell - the cell number (idx) of the cell
+   */
+  clearDirtyCell(row: number, cell: number): void;
 
   /**
    * Sets the status of a given row in the grid.
@@ -1071,7 +1096,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
   on(events: 'sorted', handler: JQuery.EventHandlerBase<any, SohoDataGridSortedEvent>): this;
   on(events: 'expandrow', handler: JQuery.EventHandlerBase<any, SohoDataGridRowExpandEvent>): this;
   on(events: 'rowactivated', handler: JQuery.EventHandlerBase<any, SohoDataGridRowActivatedEvent>): this;
-  on(events: 'rowdeactivated', handler: JQuery.EventHandlerBase<any, SohoDataGridRowDeactivatedEvent>):this;
+  on(events: 'rowdeactivated', handler: JQuery.EventHandlerBase<any, SohoDataGridRowDeactivatedEvent>): this;
   on(events: 'selected', handler: JQuery.EventHandlerBase<any, SohoDataGridSelectedRow[]>): this;
 }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -79,6 +79,7 @@ import {
 import { DataGridLookupClickDemoComponent } from './datagrid/datagrid-lookup-click-function.demo';
 import { DataGridLookupDialogDemoComponent } from './datagrid/datagrid-lookup-dialog.demo';
 import { DataGridCustomFormatterServiceDemoComponent } from './datagrid/datagrid-custom-formatter-service.demo';
+import { DataGridDirtyIndicationDemoComponent } from './datagrid/datagrid-dirty-indication.demo';
 import { DataGridDynamicDemoComponent } from './datagrid/datagrid-dynamic.demo';
 import { DataGridEditorsDemoComponent } from './datagrid/datagrid-editors.demo';
 import { DataGridEmptyMessageDemoComponent } from './datagrid/datagrid-empty-message.demo';
@@ -252,6 +253,7 @@ import { WizardDemoValidationRulesPageComponent } from './wizard/wizard-validati
     DataGridCustomFormatterDemoComponent,
     DataGridCustomFormatterServiceDemoComponent,
     DemoCellDatePickerEditorComponent,
+    DataGridDirtyIndicationDemoComponent,
     DataGridDynamicDemoComponent,
     DataGridEditorsDemoComponent,
     DataGridEmptyMessageDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -47,6 +47,7 @@ import { DataGridLookupClickDemoComponent } from './datagrid/datagrid-lookup-cli
 import { DataGridLookupDialogDemoComponent } from './datagrid/datagrid-lookup-dialog.demo';
 
 import { DataGridRowReorderDemoComponent } from './datagrid/datagrid-rowreorder.demo';
+import { DataGridDirtyIndicationDemoComponent } from './datagrid/datagrid-dirty-indication.demo';
 import { DataGridDynamicDemoComponent } from './datagrid/datagrid-dynamic.demo';
 import { DataGridEditorsDemoComponent } from './datagrid/datagrid-editors.demo';
 import { DataGridExportWithoutDataGridDemoComponent } from './datagrid/datagrid-export-without-datagrid.demo';
@@ -195,6 +196,7 @@ export const routes: Routes = [
   { path: 'contextual-action-panel',                component: ContextualActionPanelDemoComponent },
   { path: 'datagrid-breadcrumb',                    component: DataGridBreadcrumbDemoComponent },
   { path: 'datagrid-content',                       component: DataGridContentDemoComponent },
+  { path: 'datagrid-dirty-indication',              component: DataGridDirtyIndicationDemoComponent },
   { path: 'datagrid-dynamic',                       component: DataGridDynamicDemoComponent },
   { path: 'datagrid-empty-message',                 component: DataGridEmptyMessageDemoComponent },
   { path: 'datagrid-editors',                       component: DataGridEditorsDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -57,6 +57,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-code-block-editor']"><span>DataGrid - Code Block Editor</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-custom-formatter']"><span>DataGrid - Custom Formatter</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-custom-formatter-service']"><span>DataGrid - Custom Formatter Service</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['datagrid-dirty-indication']"><span>DataGrid - Dirty Indication</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-dynamic']"><span>DataGrid - Dynamic</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-editors']"><span>DataGrid - Editors</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-empty-message']"><span>DataGrid - Empty Message</span></a></div>

--- a/src/app/datagrid/datagrid-dirty-indication-data.ts
+++ b/src/app/datagrid/datagrid-dirty-indication-data.ts
@@ -1,0 +1,168 @@
+export const DIRTY_INDICATION_COLUMNS: any[] = [
+  {
+    id: 'selectionCheckbox',
+    sortable: false,
+    resizable: false,
+    formatter: Soho.Formatters.SelectionCheckbox,
+    align: 'center'
+  },
+  {
+    id: 'id',
+    name: 'Row Id',
+    field: 'id',
+    formatter: Soho.Formatters.Readonly
+  },
+  {
+    id: 'productName',
+    hidden: true,
+    name: 'Product Name',
+    sortable: false,
+    field: 'productName',
+    formatter: Soho.Formatters.Hyperlink,
+    editor: Soho.Editors.Input
+  },
+  {
+    id: 'activity',
+    name: 'Activity',
+    field: 'activity',
+    required: true,
+    editor: Soho.Editors.Input,
+    validate: 'required'
+  },
+  {
+    id: 'portable',
+    name: 'Portable',
+    field: 'portable',
+    align: 'center',
+    formatter: Soho.Formatters.Checkbox,
+    editor: Soho.Editors.Checkbox
+  },
+  {
+    id: 'price',
+    name: 'Price',
+    field: 'price',
+    align: 'right',
+    formatter: Soho.Formatters.Decimal,
+    validate: 'required',
+    numberFormat: {
+      minimumFractionDigits: 3,
+      maximumFractionDigits: 3
+    },
+    editor: Soho.Editors.Input,
+    mask: '####.00',
+    maskMode: 'number'
+  },
+  {
+    id: 'orderDate',
+    name: 'Order Date',
+    field: 'orderDate',
+    formatter: Soho.Formatters.Date,
+    editor: Soho.Editors.Date,
+    validate: 'required date'
+  },
+  {
+    id: 'action',
+    name: 'Action',
+    field: 'action',
+    align: 'center',
+    formatter: Soho.Formatters.Dropdown,
+    editor: Soho.Editors.Dropdown,
+    validate: 'required',
+    options: [
+      { id: '', label: '', value: '' },
+      { id: 'oh1', label: 'On Hold', value: 'oh' },
+      { id: 'sh1', label: 'Shipped', value: 'sh' },
+      { id: 'ac1', label: 'Action', value: 'ac' }
+    ]
+  }
+];
+
+export const DIRTY_INDICATION_DATA: any[] = [
+  {
+    id: 1,
+    productId: 2142201,
+    productName: 'Compressor',
+    activity: '<svg/onload=alert(1)>',
+    quantity: 1,
+    price: 210.99,
+    status: 'OK',
+    orderDate: '',
+    portable: false,
+    action: 'ac',
+    description: 'Compressor comes with various air compressor'
+  },
+  {
+    id: 2,
+    productId: 2241202,
+    productName: 'Different Compressor',
+    activity: 'Inspect and Repair',
+    quantity: 2,
+    price: 210.991,
+    status: '',
+    orderDate: new Date(2016, 2, 15, 0, 30, 36),
+    portable: false,
+    action: 'oh',
+    description: 'The kit has an air blow gun that can be used for cleaning'
+  },
+  {
+    id: 3,
+    productId: 2342203,
+    productName: 'Portable Compressor',
+    activity: '',
+    portable: true,
+    quantity: null,
+    price: 120.992,
+    status: null,
+    orderDate: new Date(2014, 6, 3),
+    action: 'ac'
+  },
+  {
+    id: 4,
+    productId: 2445204,
+    productName: 'Another Compressor',
+    activity: 'Assemble Paint',
+    portable: true,
+    quantity: 3,
+    price: null,
+    status: 'OK',
+    orderDate: new Date(2015, 3, 3),
+    action: 'ac',
+    description: 'Compressor comes with with air tool kit'
+  },
+  {
+    id: 5,
+    productId: 2542205,
+    productName: 'De Wallt Compressor',
+    activity: 'Inspect and Repair',
+    portable: false,
+    quantity: 4,
+    price: 210.99,
+    status: 'OK',
+    orderDate: new Date(2015, 5, 5),
+    action: 'oh'
+  },
+  {
+    id: 6,
+    productId: 2642205,
+    productName: 'Air Compressors',
+    activity:  'Inspect and Repair',
+    portable: false,
+    quantity: 41,
+    price: 120.99,
+    status: 'OK',
+    orderDate: new Date(2014, 6, 9),
+    action: 'oh'
+  },
+  {
+    id: 7,
+    productId: 2642206,
+    productName: 'Some Compressor',
+    activity: 'inspect and Repair',
+    portable: true,
+    quantity: 41,
+    price: 123.99,
+    status: 'OK',
+    orderDate: new Date(2014, 6, 9),
+    action: 'oh'
+  }
+];

--- a/src/app/datagrid/datagrid-dirty-indication.demo.html
+++ b/src/app/datagrid/datagrid-dirty-indication.demo.html
@@ -1,0 +1,52 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Soho Data Grid - Dirty Indication Demo</h2>
+    <p>Make changes to any cells it should add dirty indicator to the cell<p>
+    <p>
+      Dirty cells can be clear by clicking the button &quot;Clear Dirty&quot;<br>
+      &ndash; Specific Cell (row: {{row}}, cell: {{cell}})<br>
+      &ndash; All Cells in Row (row: {{row}})<br>
+      &ndash; All (all cells in grid)
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
+    <soho-toolbar>
+      <soho-toolbar-title>
+        <span soho-toolbar-section-title></span>
+      </soho-toolbar-title>
+      <soho-toolbar-button-set>
+        <button soho-menu-button menu="action-popupmenu"
+          (selected)="onClearDirtySelected($event)">Clear Dirty</button>
+          <ul soho-popupmenu id="action-popupmenu">
+            <li soho-popupmenu-item><a soho-popupmenu-label data-action="specific-cell">Specific Cell (row: {{row}}, cell: {{cell}})</a></li>
+            <li soho-popupmenu-item><a soho-popupmenu-label data-action="all-cells-in-row">All Cells in Row (row: {{row}})</a></li>
+            <li soho-popupmenu-item><a soho-popupmenu-label data-action="all">All</a></li>
+          </ul>
+      </soho-toolbar-button-set>
+    </soho-toolbar>
+
+    <soho-toolbar maxVisibleButtons="4" class="contextual-toolbar is-hidden">
+      <soho-toolbar-title>
+        <div soho-selection-count>0 Selected</div>
+      </soho-toolbar-title>
+      <soho-toolbar-button-set>
+        <button class="btn" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-link"></use>
+          </svg>
+          <span>Item 1</span>
+        </button>
+      </soho-toolbar-button-set>
+    </soho-toolbar>
+
+    <div soho-datagrid
+      *ngIf="gridOptions"
+      [gridOptions]="gridOptions"
+    ></div>
+
+  </div>
+</div>

--- a/src/app/datagrid/datagrid-dirty-indication.demo.ts
+++ b/src/app/datagrid/datagrid-dirty-indication.demo.ts
@@ -1,0 +1,58 @@
+import {
+  Component,
+  ViewChild,
+  OnInit
+} from '@angular/core';
+
+import {
+  SohoDataGridComponent,
+} from 'ids-enterprise-ng';
+
+import {
+  DIRTY_INDICATION_COLUMNS,
+  DIRTY_INDICATION_DATA
+} from './datagrid-dirty-indication-data';
+
+const ROW = 2;
+const CELL = 5;
+
+@Component({
+  selector: 'app-datagrid-dirty-indication-demo',
+  templateUrl: './datagrid-dirty-indication.demo.html',
+})
+export class DataGridDirtyIndicationDemoComponent implements OnInit {
+  @ViewChild(SohoDataGridComponent) sohoDataGridComponent: SohoDataGridComponent;
+
+  public gridOptions = undefined;
+  public row = ROW;
+  public cell = CELL;
+
+  ngOnInit(): void {
+    this.gridOptions = {
+      columns: DIRTY_INDICATION_COLUMNS,
+      dataset: DIRTY_INDICATION_DATA,
+      editable: true,
+      clickToSelect: false,
+      selectable: 'multiple',
+      paging: true,
+      pagesize: 5,
+      showDirty: true,
+      pagesizes: [5, 10, 25, 50]
+    };
+  }
+
+  onClearDirtySelected(event: SohoContextMenuEvent) {
+    const action = event.args.attr('data-action');
+    const gridApi = this.sohoDataGridComponent;
+
+    if (action === 'specific-cell') {
+      gridApi.clearDirtyCell(ROW, CELL);
+    }
+    if (action === 'all-cells-in-row') {
+      gridApi.clearDirtyRow(ROW);
+    }
+    if (action === 'all') {
+      gridApi.clearDirty();
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support for clear dirty cells for specific cell, all cells in given row, or specific cell.

**Related github/jira issue (required)**:
Closes #293

**Steps necessary to review your pull request (required)**:
Make sure PR(1409) has been merged in EP
https://github.com/infor-design/enterprise/pull/1409

http://localhost:4200/datagrid-dirty-indication
- Open above link
- Make changes to any cells it should add dirty indicator to the cell
- Dirty cells can be clear by clicking the button "Clear Dirty"
– Clear Dirty > Specific Cell (row: 2, cell: 5)
– Clear Dirty > All Cells in Row (row: 2)
– Clear Dirty > All (all cells in grid)