### PR TITLE
Added `personalize-menu` and `application menu` state.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 5.3.0 Features
 
-- [DemoApp] - Added `PersonalizeMenuComponent` example. `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))
-- [DemoApp] - Added open status persistence to the demo's application menu. `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))
+- [DemoApp] - Added `PersonalizeMenuComponent` example. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))
+- [DemoApp] - Added open status persistence to the demo's application menu. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))
 
 ## v5.2.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - [Datepicker] - Adds an example to show custom validation to the datepicker test page. `TJM` ([#411](https://github.com/infor-design/enterprise-ng/issues/411)
 
+### 5.3.0 Features
+
+- [DemoApp] - Added `PersonalizeMenuComponent` example. `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))
+- [DemoApp] - Added open status persistence to the demo's application menu. `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))
+
 ## v5.2.1
 
 ### 5.2.1 Fixes

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,7 +6,8 @@
 <soho-icons-empty></soho-icons-empty>
 <app-masthead-demo></app-masthead-demo>
 
-<nav soho-application-menu class="is-personalizable" [filterable]="true" [openOnLarge]="true" [dismissOnClickMobile]="true">
+<nav soho-application-menu class="is-personalizable" [filterable]="true" [openOnLarge]="false"
+  [dismissOnClickMobile]="true" (menuVisibility)="onMenuVisibility($event)">
   <div soho-searchfield-wrapper>
     <label class="audible" for="application-menu-searchfield">Search</label>
     <input soho-searchfield id="application-menu-searchfield" [clearable]="true" />
@@ -19,5 +20,4 @@
       <router-outlet></router-outlet>
   </div>
 </div>
-<div soho-personalize [options]="personalizeOptions" (changetheme)="onChangeTheme($event)" (changecolors)="onChangeColors($event)">
-</div>
+<div soho-personalize (changetheme)="onChangeTheme($event)"></div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,7 +9,8 @@ import {
 import { HeaderDynamicDemoRefService } from './header/header-dynamic-demo-ref.service';
 import {
   SohoPersonalizeDirective,
-  SohoRenderLoopService
+  SohoRenderLoopService,
+  SohoApplicationMenuComponent
 } from 'ids-enterprise-ng';
 
 @Component({
@@ -20,11 +21,23 @@ import {
   encapsulation: ViewEncapsulation.None
 })
 export class AppComponent implements AfterViewInit {
+  /**
+   * Local Storage Key
+   */
+  private static IS_APPLICATION_MENU_OPEN_KEY = 'is-application-menu-open';
+
+  @ViewChild(SohoApplicationMenuComponent)
+  public applicationMenu: SohoApplicationMenuComponent;
 
   @ViewChild(SohoPersonalizeDirective) personalize: SohoPersonalizeDirective;
 
   @HostBinding('class.no-scroll') get isNoScroll() { return true; }
 
+  /**
+   * Include the uplift icons only if required by the current theme, this
+   * is not quite perfect, as we need to listen for the theme change here.
+   * Maybe wrap all the icons into their own component?
+   */
   public useUpliftIcons = false;
 
   public personalizeOptions: SohoPersonalizeOptions = {};
@@ -36,30 +49,30 @@ export class AppComponent implements AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    // Has to run after the view has been initialised otherwise
-    // the personalise component is not ready.
-    this.setInitialPersonalization();
+    if (this.isApplicationMenuOpen) {
+      this.applicationMenu.openMenu(true, true);
+    } else {
+      console.log('close');
+      this.applicationMenu.closeMenu();
+    }
   }
 
-  setInitialPersonalization() {
-    const theme = localStorage.getItem('soho_theme');
-    let colors = localStorage.getItem('soho_color');
-    if (theme) {
-      this.personalize.theme = theme;
-    }
-    if (colors) {
-      colors = JSON.parse(colors);
-      this.personalize.colors = colors;
-    }
+  public get isApplicationMenuOpen(): boolean {
+    const valueString = localStorage.getItem(AppComponent.IS_APPLICATION_MENU_OPEN_KEY);
+    return valueString ? (valueString === 'true') : true;
+  }
+
+  public set isApplicationMenuOpen(open: boolean) {
+    localStorage.setItem(AppComponent.IS_APPLICATION_MENU_OPEN_KEY, open ? 'true' : 'false');
   }
 
   onChangeTheme(ev: SohoChangeThemePersonalizeEvent) {
     this.useUpliftIcons = ev.theme === 'uplift';
-    console.log('Theme changed: ', ev);
-    localStorage.setItem('soho_theme', ev.theme);
   }
-  onChangeColors(ev: SohoChangeColorsPersonalizeEvent) {
-    console.log('Colors changed: ', ev);
-    localStorage.setItem('soho_color', JSON.stringify(ev.colors));
+
+  public onMenuVisibility(visible: boolean): void {
+    if (this.isApplicationMenuOpen !== visible) {
+      this.isApplicationMenuOpen = visible;
+    }
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -146,6 +146,7 @@ import { MenuButtonDemoComponent } from './menu-button/menu-button.demo';
 import { MessageDemoComponent } from './message/message.demo';
 import { ModalDialogDemoModule } from './modal-dialog/modal-dialog.demo.module';
 import { PagerStandaloneDemoComponent } from './pager/pager-standalone.demo';
+import { PersonalizeMenuComponent } from './personalize-menu/personalize-menu.component';
 import { PieDemoComponent } from './pie/pie.demo';
 import { PopDownDemoComponent } from './popdown/popdown.demo';
 import { PopupMenuDemoComponent } from './popupmenu/popupmenu.demo';
@@ -332,6 +333,7 @@ import { LocaleInitializerModule } from './locale-initializer/locale-initializer
     MenuButtonDemoComponent,
     MessageDemoComponent,
     PagerStandaloneDemoComponent,
+    PersonalizeMenuComponent,
     PieDemoComponent,
     PopDownDemoComponent,
     PopupMenuDemoComponent,

--- a/src/app/header/header-dynamic.demo.html
+++ b/src/app/header/header-dynamic.demo.html
@@ -47,30 +47,12 @@
         </ng-template>
       </ng-template>
 
-
-
     </soho-toolbar-button-set>
 
     <!-- If the currentToolbarOptions are null/undefined then display the "default" toolbar buttons
          and more menu. -->
     <soho-toolbar-more-button>
-      <ul class="popupmenu is-selectable">
-        <li class="heading" role="presentation">Theme</li>
-        <li class="is-selectable is-checked"><a href="#" [attr.data-theme]="defaultPersonalizeTheme">Default</a></li>
-        <li class="is-selectable"><a href="#" data-theme="light-theme">Light</a></li>
-        <li class="is-selectable"><a href="#" data-theme="dark-theme">Dark</a></li>
-        <li class="is-selectable"><a href="#" data-theme="high-contrast-theme">High Contrast</a></li>
-        <li class="is-selectable"><a href="#" data-theme="uplift-theme">Uplift</a></li>
-        <li class="separator"></li>
-        <li class="heading" role="presentation">Personalization</li>
-        <li class="is-selectable is-checked"><a [attr.data-rgbcolor]="defaultPersonalizeColor" href="#">Default</a></li>
-        <li class="is-selectable"><a data-rgbcolor="#368AC0" href="#">Azure</a></li>
-        <li class="is-selectable"><a data-rgbcolor="#EFA836" href="#">Amber</a></li>
-        <li class="is-selectable"><a data-rgbcolor="#9279A6" href="#">Amethyst</a></li>
-        <li class="is-selectable"><a data-rgbcolor="#579E95" href="#">Turqoise</a></li>
-        <li class="is-selectable"><a data-rgbcolor="#76B051" href="#">Emerald</a></li>
-        <li class="is-selectable"><a data-rgbcolor="#5C5C5C" href="#">Graphite</a></li>
-      </ul>
+      <app-personalize-menu ></app-personalize-menu>
     </soho-toolbar-more-button>
 
   </soho-toolbar>

--- a/src/app/personalize-menu/personalize-menu.component.html
+++ b/src/app/personalize-menu/personalize-menu.component.html
@@ -1,0 +1,10 @@
+<li soho-popupmenu-heading>{{'Theme' | sohoTranslate}}</li>
+<li soho-popupmenu-item [isSelectable]="true" [isChecked]="theme.selected" *ngFor="let theme of themes">
+  <a soho-popupmenu-label [attr.data-theme]="theme.value">{{ theme.name }}</a>
+</li>
+<li soho-popupmenu-separator></li>
+<li soho-popupmenu-heading>Personalization</li>
+<li soho-popupmenu-item [isSelectable]="true" [isChecked]="color.selected" *ngFor="let color of colours">
+  <a soho-popupmenu-label [attr.data-rgbcolor]="color.rgb">{{ color.name }}</a>
+</li>
+<div soho-personalize (changetheme)="onChangeTheme($event)" (changecolors)="onChangeColors($event)"></div>

--- a/src/app/personalize-menu/personalize-menu.component.spec.ts
+++ b/src/app/personalize-menu/personalize-menu.component.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PersonalizeMenuComponent } from './personalize-menu.component';
+import { SohoComponentsModule } from 'ids-enterprise-ng';
+
+describe('PersonalizeMenuComponent', () => {
+  let component: PersonalizeMenuComponent;
+  let fixture: ComponentFixture<PersonalizeMenuComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PersonalizeMenuComponent ],
+      providers: [],
+      imports: [ SohoComponentsModule ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PersonalizeMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/personalize-menu/personalize-menu.component.ts
+++ b/src/app/personalize-menu/personalize-menu.component.ts
@@ -1,0 +1,156 @@
+import {
+  Component,
+  ViewChild,
+  OnInit,
+  HostBinding
+} from '@angular/core';
+import { Color } from './theme-color.model';
+import { Theme } from './theme.model';
+import { SohoPersonalizeDirective } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-personalize-menu',
+  templateUrl: './personalize-menu.component.html'
+})
+export class PersonalizeMenuComponent implements OnInit {
+  @ViewChild(SohoPersonalizeDirective)
+  private personalize: SohoPersonalizeDirective;
+
+  /**
+   * Mark as a popupmenu.
+   */
+  @HostBinding('class.popupmenu') isPopupMenu = true;
+
+  /**
+   * Mark as selectable.
+   */
+  @HostBinding('class.is-selectable') isSelectable = true;
+
+  /**
+   * Theme options - use the theme api?
+   */
+  public themes: Theme[] = [
+    { name: 'Light', value: 'light', selected: true },
+    { name: 'Dark', value: 'dark' },
+    { name: 'High-Contrast', value: 'high-contrast' },
+    { name: 'Uplift', value: 'uplift' }
+];
+
+  /**
+   * Colour options - use the theme api?
+   */
+  public colours: Color[] = [
+    { rgb: '#368AC0', name: 'Azure', selected: true },
+    { rgb: '#EFA836', name: 'Amber' },
+    { rgb: '#9279A6', name: 'Amethyst' },
+    { rgb: '#579E95', name: 'Turqoise' },
+    { rgb: '#76B051', name: 'Emerald' },
+    { rgb: '#5C5C5C', name: 'Graphite' }
+  ];
+
+  /**
+   * Default Colour: this should really be based on the one selected in
+   * the IDS Enterprise component code.
+   */
+  private readonly DEFAULT_COLOUR = '#368AC0';
+
+  /**
+   * Default Theme: this should really be based on the one selected in
+   * the IDS Enterprise component code.
+   */
+  private readonly DEFAULT_THEME = 'light';
+
+  /**
+   * Storage key for the theme.
+   */
+  private readonly IDS_ENTERPRISE_THEME_KEY = 'soho_theme';
+
+  /**
+   * Storage key for the colour.
+   */
+  private readonly IDS_ENTERPRISE_COLOUR_KEY = 'soho_color';
+
+  /**
+   * Initialize the component after Angular first displays the data-bound
+   * properties and sets the any input properties.
+   *
+   * In this case, initialises the data members: "colours" and "themes"
+   * with the currently selected theme/colour respectively.
+   */
+  public ngOnInit(): void {
+    // Get the current values using the getters.
+    const currentTheme = this.personalize.theme = this.theme;
+    const currentColour = this.personalize.colors = this.colour;
+
+    // Make sure only the current theme is marked as selected.
+    this.themes.forEach((theme) => {
+      theme.selected = (theme.value === currentTheme);
+    });
+
+    // Make sure only the current colour is marked as selected.
+    this.colours.forEach((colour) => {
+      // The colour is appearing as a real rgb value, so need to
+      colour.selected = (colour.rgb === currentColour);
+    });
+  }
+
+  /**
+   * Handle the theme change event, by setting it in local storage.
+   *
+   * @todo may want to consider making the persistence of this
+   * configurable, so we could use a state pattern.
+   *
+   * @param ev the personalisation event; never null.
+   */
+  public onChangeTheme(ev: SohoChangeThemePersonalizeEvent) {
+    this.theme = ev.data;
+  }
+
+  /**
+   * Handle the colour change event, by setting is in local storage.
+   *
+   * @todo may want to consider making the persistence of this
+   * configurable, so we could use states.
+   *
+   * @param ev the personalisation event; never null.
+   */
+
+  public onChangeColors(ev: SohoChangeColorsPersonalizeEvent) {
+    this.colour = ev.data;
+  }
+
+  /**
+   * Returns the currently selected theme, defaulting to
+   * a sensible default theme if one is not yet set.
+   */
+  public get theme(): string {
+    const theme = localStorage.getItem(this.IDS_ENTERPRISE_THEME_KEY);
+    return theme ? theme : this.DEFAULT_THEME;
+  }
+
+  /**
+   * Persists the given theme.
+   *
+   * @param themeName the theme name.
+   */
+  public set theme(themeName: string) {
+    localStorage.setItem(this.IDS_ENTERPRISE_THEME_KEY, themeName);
+  }
+
+  /**
+   * Returns the currently selected colour, defaulting to
+   * a sensible default colour if one is not yet set.
+   */
+  public get colour(): string {
+    const color = localStorage.getItem(this.IDS_ENTERPRISE_COLOUR_KEY);
+    return color ? color : this.DEFAULT_COLOUR;
+  }
+
+  /**
+   * Set the current colour, storing it such that it perists between
+   * sessions.
+   */
+  public set colour(colour: string) {
+    localStorage.setItem(this.IDS_ENTERPRISE_COLOUR_KEY, colour);
+  }
+}

--- a/src/app/personalize-menu/theme-color.model.ts
+++ b/src/app/personalize-menu/theme-color.model.ts
@@ -1,0 +1,5 @@
+export class Color {
+  rgb: string;
+  name: string;
+  selected?: boolean;
+}

--- a/src/app/personalize-menu/theme.model.ts
+++ b/src/app/personalize-menu/theme.model.ts
@@ -1,0 +1,5 @@
+export class Theme {
+  name: string;
+  value: string;
+  selected?: boolean;
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added a simple example of a `PersonalizeMenuComponent` to the Demo Application that developers can use in their application as a starting point.

Ultimately, a more complex settings dialog could be added as part of the underlying EP controls.

**Related github/jira issue (required)**:

Closes #424 and #423.

**Steps necessary to review your pull request (required)**:

```sh
npm run build:lib
npm run start
```

Navigate to http://localhost:4200/ids-enterprise-ng-demo.

Ensure the state of the application menu is retained when refreshing the page.

Ensure the "Personalize Menu" on the application menu changes the theme, and the colours.  Also ensure that the settings are retained when refreshing the page.
