### PR TITLE
318 - Fix having to hit enter twice to filter in datagrid

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -297,12 +297,6 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
       const pagerInfo: SohoPagerPagingInfo = {};
       this.datagrid.settings.dataset = dataset;
 
-      // TreeGrid does not have paging
-      // set as active page so datagrid headers aren't rebuilt
-      if (this.treeGrid) {
-        pagerInfo.activePage = -1;
-      }
-
       this.ngZone.runOutsideAngular(() => {
         // @todo do we need hints as this may be bundled up with other changes.
         this.datagrid.updateDataset(dataset, pagerInfo);

--- a/src/app/datagrid/datagrid-treegrid-dynamicfiltering.demo.html
+++ b/src/app/datagrid/datagrid-treegrid-dynamicfiltering.demo.html
@@ -12,11 +12,13 @@
   <div class="row top-padding">
     <div class="twelve columns demo" role="main">
       <section class="scrollable contained-scrolling-right-bottom" style="height: 100%">
-        <div soho-busyindicator soho-datagrid
-             selectable="single"
+        <div soho-busyindicator soho-datagrid selectable="single"
+
+             *ngIf="gridOptions"
              [treeGrid]="true"
-             [columns]="columns"
+             [gridOptions]="gridOptions"
              [dataset]="data"
+
              (filtered)="onFiltered($event)">
         </div>
       </section>

--- a/src/app/datagrid/datagrid-treegrid-service.demo.ts
+++ b/src/app/datagrid/datagrid-treegrid-service.demo.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@angular/core';
+import {Observable} from 'rxjs';
+import {HttpClient} from '@angular/common/http';
 
 @Injectable()
 export class DatagridTreegridServiceDemo {
@@ -6,7 +8,7 @@ export class DatagridTreegridServiceDemo {
   private _columns: SohoDataGridColumn[];
   private _data: Object[];
 
-  constructor() {}
+  constructor(private http: HttpClient) {}
 
   public getColumns(): SohoDataGridColumn[] {
     if (!this._columns) {
@@ -83,5 +85,9 @@ export class DatagridTreegridServiceDemo {
       {id: 16, alpha: 'N'},
       {id: 17, alpha: 'O'}
     ]
+  }
+
+  public getInitialFilterDemoData(): Observable<any> {
+    return this.http.get('./app/demodata/tree-filtering.demo.json');
   }
 }

--- a/src/app/demodata/tree-filtering.demo.json
+++ b/src/app/demodata/tree-filtering.demo.json
@@ -1,0 +1,25 @@
+[
+  {"id": 1, "alpha": "A"},
+  {"id": 2, "alpha": "B"},
+  {
+    "id": 3, 
+    "alpha": "C", 
+    "depth": 1, 
+    "children": [
+      {"id": 4, "alpha": "C1", "depth": 2},
+      {"id": 5, "alpha": "C2", "depth": 2}
+    ]
+  },
+  {"id": 6, "alpha": "D"},
+  {"id": 7, "alpha": "E"},
+  {"id": 8, "alpha": "F"},
+  {"id": 9, "alpha": "G"},
+  {"id": 10, "alpha": "H"},
+  {"id": 11, "alpha": "I"},
+  {"id": 12, "alpha": "J"},
+  {"id": 13, "alpha": "K"},
+  {"id": 14, "alpha": "L"},
+  {"id": 15, "alpha": "M"},
+  {"id": 16, "alpha": "N"},
+  {"id": 17, "alpha": "O"}
+]


### PR DESCRIPTION
- Updated example to illustrate the issue. Used HTTP service to illustrate how datagrid tree is used in a real world scenario.

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Have to hit enter twice to filter using server side filtering. This is caused by setting activePage to -1 in the angular component wrapper. _soho-datagrid.component.ts_ I believe this was a workaround for a past issue. It doesn't appear to be needed anymore.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise-ng/issues/318

**Steps necessary to review your pull request (required)**:
**To Reproduce**
Steps to reproduce the behavior:
1. Get code from PR
2. Navigate to http://localhost:4200/ids-enterprise-ng-demo/datagrid-treegrid-dynamicfilter
3. Toggle filter row
4. Apply this code back to soho-datagrid.component.ts
```
if (this.treeGrid) {
    pagerInfo.activePage = -1;
}
```
5. Filter the list. Notice enter needs to be hit twice. Remove above code and it should filter as expected.