### PR TITLE
added isPersonalizable input to soho-app-menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 5.3.0 Features
 
+- [AppMenu] - Added isPersonalizable input for setting the is-personalization class on the EP app-menu element. `PWP`
 - [DataGrid] - Added 'resetColumns' and 'personalizeColumns' to the datagrid component. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))
 - [DataGrid] - Added 'entereditmode', 'exiteditmode' and 'beforeentereditmode' event outputs from component.  `BTHH` ([#410](https://github.com/infor-design/enterprise-ng/issues/410))
 - [PopupMenu] - Added 'isIndented' to soho-popupmenu-item. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,26 +2,23 @@
 
 ## v5.3.0
 
+### 5.3.0 Features
+
+- `[AppMenu]` - Added 'isPersonalizable' input for setting the is-personalization class on the EP app-menu element. `PWP`
+- `[DataGrid]` - Added 'resetColumns' and 'personalizeColumns' to the datagrid component. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))
+- `[DataGrid]` - Added 'entereditmode', 'exiteditmode' and 'beforeentereditmode' event outputs from component.  `BTHH` ([#410](https://github.com/infor-design/enterprise-ng/issues/410))
+- `[Datepicker]` - Adds an example to show custom validation to the datepicker test page. `TJM` ([#411](https://github.com/infor-design/enterprise-ng/issues/411)
+- `[DemoApp]` - Added `PersonalizeMenuComponent` example. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))
+- `[DemoApp]` - Added open status persistence to the demo's application menu. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))
+- `[PopupMenu]` - Added 'isIndented' to soho-popupmenu-item. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))
+
 ### 5.3.0 Fixes
-
-### 5.3.0 Features
-
-- [AppMenu] - Added isPersonalizable input for setting the is-personalization class on the EP app-menu element. `PWP`
-- [DataGrid] - Added 'resetColumns' and 'personalizeColumns' to the datagrid component. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))
-- [DataGrid] - Added 'entereditmode', 'exiteditmode' and 'beforeentereditmode' event outputs from component.  `BTHH` ([#410](https://github.com/infor-design/enterprise-ng/issues/410))
-- [PopupMenu] - Added 'isIndented' to soho-popupmenu-item. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))
-- [Datepicker] - Adds an example to show custom validation to the datepicker test page. `TJM` ([#411](https://github.com/infor-design/enterprise-ng/issues/411)
-
-### 5.3.0 Features
-
-- [DemoApp] - Added `PersonalizeMenuComponent` example. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))
-- [DemoApp] - Added open status persistence to the demo's application menu. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))
 
 ## v5.2.1
 
 ### 5.2.1 Fixes
 
-- [General] - Bug fixes from updating to the latest ids-enteprise package `CRL` ([ids-enterprise@4.17.1](https://github.com/infor-design/enterprise/releases/tag/4.17.1)
+- `[General]` - Bug fixes from updating to the latest ids-enteprise package `CRL` ([ids-enterprise@4.17.1](https://github.com/infor-design/enterprise/releases/tag/4.17.1)
 
 ## v5.2.0
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "classlist.js": "^1.1.20150312",
     "core-js": "^2.5.4",
     "d3": "4.13.0",
-    "ids-enterprise": "4.18.0-dev.20190409",
+    "ids-enterprise": "4.18.0-dev.20190410",
     "jquery": "3.3.1",
     "lscache": "^1.2.0",
     "rxjs": "~6.4.0",

--- a/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.component.ts
@@ -108,9 +108,9 @@ export class SohoApplicationMenuComponent implements AfterViewInit, AfterViewChe
   // Host Bindings
   // -------------------------------------------
 
-  @HostBinding('class') get classes() {
-    return 'application-menu';
-  }
+  @HostBinding('class.application-menu') appMenu = true;
+
+  @HostBinding('class.is-personalizable') @Input() isPersonalizable = false;
 
   /**
    * This will let the Soho controls bind the application menu trigger naturally


### PR DESCRIPTION
- added isPersonalizable input to soho-app-menu
- upped ids-ep version to latest nightly build

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Setting a class on app-menu was not working due to a host binding that would overwrite any classes set prior
