### PR TITLE
blockgrid coverage, added deactivateBlock, npm run testdebug for debugging tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "pack:lib": "cd dist/ids-enterprise-ng && npm pack",
     "package": "npm run build:lib && npm pack",
     "test": "npx ng test ids-enterprise-ng --code-coverage --watch=false",
+    "testdebug": "npx ng test ids-enterprise-ng --code-coverage --watch=true --browsers Chrome",
     "lint": "npx ng lint && npm run mdlint",
     "mdlint": "npm run mdlint:docs && npm run mdlint:src",
     "mdlint:src": "npx markdownlint ./projects/ids-enterprise-ng/src/",

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -118,6 +118,10 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
     });
   }
 
+  public deactivateBlock(): void {
+    this.blockgrid.selectBlock($(), false);
+  }
+
   public selectBlocks(idx: number[]) {
     this.ngZone.runOutsideAngular(() => {
       const blockChildren: NodeList = this.element.nativeElement.querySelectorAll('.block');

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
@@ -98,19 +98,40 @@ describe('Soho blockgrid Unit Tests', () => {
     fixture.detectChanges(); // detect changes to cause the blockgrid component to be built.
     expect((comp as any).blockgrid).not.toBeUndefined();
 
+    // check activateBlock happy path
     const selectBlockSpy = spyOn((comp as any).blockgrid, 'selectBlock');
     comp.activateBlock(1);
     expect(selectBlockSpy).toHaveBeenCalledTimes(1);
     expect(selectBlockSpy.calls.mostRecent().args.length).toEqual(2);
     expect(selectBlockSpy.calls.mostRecent().args[1]).toEqual(false);
 
+    // check activateBlock safety checks
     selectBlockSpy.calls.reset();
+    comp.activateBlock(-1); // lower out of bounds index
+    expect(selectBlockSpy).not.toHaveBeenCalled();
+    comp.activateBlock(5); // upper out of bounds index
+    expect(selectBlockSpy).not.toHaveBeenCalled();
 
-    comp.selectBlocks([2, 3]);
+    // check deactivateBlock
+    selectBlockSpy.calls.reset();
+    comp.deactivateBlock();
     expect(selectBlockSpy).toHaveBeenCalledTimes(1);
+    expect(selectBlockSpy.calls.mostRecent().args.length).toEqual(2);
+    expect(selectBlockSpy.calls.mostRecent().args[1]).toEqual(false);
+
+    selectBlockSpy.calls.reset();
+    comp.selectBlocks([2, 3]);
     expect(selectBlockSpy).toHaveBeenCalledTimes(1);
     expect(selectBlockSpy.calls.mostRecent().args.length).toEqual(2);
     expect(selectBlockSpy.calls.mostRecent().args[1]).toEqual(true);
+
+    // todo: Cannot test deselectBlock functionality. No EP API in blockgrid.js is available. 2/19/2019
+  });
+
+  it('Check ngDestroy safety check for coverage', () => {
+    // since no jquery component will be created here the destroy method
+    // should cause the safety checks to be covered.
+    comp.ngOnDestroy();
   });
 });
 


### PR DESCRIPTION
- soho-blockgrid.spec now at 100% coverage
- added deactivateBlock wrapping function
- added testdebug npm script for debugging tests in Chrome

**Related github/jira issue (required)**:
Closes #362

**Steps necessary to review your pull request (required)**:
* run karma tests
