### PR TITLE
was unable to clear the empty message for a datagrid.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 5.1.0 Fixes
 
+- `[DataGrid]` - changed emptyMessage setter so it will remove any empty message if passed a null or undefined. `PWP`
 - `[Accordion]` - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request 290]
 
 ### 5.1.0 Chore & Maintenance

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 5.1.0 Fixes
 
-- `[DataGrid]` - changed emptyMessage setter so it will remove any empty message if passed a null or undefined. `PWP`
-- `[Accordion]` - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request 290]
+- `[DataGrid]` - changed emptyMessage setter so it will remove any empty message if passed a null or undefined. `PWP` ([Pull Request 305])
+- `[Accordion]` - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request 290])
 
 ### 5.1.0 Chore & Maintenance
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -973,11 +973,14 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
 
   /**
    * The `emptyMessage` data grid option.
+   * Use null or undefined to remove any empty message.
    */
-  @Input() set emptyMessage(emptyMessage: SohoEmptyMessageOptions) {
-    /** Check for undefined/null and reset to the default message */
-    emptyMessage = emptyMessage ||
-      {title: (Soho.Locale ? Soho.Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data'};
+  @Input() set emptyMessage(emptyMessage: SohoEmptyMessageOptions | null | undefined) {
+    // Check for undefined/null and reset to the default message
+    if (!emptyMessage) {
+      // soho only takes a null here so making it so any !emptyMessage gets set to null
+      emptyMessage = null;
+    }
 
     this._gridOptions.emptyMessage = emptyMessage;
     if (this.jQueryElement) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Was unable to unset the empty message for a datagrid. I fixed it so that null and undefined would unset it.

**Steps necessary to review your pull request (required)**:
- Set datagrid @Input emptyMessage to null
- example will show a default empty message while the data is loading.