### PR TITLE
StepProcess in 'linearProgression' mode not working as expected in a …

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.html
+++ b/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.html
@@ -7,6 +7,10 @@
     </soho-toolbar-title>
   </div>
   <ng-content select='ul[soho-step-list]'></ng-content>
+  <div class="phone-action-bar phone-visible">
+    <button soho-button="secondary" class="btn btn-secondary js-btn-save-changes">Save &amp; Close</button>
+    <button soho-button="primary" class="btn btn-primary js-toggle-sidebar">Continue</button>
+  </div>
 </div>
 
 <!-- STEP CONTROL CONTENT -->


### PR DESCRIPTION
…Responsive mode (Mobile) #215


StepProcess in 'linearProgression' mode not working as expected in a Responsive mode (Mobile).
'Save and Close' and 'Next' only available when viewing the step content. If you view the step list, there is no way to view the next step or to save and close the step control.

https://github.com/infor-design/enterprise-ng/issues/215

1. Create a Step Control where linearProgression is true
2. View the control on a phone
3. Show the steps
Should see a 'save and close' and 'continue' button
Test that the continue button show the current step panel

