### PR TITLE
- Fix for https://github.com/infor-design/enterprise-ng/issues/389

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,19 +4,20 @@
 
 ### 5.1.0 Features
 
-- `[AutoComplete]` Added caseSensitive option to autocomplete component `PWP` ([362](https://github.com/infor-design/enterprise-ng/issues/362)'
-- `[Blockgrid]` Added activateBlock and selectBlocks apis to blockgrid component `PWP` ([362](https://github.com/infor-design/enterprise-ng/issues/362)'
+- `[AutoComplete]` Added caseSensitive option to autocomplete component `PWP` ([362](https://github.com/infor-design/enterprise-ng/issues/362))
+- `[Blockgrid]` Added activateBlock and selectBlocks apis to blockgrid component `PWP` ([362](https://github.com/infor-design/enterprise-ng/issues/362))
 - `[DataGrid]` 4.0 Datagrid expose error row clear functions `PWP` ([#314](https://github.com/infor-design/enterprise-ng/issues/314))
 - `[DataGrid]` Added a few missing toolbar options to the types. `TJM` ([#336](https://github.com/infor-design/enterprise-ng/issues/336))
 - `[DataGrid]` Added headerAlign option to datagrid column. `PWP` ([#304](https://github.com/infor-design/enterprise-ng/issues/304))
 - `[DataGrid]` Added safety check on clearFilter for random errors. `TJM` ([#374](https://github.com/infor-design/enterprise-ng/issues/374))
 - `[DataGrid]` Added missing filterConditions type to datagrid column. This allows you to edit the filter dropdown conditions. `TJM` ([#350](https://github.com/infor-design/enterprise-ng/issues/350))
 - `[DataGrid]` Removed unused enum SohoGridColumnFilterTypes. If using this you should use `filterType: 'text'` instead. `TJM` ([#350](https://github.com/infor-design/enterprise-ng/issues/350))
-- `[DatePicker]` Added firstDayOfWeek option to date picker component `PWP` ([362](https://github.com/infor-design/enterprise-ng/issues/362)'
+- `[DatePicker]` Added firstDayOfWeek option to date picker component `PWP` ([362](https://github.com/infor-design/enterprise-ng/issues/362))
 - `[General]` Upgraded @angular/cli (to 7.3.2) and @angular/core (to 7.2.5).  `BTHH` ([Pull Request 386](https://github.com/infor-design/enterprise-ng/pull/386))
 
 ### 5.1.0 Fixes
 
+- `[Accordion]` - Fixed expand/collapse issue on initial load, icon was always showing a collapsed state. Fixed broken dynamic demo. `KOH` ([Pull Request 390](https://github.com/infor-design/enterprise-ng/pull/390))
 - `[Accordion]` - refactored to use `ngZone` - This effects the constructor and how often change detection is called. `BTHH` ([Pull Request 290](https://github.com/infor-design/enterprise-ng/pull/290))
 - `[ColorPicker]` - added configuration option for customColor to have the ability to input colors outside the allowed color options. `JT` ([Pull Request 301])
 - `[DataGrid]` - changed emptyMessage setter so it will remove any empty message if passed a null or undefined. `PWP` ([Pull Request 305](https://github.com/infor-design/enterprise-ng/pull/305))

--- a/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion-pane.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion-pane.component.ts
@@ -7,13 +7,7 @@ import {
 
 @Component({
   selector: 'soho-accordion-pane',
-  templateUrl: './soho-accordion-pane.component.html',
-  // This assumes not expanded ... need this to be dynamic!
-  styles: [`
-    :host {
-      display: none;
-      height: 0px;`
-    ]
+  templateUrl: './soho-accordion-pane.component.html'
 })
 export class SohoAccordionPaneComponent {
   @HostBinding('class.accordion-pane') get isAccordionPane() { return true; }

--- a/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.ts
@@ -68,7 +68,7 @@ export class SohoAccordionComponent implements AfterViewInit, AfterViewChecked, 
   /**
    * Used to call updated from the afterViewChecked lifecycle event.
    */
-  private updateRequired = true;
+  private updateRequired: boolean;
 
   // -------------------------------------------
   // Component Output

--- a/src/app/accordion/accordion-dynamic.demo.ts
+++ b/src/app/accordion/accordion-dynamic.demo.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  AfterViewInit,
   ViewChild,
   QueryList,
   ContentChildren,
@@ -17,7 +16,7 @@ import {
   selector: 'accordion-dynamic-demo', // tslint:disable-line
   templateUrl: './accordion-dynamic.demo.html',
 })
-export class AccordionDynamicDemoComponent implements AfterViewInit {
+export class AccordionDynamicDemoComponent {
 
   // tslint:disable-next-line:no-forward-ref
   @ContentChildren(forwardRef(() => SohoAccordionHeaderComponent))
@@ -35,10 +34,6 @@ export class AccordionDynamicDemoComponent implements AfterViewInit {
   public allowOnePane = true;
 
   @ViewChild(SohoAccordionComponent) accordion: SohoAccordionComponent;
-
-  ngAfterViewInit(): void {
-    this.accordion.updated();
-  }
 
   public addMore() {
     this.sampleData.forEach((d) => { d.expanded = false; });
@@ -78,9 +73,6 @@ export class AccordionDynamicDemoComponent implements AfterViewInit {
 
       // this.accordion.collapse(header)
       header.expanded = true;
-
-      setTimeout(() => { this.accordion.updated(); });
-
     }
   }
 
@@ -89,8 +81,6 @@ export class AccordionDynamicDemoComponent implements AfterViewInit {
 
     if (header) {
       header.expanded = false;
-
-      setTimeout(() => { this.accordion.updated(); });
     }
 
   }

--- a/src/app/accordion/accordion-panels.demo.html
+++ b/src/app/accordion/accordion-panels.demo.html
@@ -63,6 +63,36 @@
   </div>
 </div>
 
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">All headers expanded on initial load</h2>
+    <soho-accordion
+      [allowOnePane]="false"
+      [hasPanels]="true"
+      (beforeexpand)="onBeforeExpand($event)"
+      (beforecollapse)="onBeforeCollapse($event)"
+      (beforeselect)="onBeforeSelect($event)"
+      (afterexpand)="onAfterExpand($event)"
+      (selected)="onSelected($event)"
+      (followlink)="onFollowlink($event)"
+      (expand)="onExpand($event)"
+      (collapse)="onCollapse($event)"
+      (aftercollapse)="onAfterCollapse($event)"
+    >
+      <soho-accordion-header [isExpanded]="true">Warehouse Location A</soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header>Item 1</soho-accordion-header>
+        <soho-accordion-header>Item 2</soho-accordion-header>
+      </soho-accordion-pane>
+      <soho-accordion-header [isExpanded]="true">Warehouse Location B</soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header>Item 1</soho-accordion-header>
+        <soho-accordion-header>Item 2</soho-accordion-header>
+      </soho-accordion-pane>
+    </soho-accordion>
+  </div>
+</div>
+
 <ng-template #AccordionContent>
   <soho-accordion-header>Warehouse Location A</soho-accordion-header>
   <soho-accordion-pane>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
1. Fix for expand icons showing the wrong state on initial load. 
2. Fixes broken dynamic accordion demo. 
3. Added an example to show all headers expanded on initial load. Matches http://master-enterprise.demo.design.infor.com/components/accordion/test-expand-all.html
4. Fixes https://github.com/infor-design/enterprise-ng/issues/389

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise-ng/issues/389

Include:
All headers expanded added to http://localhost:4200/ids-enterprise-ng-demo/accordion/panels
![accordion-all-expanded](https://user-images.githubusercontent.com/1056684/54137463-b7b55280-43eb-11e9-9c9f-5928e18a3aeb.png)
