### PR TITLE
Need a safety check in soho-listview clearAllSelected #357

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[ColorPicker]` - added configuration option for customColor to have the ability to input colors outside the allowed color options. `JT` ([Pull Request 301])
 - `[DatePicker]` - remove configuration for customValidation. `JT` ([Pull Request 300])
 - `[TextArea]` - input events now cause ngModel update events to be fired. `BTHH`  ([Pull Request 345](https://github.com/infor-design/enterprise-ng/pull/345))
+- `[ListView]` - added safety checks for both `clearAllSelected()` and `toggleAll()` methods. `NBCP`  ([Pull Request 364](https://github.com/infor-design/enterprise-ng/pull/364))
 
 ### 5.1.0 Chore & Maintenance
 

--- a/projects/ids-enterprise-ng/src/lib/listview/soho-listview.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/listview/soho-listview.component.ts
@@ -424,7 +424,7 @@ export class SohoListViewComponent implements AfterViewInit, OnDestroy, AfterVie
   /**
    * Toggle the selected listview items between all and none.
    */
-  toggleAll () {
+  toggleAll() {
     if (this.listview) {
       this.ngZone.runOutsideAngular(() => this.listview.toggleAll());
     }

--- a/projects/ids-enterprise-ng/src/lib/listview/soho-listview.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/listview/soho-listview.component.ts
@@ -416,14 +416,18 @@ export class SohoListViewComponent implements AfterViewInit, OnDestroy, AfterVie
    * Clear all the currently selected listview items that are selected.
    */
   clearAllSelected() {
-    this.ngZone.runOutsideAngular(() => this.listview.clearAllSelected());
+    if (this.listview) {
+      this.ngZone.runOutsideAngular(() => this.listview.clearAllSelected());
+    }
   }
 
   /**
    * Toggle the selected listview items between all and none.
    */
   toggleAll () {
-    this.ngZone.runOutsideAngular(() => this.listview.toggleAll());
+    if (this.listview) {
+      this.ngZone.runOutsideAngular(() => this.listview.toggleAll());
+    }
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/listview/soho-listview.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/listview/soho-listview.spec.ts
@@ -76,6 +76,30 @@ describe('Soho Listview Unit Tests', () => {
     expect(el.classList).toContain('listview');
   });
 
+  it('should only call clearAllSelected when listView is available', () => {
+    const clearAllSelectedSpy = spyOn(comp['listview'], 'clearAllSelected');
+    comp.clearAllSelected();
+    expect(clearAllSelectedSpy).toHaveBeenCalledTimes(1);
+
+    comp['listview'] = null;
+    clearAllSelectedSpy.calls.reset();
+
+    comp.clearAllSelected();
+    expect(clearAllSelectedSpy).not.toHaveBeenCalled();
+  });
+
+  it('should only call toggleAll when listView is available', () => {
+    const toggleAllSpy = spyOn(comp['listview'], 'toggleAll');
+    comp.toggleAll();
+    expect(toggleAllSpy).toHaveBeenCalledTimes(1);
+
+    comp['listview'] = null;
+    toggleAllSpy.calls.reset();
+
+    comp.clearAllSelected();
+    expect(toggleAllSpy).not.toHaveBeenCalled();
+  });
+
   // Add more method tests.
 });
 
@@ -161,5 +185,4 @@ describe('Soho ListView Render', () => {
         expect(input.classList.contains('listview-selection-checkbox')).toBeTruthy('is listview-selection-checkbox');
       });
   });
-
 });

--- a/src/app/listview/listview.demo.ts
+++ b/src/app/listview/listview.demo.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  OnInit,
   ViewChild
  } from '@angular/core';
 
@@ -20,7 +21,7 @@ import { ContentTypeService } from './content-type.service';
   `],
   providers: [ContentTypeService]
 })
-export class ListViewDemoComponent {
+export class ListViewDemoComponent implements OnInit {
 
   @ViewChild('singleSelectListView') singleSelectListView: SohoListViewComponent;
 
@@ -63,6 +64,10 @@ export class ListViewDemoComponent {
     this.demoTasks.push({task: '063010', date: '10/11/2015' , desc: 'Special fields test - New item has been created.'});
     this.demoTasks.push({task: '063011', date: '10/11/2015' , desc: 'Call TMZ Inc at 5 PM'});
     this.demoTasks.push({task: '063012', date: '07/08/2015' , desc: 'Part #6212132 has low inventory level'});
+  }
+
+  ngOnInit() {
+    this.singleSelectListView.clearAllSelected();
   }
 
   addItems() {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This adds a safety check for both `clearAllSelected()` and `toggleAll()` methods which fixes js errors thrown when these methods are called `OnInit`

**Related github/jira issue (required)**:
Closes #357 

**Steps necessary to review your pull request (required)**:
1. Checkout the branch
2. Run the demo app
3. Go to http://localhost:4200/ids-enterprise-ng-demo/listview

**Expected**: No js errors should be logged on the console
