### PR TITLE
350 - Added Datagrid filterConditions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@
 - `[DataGrid]` Added a few missing toolbar options to the types. `TJM` ([#336](https://github.com/infor-design/enterprise-ng/issues/336))
 - `[DataGrid]` Added headerAlign option to datagrid column. `PWP` ([#304](https://github.com/infor-design/enterprise-ng/issues/304))
 - `[DataGrid]` Added safety check on clearFilter for random errors. `TJM` ([#374](https://github.com/infor-design/enterprise-ng/issues/374))
+- `[DataGrid]` Added missing filterConditions type to datagrid column. This allows you to edit the filter dropdown conditions. `TJM` ([#350](https://github.com/infor-design/enterprise-ng/issues/350))
+- `[DataGrid]` Removed unused enum SohoGridColumnFilterTypes. If using this you should use `filterType: 'text'` instead. `TJM` ([#350](https://github.com/infor-design/enterprise-ng/issues/350))
 - `[DatePicker]` Added firstDayOfWeek option to date picker component `PWP` ([362](https://github.com/infor-design/enterprise-ng/issues/362)'
 - `[General]` Upgraded @angular/cli (to 7.3.2) and @angular/core (to 7.2.5).  `BTHH` ([Pull Request 386](https://github.com/infor-design/enterprise-ng/pull/386))
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/index.ts
@@ -1,7 +1,6 @@
 export {
   SohoDataGridComponent,
   SohoDataGridToggleRowEvent,
-  SohoGridColumnFilterTypes,
   SohoAngularEditorAdapter
 } from './soho-datagrid.component';
 export { SohoDataGridModule } from './soho-datagrid.module';

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -2148,24 +2148,6 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
 }
 
 /**
- * Enumeration of the Soho Datagrid FilterTypes.
- * Note: integer, percent and lookup are not yet implemented the soho datagrid.js
- * See http://stackoverflow.com/questions/15490560/create-an-enum-with-string-values-in-typescript
- * for more details about creating an enum of strings.
- */
-export enum SohoGridColumnFilterTypes {
-  Text     = 'text',
-  Checkbox = 'checkbox',
-  Contents = 'contents',
-  Date     = 'date',
-  Decimal  = 'decimal',
-  Integer  = 'integer',
-  Lookup   = 'lookup',
-  Percent  = 'percent',
-  Select   = 'select'
-}
-
-/**
  * Details of the 'expandrow' and 'collapserow' events.
  */
 export interface SohoDataGridToggleRowEvent extends SohoDataGridRowExpandEvent {

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -356,7 +356,13 @@ type SohoDataGridSortFunction = (
   ascending: boolean
 ) => boolean;
 
-type SohoDataGridColumnFilterType = 'text' | 'checkbox' | 'contents' | 'date' | 'decimal' | 'integer' | 'percent' | 'select' | 'time';
+type SohoDataGridColumnFilterType = 'text' | 'checkbox' | 'contents' | 'date' | 'decimal' |
+  'integer' | 'lookup' | 'percent' | 'select' | 'time';
+
+type SohoDataGridColumnFilterConditions = 'contains' | 'does-not-contain' | 'equals' | 'does-not-equal' | 'is-empty' |
+  'is-not-empty' | 'selected-notselected' | 'selected' | 'not-selected' | 'equals' | 'does-not-equal' |
+  'is-empty' | 'is-not-empty' | 'in-range' | 'less-than' | 'less-equals' | 'greater-than' |
+  'greater-equals' | 'end-with' | 'does-not-end-with' | 'start-with' | 'does-not-start-with';
 
 interface SohoDataGridCellEditor {
   className: string;
@@ -596,6 +602,9 @@ interface SohoDataGridColumn {
 
   // 'checkbox', 'date', 'decimal', 'contents', 'select' otherwise a string.
   filterType?: SohoDataGridColumnFilterType | string;
+
+  /** Limit filter conditions to a prescribed set of conditionals.  */
+  filterConditions?: SohoDataGridColumnFilterConditions[];
 
   /** Column formatter function.  */
   filterFormatter?: SohoDataGridColumnFormatterFunction | string;

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
@@ -12,7 +12,7 @@ import { SohoDataGridComponent } from './soho-datagrid.component';
 const COLUMNS: SohoDataGridColumn[] = [
   { id: 'selectionCheckbox', sortable: false, resizable: false, width: 50, formatter: Soho.Formatters.SelectionCheckbox, align: 'center', exportable: false },
   { id: 'productId',   name: 'Product Id',   field: 'productId',   sortable: false, filterType: 'integer', width: 140, formatter: Soho.Formatters.Readonly },
-  { id: 'productName', name: 'Product Name', field: 'productName', sortable: false, filterType: 'text',    width: 150, formatter: Soho.Formatters.Hyperlink },
+  { id: 'productName', name: 'Product Name', field: 'productName', sortable: false, filterType: 'text', filterConditions: ['equals', 'contains'],  width: 150, formatter: Soho.Formatters.Hyperlink },
   { id: 'activity',    name: 'Activity',     field: 'activity',    sortable: false, filterType: 'text',    width: 125, hidden: true },
   { id: 'quantity',    name: 'Quantity',     field: 'quantity',    sortable: false,                        width: 125 },
   { id: 'price',       name: 'Price',        field: 'price',       sortable: false, filterType: 'decimal', width: 125, formatter: Soho.Formatters.Decimal },

--- a/src/app/datagrid/datagrid-demo.service.ts
+++ b/src/app/datagrid/datagrid-demo.service.ts
@@ -64,22 +64,6 @@ export class DataGridDemoService extends SohoDataGridService {
         formatter: Soho.Formatters.Readonly
       });
 
-    /*
-      It is possible to use the card here but its not the prefered approach.
-
-      this.columns.push({
-        id: 'productDesc',
-        filterType: <any>SohoGridColumnFilterTypes.Text,
-        name: 'Product Desc',
-        sortable: false,
-        field: 'productName',
-        formatter: Soho.Formatters.Template,
-        template: '<p class="datagrid-row-heading">{{productId}}</p><p class="datagrid-row-subheading">{{productName}}</p>',
-        click: (e: any, args: any) => { console.log('link was clicked', args); }
-      });
-
-    */
-
     this.columns.push({
       id: 'productDesc',
       filterType: 'text',
@@ -111,7 +95,8 @@ export class DataGridDemoService extends SohoDataGridService {
       id: 'quantity',
       name: 'Quantity',
       filterType: 'text',
-      field: 'quantity'
+      field: 'quantity',
+      filterConditions: ['equals', 'contains']
     });
 
     this.columns.push({

--- a/src/app/datagrid/datagrid-demo.service.ts
+++ b/src/app/datagrid/datagrid-demo.service.ts
@@ -3,8 +3,7 @@ import { of,  Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 
 import {
-  SohoDataGridService,
-  SohoGridColumnFilterTypes
+  SohoDataGridService
 } from 'ids-enterprise-ng';
 
 declare var Formatters: any;
@@ -83,7 +82,7 @@ export class DataGridDemoService extends SohoDataGridService {
 
     this.columns.push({
       id: 'productDesc',
-      filterType: <any>SohoGridColumnFilterTypes.Text,
+      filterType: 'text',
       name: 'Product Desc',
       sortable: false,
       field: 'productName',
@@ -92,7 +91,7 @@ export class DataGridDemoService extends SohoDataGridService {
 
     this.columns.push({
       id: 'productDesc',
-      filterType: <any>SohoGridColumnFilterTypes.Text,
+      filterType: 'text',
       name: 'Product Desc',
       sortable: false,
       field: 'productName',
@@ -104,14 +103,14 @@ export class DataGridDemoService extends SohoDataGridService {
     this.columns.push({
       id: 'activity',
       name: 'Activity',
-      filterType: <any>SohoGridColumnFilterTypes.Text,
+      filterType: 'text',
       field: 'activity'
     });
 
     this.columns.push({
       id: 'quantity',
       name: 'Quantity',
-      filterType: <any>SohoGridColumnFilterTypes.Text,
+      filterType: 'text',
       field: 'quantity'
     });
 
@@ -127,7 +126,7 @@ export class DataGridDemoService extends SohoDataGridService {
     this.columns.push({
       id: 'price1',
       name: 'Actual long Price',
-      filterType: <any>SohoGridColumnFilterTypes.Decimal,
+      filterType: 'decimal',
       field: 'price',
       formatter: Soho.Formatters.Decimal
     });
@@ -144,7 +143,7 @@ export class DataGridDemoService extends SohoDataGridService {
       id: 'price4',
       hidden: true,
       name: 'Price - special formatted',
-      filterType: <any>SohoGridColumnFilterTypes.Decimal,
+      filterType: 'decimal',
       field: 'price',
       formatter: Soho.Formatters.Decimal,
       numberFormat: { minimumFractionDigits: 0, maximumFractionDigits: 6 }
@@ -154,7 +153,7 @@ export class DataGridDemoService extends SohoDataGridService {
       id: 'orderDate',
       width: 300,
       name: 'Order Date',
-      filterType: <any>SohoGridColumnFilterTypes.Date,
+      filterType: 'date',
       field: 'orderDate',
       formatter: Soho.Formatters.Date,
       dateFormat: Soho.Locale.calendar().dateFormat.datetime // @todo
@@ -163,7 +162,7 @@ export class DataGridDemoService extends SohoDataGridService {
     this.columns.push({
       id: 'status',
       name: 'Status',
-      filterType: <any>SohoGridColumnFilterTypes.Select,
+      filterType: 'select',
       options: [{ value: "ok", label: "OKAY" }, { value: "OK", label: "BIG OKAY" }, { value: "error", label: "ERROR" }, { value: "success", label: "SUCCESS" }],
       field: 'status',
       formatter: Soho.Formatters.Dropdown

--- a/src/app/datagrid/datagrid-paging-data.ts
+++ b/src/app/datagrid/datagrid-paging-data.ts
@@ -2,7 +2,7 @@
 export const PAGING_COLUMNS: SohoDataGridColumn[] = [
   { id: 'selectionCheckbox', sortable: false, resizable: false, width: 50, formatter: Soho.Formatters.SelectionCheckbox, align: 'center', exportable: false },
   { id: 'productId',   name: 'Product Id',   field: 'productId',   sortable: false, filterType: 'integer', width: 140, formatter: Soho.Formatters.Readonly },
-  { id: 'productName', name: 'Product Name', field: 'productName', sortable: false, filterType: 'text',    width: 150, formatter: Soho.Formatters.Hyperlink },
+  { id: 'productName', name: 'Product Name', field: 'productName', sortable: false, filterType: 'text', filterConditions: ['equals', 'contains'], width: 150, formatter: Soho.Formatters.Hyperlink },
   { id: 'activity',    name: 'Activity',     field: 'activity',    sortable: false, filterType: 'text',    width: 125, hidden: true },
   { id: 'quantity',    name: 'Quantity',     field: 'quantity',    sortable: false,                        width: 125 },
   { id: 'price',       name: 'Price',        field: 'price',       sortable: false, filterType: 'decimal', width: 125, formatter: Soho.Formatters.Decimal },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added missing types for filterConditions so that that option can be used in NG
Removed unused / legacy SohoGridColumnFilterTypes

**Related github/jira issue (required)**:
Closes #350 

**Steps necessary to review your pull request (required)**:
http://localhost:4200/ids-enterprise-ng-demo/datagrid-service
- open quantity dropdown
- notice only 2 items shown.

