### PR TITLE
2040 - Fixes an issue where the app menu didnt open

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/application-menu/soho-application-menu.component.ts
@@ -292,6 +292,9 @@ export class SohoApplicationMenuComponent implements AfterViewInit, AfterViewChe
       };
 
       // Initialise the SoHoXi control.
+      if (this._triggers.length === 0) {
+        this._triggers.push($('.application-menu-trigger'));
+      }
       this.jQueryElement.applicationmenu(options);
 
       // Once the control is initialised, extract the control


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The app menu trigger did not toggle the menu. Wouldn't mind @EdwardCoyle following up on this one with me. But this fix works.

**Related github/jira issue (required)**:
Fixes NG Part of #2040 

**Steps necessary to review your pull request (required)**:
- pull branch
- npm run build:lib
- npm run start
- go to http://localhost:4200/
- press the hamburger and toggle menu menu (this didnt work)

See also example tweaks in EP https://github.com/infor-design/enterprise/pull/2041
