### PR TITLE
added selectBlocks and activateBlock apis to blockgrid component

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 5.1.0 Features
 
+- `[Blockgrid]` Added activateBlock and selectBlocks apis to blockgrid component `PWP` ([362](https://github.com/infor-design/enterprise-ng/issues/362)'
 - `[Datagrid]` 4.0 Datagrid expose error row clear functions `PWP` ([#314](https://github.com/infor-design/enterprise-ng/issues/314))
 
 ### 5.1.0 Fixes

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -100,7 +100,7 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
         return; // safety check
       }
 
-      this.blockgrid.selectBlock($(blockChildren[idx]),false);
+      this.blockgrid.selectBlock($(blockChildren[idx]), false);
     });
   }
 
@@ -115,12 +115,15 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   private onSelected(args: any[]) {
     this.ngZone.run(() => this.selected.emit(args));
   }
+
   private onDeselected(args: any[]) {
     this.ngZone.run(() => this.deselected.emit(args));
   }
+
   private onActivated(args: any[]) {
     this.ngZone.run(() => this.activated.emit(args));
   }
+
   private onDeactivated(args: any[]) {
     this.ngZone.run(() => this.deactivated.emit(args));
   }

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -7,7 +7,8 @@ import {
   ElementRef,
   EventEmitter,
   HostBinding,
-  Input, NgZone,
+  Input,
+  NgZone,
   OnDestroy,
   Output,
 } from '@angular/core';
@@ -17,17 +18,15 @@ import {
   template: '<ng-content></ng-content>',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-
 export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
-  /** Options. */
-  private options: SohoBlockGridOptions = {};
 
   @HostBinding('class.blockgrid') get isBlockGrid() {
     return true;
   }
 
   /** Defines the data to use, must be specified for this component. */
-  @Input() set dataset(dataset: Array<any>) {
+  @Input()
+  public set dataset(dataset: Array<any>) {
     this.options.dataset = dataset;
 
     if (this.blockgrid) {
@@ -35,14 +34,27 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
       this.updated(this.blockgrid.settings);
     }
   }
+  public get dataset(): Array<any> {
+    if (!this.blockgrid) {
+      return this.options.dataset;
+    }
+    return this.blockgrid.settings.dataset;
+  }
 
   /** Defines the selection type. */
-  @Input() set selectable(selectable: any) {
+  @Input()
+  public set selectable(selectable: SohoBlockGridSelectable) {
     this.options.selectable = selectable;
     if (this.blockgrid) {
       this.blockgrid.settings.selectable = selectable;
       this.updated(this.blockgrid.settings);
     }
+  }
+  public get selectable(): SohoBlockGridSelectable {
+    if (!this.blockgrid) {
+      return this.options.selectable;
+    }
+    return this.blockgrid.settings.selectable;
   }
 
   /* Events*/
@@ -51,6 +63,8 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   @Output() activated: EventEmitter<Object[]> = new EventEmitter<Object[]>();
   @Output() deactivated: EventEmitter<Object[]> = new EventEmitter<Object[]>();
 
+  /** Options. */
+  private options: SohoBlockGridOptions = {};
   private jQueryElement: JQuery;
   private blockgrid: SohoBlockGrid;
 

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -4,12 +4,14 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  ContentChildren,
   ElementRef,
   EventEmitter,
   HostBinding,
   Input, NgZone,
   OnDestroy,
   Output,
+  QueryList,
 } from '@angular/core';
 
 @Component({
@@ -25,6 +27,8 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   @HostBinding('class.blockgrid') get isBlockGrid() {
     return true;
   }
+
+  @ContentChildren('.block') blockChildren: QueryList<ElementRef>;
 
   /** Defines the data to use, must be specified for this component. */
   @Input() set dataset(dataset: Array<any>) {
@@ -91,6 +95,25 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   public updated(settings: any): SohoBlockGridComponent {
     this.ngZone.runOutsideAngular(() => this.blockgrid.updated(settings));
     return this;
+  }
+
+  public activateBlock(idx: number): void {
+    this.ngZone.runOutsideAngular(() => {
+      const blockChildren: NodeList = this.element.nativeElement.querySelectorAll('.block');
+      if (!blockChildren || idx < -1 || idx >= blockChildren.length) {
+        return; // safety check
+      }
+
+      this.blockgrid.selectBlock($(blockChildren[idx]),false);
+    });
+  }
+
+  public selectBlocks(idx: number[]) {
+    this.ngZone.runOutsideAngular(() => {
+      const blockChildren: NodeList = this.element.nativeElement.querySelectorAll('.block');
+      const blockChildrenArray = Array.from(blockChildren).filter((blockChild, index) => idx.includes(index));
+      this.blockgrid.selectBlock($(blockChildrenArray), true);
+    });
   }
 
   private onSelected(args: any[]) {

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -4,14 +4,12 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  ContentChildren,
   ElementRef,
   EventEmitter,
   HostBinding,
   Input, NgZone,
   OnDestroy,
   Output,
-  QueryList,
 } from '@angular/core';
 
 @Component({
@@ -27,8 +25,6 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   @HostBinding('class.blockgrid') get isBlockGrid() {
     return true;
   }
-
-  @ContentChildren('.block') blockChildren: QueryList<ElementRef>;
 
   /** Defines the data to use, must be specified for this component. */
   @Input() set dataset(dataset: Array<any>) {

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -110,7 +110,7 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   public activateBlock(idx: number): void {
     this.ngZone.runOutsideAngular(() => {
       const blockChildren: NodeList = this.element.nativeElement.querySelectorAll('.block');
-      if (!blockChildren || idx < -1 || idx >= blockChildren.length) {
+      if (!blockChildren || idx <= -1 || idx >= blockChildren.length) {
         return; // safety check
       }
 

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
@@ -4,7 +4,6 @@
  * This file contains the Typescript mappings for the public
  * interface of the Soho jQuery BlockGrid control.
  */
-// @ts-ignore
 type SohoBlockGridSelectable = boolean | 'single' | 'multiple' | 'mixed';
 
 /**

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
@@ -4,6 +4,7 @@
  * This file contains the Typescript mappings for the public
  * interface of the Soho jQuery BlockGrid control.
  */
+// @ts-ignore
 type SohoBlockGridSelectable = boolean | 'single' | 'multiple' | 'mixed';
 
 /**
@@ -15,7 +16,7 @@ interface SohoBlockGridOptions {
 
   /** Selection Mode Property */
   selectable?: SohoBlockGridSelectable;
- }
+}
 
 /**
  * BlockGrid Api.
@@ -24,7 +25,7 @@ interface SohoBlockGrid {
   settings: SohoBlockGridOptions;
 
   /** Select a block */
-  selectBlock(activeBlock: any[], isCheckbox: boolean): void;
+  selectBlock(activeBlock: JQuery<Node | Node[]>, isCheckbox: boolean): void;
 
   /** Updates the blockgrid with any new settings. */
   updated(settings?: SohoBlockGridOptions): void;

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
@@ -16,7 +16,7 @@ const blockGridTestData = [
   { img: 'https://randomuser.me/api/portraits/med/women/12.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, Architect' }
 ];
 
-fdescribe('Soho blockgrid Unit Tests', () => {
+describe('Soho blockgrid Unit Tests', () => {
   let comp:     SohoBlockGridComponent;
   let fixture:  ComponentFixture<SohoBlockGridComponent>;
   let de:       DebugElement;
@@ -121,7 +121,7 @@ class SohoBlockGridTestComponent {
   public data = blockGridTestData;
   @ViewChild(SohoBlockGridComponent) blockgrid: SohoBlockGridComponent;
 }
-fdescribe('Soho blockgrid Render', () => {
+describe('Soho blockgrid Render', () => {
   let blockgrid:  SohoBlockGridComponent;
   let component: SohoBlockGridTestComponent;
   let fixture:   ComponentFixture<SohoBlockGridTestComponent>;

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
@@ -2,17 +2,32 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { Component, DebugElement, ViewChild } from '@angular/core';
+import { Component, DebugElement, EventEmitter, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { SohoBlockGridModule } from './soho-blockgrid.module';
 import { SohoBlockGridComponent } from './soho-blockgrid.component';
 
-describe('Soho blockgrid Unit Tests', () => {
+const blockGridTestData = [
+  { img: 'https://randomuser.me/api/portraits/med/women/8.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, Developer' },
+  { img: 'https://randomuser.me/api/portraits/med/women/9.jpg', maintxt: 'Jane Taylor', subtxt: 'Infor, Developer' },
+  { img: 'https://randomuser.me/api/portraits/med/women/10.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, SVP' },
+  { img: 'https://randomuser.me/api/portraits/med/women/11.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, Developer' },
+  { img: 'https://randomuser.me/api/portraits/med/women/12.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, Architect' }
+];
+
+fdescribe('Soho blockgrid Unit Tests', () => {
   let comp:     SohoBlockGridComponent;
   let fixture:  ComponentFixture<SohoBlockGridComponent>;
   let de:       DebugElement;
   let el:       HTMLElement;
+
+  // todo ppatton, theo, this is also in soho-standalone-pager.componet.spec.ts - maybe consider test helper class
+  const testFireEvent = (eventEmitter: EventEmitter<any>, functionName: string, eventName: string) => {
+    const eventEmitterSpy = spyOn<any>(eventEmitter, functionName);
+    (comp as any).jQueryElement.trigger(eventName);
+    expect(eventEmitterSpy).toHaveBeenCalledTimes(1);
+  };
 
   beforeEach( () => {
     TestBed.configureTestingModule({
@@ -26,27 +41,87 @@ describe('Soho blockgrid Unit Tests', () => {
     el = de.nativeElement;
   });
 
-  it('Check Content', () => {
-    expect(el.nodeName).toEqual('DIV');
+  it('Check Inputs', () => {
+    const emptyData: any[] = [];
+    let selectable: SohoBlockGridSelectable = 'single';
+
+    // check that block grid options buffer variable is working.
+    comp.dataset = emptyData;
+    comp.selectable = selectable;
+    expect(comp.dataset).toEqual(emptyData);
+    expect(comp.selectable).toEqual(selectable);
+
+    // detect changes to cause the blockgrid component to be built.
+    fixture.detectChanges();
+    expect((comp as any).blockgrid).not.toBeUndefined();
+
+    // Now that the blockgrid has been built:
+    // 1. check to make sure inputs data makes it into the blockgrid.settings object.
+    // 2. verify each input call results in a call to the SohoBlockGridComponent.updated()
+    // 3. verify each input call also results in a call to blockgrid.updated()
+
+    // callthrough blockgrid updated function gets called
+    const updatedSpy = spyOn(comp, 'updated').and.callThrough();
+    const blockgridUpdatedSpy = spyOn<any>((comp as any).blockgrid, 'updated');
+
+    selectable = 'mixed';
+    comp.dataset = blockGridTestData;
+    comp.selectable = selectable;
+
+    expect(comp.dataset).toEqual(blockGridTestData);
+    expect(comp.selectable).toEqual(selectable);
+
+    expect(updatedSpy).toHaveBeenCalledTimes(2);
+    expect(blockgridUpdatedSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('Check Outputs', () => {
+    const selectable: SohoBlockGridSelectable = 'mixed';
+    comp.dataset = blockGridTestData;
+    comp.selectable = selectable;
+
+    // detect changes to cause the blockgrid component to be built.
+    fixture.detectChanges();
+    expect((comp as any).blockgrid).not.toBeUndefined();
+
+    testFireEvent((comp as any).selected, 'emit', 'selected');
+    testFireEvent((comp as any).deselected, 'emit', 'deselected');
+    testFireEvent((comp as any).activated, 'emit', 'activated');
+    testFireEvent((comp as any).deactivated, 'emit', 'deactivated');
+  });
+
+  it('Check public functions', () => {
+    const selectable: SohoBlockGridSelectable = 'mixed';
+    comp.dataset = blockGridTestData;
+    comp.selectable = selectable;
+
+    fixture.detectChanges(); // detect changes to cause the blockgrid component to be built.
+    expect((comp as any).blockgrid).not.toBeUndefined();
+
+    const selectBlockSpy = spyOn((comp as any).blockgrid, 'selectBlock');
+    comp.activateBlock(1);
+    expect(selectBlockSpy).toHaveBeenCalledTimes(1);
+    expect(selectBlockSpy.calls.mostRecent().args.length).toEqual(2);
+    expect(selectBlockSpy.calls.mostRecent().args[1]).toEqual(false);
+
+    selectBlockSpy.calls.reset();
+
+    comp.selectBlocks([2, 3]);
+    expect(selectBlockSpy).toHaveBeenCalledTimes(1);
+    expect(selectBlockSpy).toHaveBeenCalledTimes(1);
+    expect(selectBlockSpy.calls.mostRecent().args.length).toEqual(2);
+    expect(selectBlockSpy.calls.mostRecent().args[1]).toEqual(true);
   });
 });
 
 @Component({
-  template: `<div soho-blockgrid [dataset]="data">`
+  template: `<div soho-blockgrid [dataset]="data"></div>`
 })
 class SohoBlockGridTestComponent {
+  public data = blockGridTestData;
   @ViewChild(SohoBlockGridComponent) blockgrid: SohoBlockGridComponent;
-
-  public data = [
-    { img: 'https://randomuser.me/api/portraits/med/women/8.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, Developer' },
-    { img: 'https://randomuser.me/api/portraits/med/women/9.jpg', maintxt: 'Jane Taylor', subtxt: 'Infor, Developer' },
-    { img: 'https://randomuser.me/api/portraits/med/women/10.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, SVP' },
-    { img: 'https://randomuser.me/api/portraits/med/women/11.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, Developer' },
-    { img: 'https://randomuser.me/api/portraits/med/women/12.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, Architect' }
-  ];
 }
-
-describe('Soho blockgrid Render', () => {
+fdescribe('Soho blockgrid Render', () => {
   let blockgrid:  SohoBlockGridComponent;
   let component: SohoBlockGridTestComponent;
   let fixture:   ComponentFixture<SohoBlockGridTestComponent>;
@@ -65,11 +140,10 @@ describe('Soho blockgrid Render', () => {
 
     de = fixture.debugElement;
     el = de.query(By.css('[soho-blockgrid]')).nativeElement;
-
   });
 
   it('Check HTML content', () => {
+    expect(el.nodeName).toEqual('DIV');
     expect(el.hasAttribute('soho-blockgrid')).toBeTruthy('soho-blockgrid');
   });
-
 });

--- a/src/app/blockgrid/blockgrid-custom-content.demo.html
+++ b/src/app/blockgrid/blockgrid-custom-content.demo.html
@@ -1,5 +1,6 @@
 <div class="row">
   <div class="twelve columns">
+
     <h1 class="section-title">Block Grid Custom Content Demo</h1>
     <div soho-blockgrid
       [selectable]="'mixed'"
@@ -9,7 +10,7 @@
       (deselected)="onDeselected($event)"
     >
       <ng-container *ngFor="let item of data; let i = index">
-        <div class="block is-selectable card" role="listitem" tabindex="0">
+        <div #BlockChild class="block is-selectable card" role="listitem" tabindex="0" attr.idx="{{i}}">
           <input type="checkbox" aria-hidden="true" role="presentation" class="checkbox" id="checkbox{{i}}" tabindex="0" attr.idx="{{i}}">
           <label for="checkbox{{i}}" class="checkbox-label"><span class="audible">Select</span></label>
           <img alt="Placeholder Image" src="{{item.image}}" class="image-round">
@@ -21,5 +22,6 @@
         </div>
       </ng-container>
     </div>
+
   </div>
 </div>

--- a/src/app/blockgrid/blockgrid-custom-content.demo.html
+++ b/src/app/blockgrid/blockgrid-custom-content.demo.html
@@ -10,7 +10,7 @@
       (deselected)="onDeselected($event)"
     >
       <ng-container *ngFor="let item of data; let i = index">
-        <div #BlockChild class="block is-selectable card" role="listitem" tabindex="0" attr.idx="{{i}}">
+        <div class="block is-selectable card" role="listitem" tabindex="0" attr.idx="{{i}}">
           <input type="checkbox" aria-hidden="true" role="presentation" class="checkbox" id="checkbox{{i}}" tabindex="0" attr.idx="{{i}}">
           <label for="checkbox{{i}}" class="checkbox-label"><span class="audible">Select</span></label>
           <img alt="Placeholder Image" src="{{item.image}}" class="image-round">

--- a/src/app/blockgrid/blockgrid-custom-content.demo.ts
+++ b/src/app/blockgrid/blockgrid-custom-content.demo.ts
@@ -25,7 +25,7 @@ export class BlockGridCustomContentDemoComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     this.blockGrid.activateBlock(1);
-    this.blockGrid.selectBlocks([3, 4, 10])
+    this.blockGrid.selectBlocks([3, 4, 10]);
   }
 
   onSelected(args) {

--- a/src/app/blockgrid/blockgrid-custom-content.demo.ts
+++ b/src/app/blockgrid/blockgrid-custom-content.demo.ts
@@ -20,7 +20,6 @@ import {
 export class BlockGridCustomContentDemoComponent implements AfterViewInit {
 
   @ViewChild(SohoBlockGridComponent) blockGrid: SohoBlockGridComponent;
-  // @ViewChildren('BlockChild') blockChildren: QueryList<ElementRef>;
 
   public data = DATA;
 

--- a/src/app/blockgrid/blockgrid-custom-content.demo.ts
+++ b/src/app/blockgrid/blockgrid-custom-content.demo.ts
@@ -1,8 +1,12 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  ViewChild,
 } from '@angular/core';
-
+import {
+  SohoBlockGridComponent
+} from 'ids-enterprise-ng';
 import {
   DATA
 } from './blockgrid-demo-data';
@@ -13,9 +17,17 @@ import {
   styleUrls: ['./blockgrid-custom-content.demo.css'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BlockGridCustomContentDemoComponent {
+export class BlockGridCustomContentDemoComponent implements AfterViewInit {
+
+  @ViewChild(SohoBlockGridComponent) blockGrid: SohoBlockGridComponent;
+  // @ViewChildren('BlockChild') blockChildren: QueryList<ElementRef>;
 
   public data = DATA;
+
+  ngAfterViewInit() {
+    this.blockGrid.activateBlock(1);
+    this.blockGrid.selectBlocks([3, 4, 10])
+  }
 
   onSelected(args) {
     console.log('onSelected', args);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Needed a programmatic way to select and activate blocks in the block grid component

**Related github/jira issue (required)**:
Closes #362

**Steps necessary to review your pull request (required)**:
 - go to http://localhost:4200/ids-enterprise-ng-demo/blockgrid-custom-content
- should see 1 block activate and 2 blocks selected via new apis
