### PR TITLE
378 - TrackDirty - Added exportAs directive property

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[TextArea]` - added configuration option for maxLength so it will have a restriction in maximum character input. `JT` ([Pull Request 302])
 - `[TextArea]` - added configuration option for maxGrow so it will expand if the characters exceed the height of the textarea. `JT` ([Pull Request 302])
 - `[TextArea]` - input events now cause ngModel update events to be fired. `BTHH`  ([Pull Request 345](https://github.com/infor-design/enterprise-ng/pull/345))
+- `[TrackDirty]` - added exportAs directive property.
 
 ### 5.1.0 Chore & Maintenance
 

--- a/projects/ids-enterprise-ng/src/lib/trackdirty/soho-trackdirty.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/trackdirty/soho-trackdirty.directive.ts
@@ -13,7 +13,8 @@ import {
 
 @Directive({
   // tslint:disable-next-line:directive-selector
-  selector: '[soho-trackdirty]'
+  selector: '[soho-trackdirty]',
+  exportAs: 'soho-trackdirty'
 })
 export class SohoTrackDirtyDirective implements AfterViewInit, OnDestroy {
 

--- a/src/app/fileupload/fileupload-lm.demo.html
+++ b/src/app/fileupload/fileupload-lm.demo.html
@@ -27,7 +27,7 @@
             <label soho-label for={{name3}}>File</label>
             <input
               soho-fileupload
-              soho-trackdirty (pristine)="onPristine($event)" (dirty)="onDirty($event)" (afterResetDirty)="onAfterResetDirty($event)"
+              soho-trackdirty #trackDirty="soho-trackdirty" (pristine)="onPristine($event)" (dirty)="onDirty($event)" (afterResetDirty)="onAfterResetDirty($event)"
               id={{name3}} name={{name3}} accept="true" value="" [attr.original]="fileName"
             />
           </div>

--- a/src/app/fileupload/fileupload-lm.demo.ts
+++ b/src/app/fileupload/fileupload-lm.demo.ts
@@ -23,7 +23,7 @@ import {
 export class FileUploadLMDemoComponent implements OnInit {
 
   @ViewChild(SohoFileUploadComponent) fileupload: SohoFileUploadComponent;
-  @ViewChild(SohoTrackDirtyDirective) trackdirty: SohoTrackDirtyDirective;
+  @ViewChild('trackDirty') trackdirty: SohoTrackDirtyDirective;
 
   public name3 = 'file-name-track-dirty-existing';
   public fileName = 'add-employee.png';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added exportAs property to the TrackDirtyDirective

**Related github/jira issue (required)**:
Closes #378 

**Steps necessary to review your pull request (required)**:
You can access now directive instance using exported name: <input soho-trackdirty #soho-trackdirty="soho-trackdirty" ..../>