### PR TITLE
346-Added-hideable-option-to-Datagrid-column

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 5.2.0 Fixes
 
 - `[ListView]` - Added optional SohoListViewOptions arg to updated() function in listview.d.ts `PWP`  ([Pull Request 384](https://github.com/infor-design/enterprise-ng/pull/384))
+- `[Datagrid]` - Added hideable option to datagrid column typings.
 
 ### 5.2.0 Chore & Maintenance
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -752,6 +752,9 @@ interface SohoDataGridColumn {
 
   /** align the header text */
   headerAlign?: SohoDataGridTextAlign;
+
+  /** If false the column will be disabled in personalization dialog */
+  hideable?: boolean;
 }
 
 interface SohoDataGridColumnNumberFormat {

--- a/src/app/datagrid/datagrid-breadcrumb.demo.html
+++ b/src/app/datagrid/datagrid-breadcrumb.demo.html
@@ -9,7 +9,7 @@
   <br>
   <div class="scrollable-area no-scroll">
     <app-datagrid-toolbar-demo></app-datagrid-toolbar-demo>
-    <div soho-busyindicator soho-datagrid (selected)="onSelected($event)" selectable="multiple" filterable="true">
+    <div soho-busyindicator soho-datagrid (selected)="onSelected($event)" selectable="multiple" filterable="true" [toolbar]="{ personalize: true }">
     </div>
   </div>
 </div>

--- a/src/app/datagrid/datagrid-demo.service.ts
+++ b/src/app/datagrid/datagrid-demo.service.ts
@@ -76,6 +76,7 @@ export class DataGridDemoService extends SohoDataGridService {
       filterType: 'text',
       name: 'Product Desc',
       sortable: false,
+      hideable: false,
       field: 'productName',
       formatter: Soho.Formatters.Template,
       template: '<p class="datagrid-row-heading">{{productId}}</p><p class="datagrid-row-subheading">{{productName}}</p>',

--- a/src/app/datagrid/datagrid-toolbar.demo.html
+++ b/src/app/datagrid/datagrid-toolbar.demo.html
@@ -44,6 +44,7 @@
       </button>
       <ul class="popupmenu">
         <li><a href="#">Refresh</a></li>
+        <li><a data-option="personalize-columns" href="#">Personalize Columns</a></li>
         <li class="separator single-selectable-section"></li>
         <li class="heading">Row Height</li>
         <li class="is-selectable"><a data-option="row-short" href="#">Short</a></li>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Missing hideable option for Datagrid column in the typings.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise-ng/issues/346

**Steps necessary to review your pull request (required)**:
There is updated Datagrid Toolbar with Personalize columns item in the toolbar.
One of the column has hideable option set to false and this column is disabled in the personalization dialog.