### PR TITLE
stacked hierarchy type support

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/hierarchy/soho-hierarchy.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/hierarchy/soho-hierarchy.component.ts
@@ -59,14 +59,27 @@ export class SohoHierarchyComponent implements OnDestroy, AfterViewInit {
     return this.options.templateId;
   }
 
+  /**
+   * @deprecated use layout = 'paging' instead.
+   */
   @Input() set paging(bool: boolean) {
     this.options.paging = bool;
   }
 
+  /**
+   * @deprecated use layout = 'paging' instead.
+   */
   get paging(): boolean {
     return this.options.paging;
   }
 
+  @Input() set layout(layout: SohoHierarchyLayoutType) {
+    this.options.layout = layout;
+  }
+
+  get layout(): SohoHierarchyLayoutType {
+    return this.options.layout;
+  }
   /**
    * Leaf is selected
    *

--- a/projects/ids-enterprise-ng/src/lib/hierarchy/soho-hierarchy.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/hierarchy/soho-hierarchy.d.ts
@@ -3,6 +3,7 @@ interface SohoHierarchyLegend {
   label: string;
 }
 
+type SohoHierarchyLayoutType = 'horizontal' | 'paging' | 'mobileOnly' | 'stacked';
 /*
   * @param legend  Pass in custom markdown for the legend structure.
   * @param legendKey  Key to use for the legend matching
@@ -18,11 +19,20 @@ interface SohoHierarchyOptions {
   dataset?: Array<any>;
   newData?: Array<any>;
   templateId?: string;
+
+  /**
+   * @deprecated use layout = 'mobileOnly' instead.
+   */
   mobileView?: boolean;
   legend?: Array<SohoHierarchyLegend>;
   legendKey?: string;
   beforeExpand?: Function;
+
+  /**
+   * @deprecated use layout = 'paging' instead.
+   */
   paging?: boolean;
+  layout?: SohoHierarchyLayoutType;
 }
 
 /**
@@ -36,6 +46,12 @@ interface SohoHierarchyData extends SohoHierarchyDataState {
   id?: string;
   children?: Array<any>;
   isLeaf?: boolean;
+
+  /** used for stacked layout */
+  ancestorPath?: SohoHierarchyData[] | null;
+
+  /** used for stacked layout */
+  centeredNode?: SohoHierarchyData[];
 }
 
 interface SohoHierarchyDataState {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
New stacked hierarchy layout
- added interface typing for centeredNode and ancestorPath
- added new generic `@Input() layout: SohoHierarchyLayoutType` 
- deprecated 2 properties not handled through the layout input.