### PR TITLE
Respect `groupSize` of defined locale in Mask components

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datepicker]` - Adds an example to show custom validation to the datepicker test page. `TJM` ([#411](https://github.com/infor-design/enterprise-ng/issues/411)
 - `[DemoApp]` - Added `PersonalizeMenuComponent` example. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))
 - `[DemoApp]` - Added open status persistence to the demo's application menu. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))
+- `[Mask]` - Respect `groupSize` and other settings of defined locale in Mask components. `PWP` ([Pull Request 468](https://github.com/infor-design/enterprise-ng/pull/468))
 - `[PopupMenu]` - Added 'isIndented' to soho-popupmenu-item. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))
 - `[General]` - Added `data-ids-enterprise-ng-version` to the html tag on module startup. `BTHH` ([Pull Request 438](https://github.com/infor-design/enterprise-ng/pull/438))
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "core-js": "^2.5.4",
     "d3": "4.13.0",
     "fix": "0.0.6",
-    "ids-enterprise": "4.18.0-rc.1",
+    "ids-enterprise": "4.18.0",
     "jquery": "^3.4.0",
     "lscache": "^1.2.0",
     "rxjs": "~6.5.1",

--- a/projects/ids-enterprise-ng/src/lib/input/soho-input.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/input/soho-input.component.ts
@@ -10,7 +10,7 @@ import {
   Output,
   HostListener,
   HostBinding,
-  Input
+  Input, NgZone
 } from '@angular/core';
 
 import {
@@ -53,7 +53,10 @@ export class SohoInputComponent extends BaseControlValueAccessor<string> impleme
    * @param element the owning element.
    * @param changeDetectionRef change detection.
    */
-  constructor(private element: ElementRef) {
+  constructor(
+    private element: ElementRef,
+    private ngZone: NgZone
+  ) {
     super();
   }
 
@@ -112,10 +115,17 @@ export class SohoInputComponent extends BaseControlValueAccessor<string> impleme
       // The processing is required to ensure we use the correct format
       // in the control.
       this.jQueryElement.val(value);
+
+      this.ngZone.runOutsideAngular(
+        () => {
+          setTimeout(() => {
+            this.element.nativeElement.dispatchEvent(new Event('input'));
+          });
+        });
     }
   }
 
-   /**
+ /**
    * This function is called when the control status changes to or from "DISABLED".
    * Depending on the value, it will enable or disable the appropriate DOM element.
    */

--- a/projects/ids-enterprise-ng/src/lib/mask/soho-mask.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/mask/soho-mask.d.ts
@@ -69,6 +69,9 @@ interface SohoMaskPatternOptions {
 
   /** The symbols to use for the formatted number. */
   symbols?: SohoMaskPatternSymbols;
+
+  /** if defined, uses a custom locale string for formatting */
+  locale?: string;
 }
 
 interface SohoMaskPatternSymbols {

--- a/projects/ids-enterprise-ng/src/lib/mask/soho-mask.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/mask/soho-mask.d.ts
@@ -192,7 +192,7 @@ interface SohoMaskStatic {
   settings: SohoMaskOptions;
 
   /** Tears dwn the control and recreates it. */
-  updated(): void;
+  updated(settings?: SohoMaskOptions): void;
 
   /** Destructor. */
   destroy(): void;

--- a/projects/ids-enterprise-ng/src/lib/mask/soho-mask.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/mask/soho-mask.directive.ts
@@ -24,7 +24,7 @@ export class SohoMaskDirective implements AfterViewInit, OnDestroy {
   @Input() set options(value: SohoMaskOptions | string) {
     this._options = (typeof value === 'string') ? JSON.parse(value) : value;
     if (this.mask) {
-      // After the mast has been created do not overwrite the mask.settings.
+      // After the mask has been created do not overwrite the mask.settings.
       // That will cause certain required defaults to go missing out of the mask.settings object.
       // Instead just call updated() with the new _options. The mask-input.js update() function
       // merges the new setting in w/o losing any important default.
@@ -226,7 +226,7 @@ export class SohoMaskDirective implements AfterViewInit, OnDestroy {
     }
   }
 
-  /** The symbols to use for the formatted number. */
+  /** The locale to use for the formatted number. */
   @Input() set locale(value: string) {
     this._options.patternOptions.locale = value;
     if (this.mask) {

--- a/projects/ids-enterprise-ng/src/lib/mask/soho-mask.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/mask/soho-mask.directive.ts
@@ -223,6 +223,15 @@ export class SohoMaskDirective implements AfterViewInit, OnDestroy {
     }
   }
 
+  /** The symbols to use for the formatted number. */
+  @Input() set locale(value: string) {
+    this._options.patternOptions.locale = value;
+    if (this.mask) {
+      this.mask.settings.patternOptions.locale = this._options.patternOptions.locale;
+      this.mask.updated();
+    }
+  }
+
   /** The currency symbol to use for the formatted number. */
   @Input() set currencySymbol(value: string) {
     this._options.patternOptions.symbols.currency = value;

--- a/projects/ids-enterprise-ng/src/lib/mask/soho-mask.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/mask/soho-mask.directive.ts
@@ -24,8 +24,11 @@ export class SohoMaskDirective implements AfterViewInit, OnDestroy {
   @Input() set options(value: SohoMaskOptions | string) {
     this._options = (typeof value === 'string') ? JSON.parse(value) : value;
     if (this.mask) {
-      this.mask.settings = this._options;
-      this.mask.updated();
+      // After the mast has been created do not overwrite the mask.settings.
+      // That will cause certain required defaults to go missing out of the mask.settings object.
+      // Instead just call updated() with the new _options. The mask-input.js update() function
+      // merges the new setting in w/o losing any important default.
+      this.mask.updated(this._options);
     }
   }
 

--- a/src/app/mask/mask.demo.html
+++ b/src/app/mask/mask.demo.html
@@ -1,81 +1,103 @@
 <div class="example-section">
+
+  <div class="row">
+    <h1>Mask</h1>
+    <span class="code-tag">Live Example</span>
+  </div>
+
+  <div class="row">
+    <div class="two-thirds column">
+      <form [formGroup]="demoForm">
+        <div class="field">
+          <label soho-label for="locales">Locales</label>
+          <select soho-dropdown noSearch id="locales" name="locales" formControlName="locale">
+            <option *ngFor="let locale of locales" [value]="locale.value">{{locale.label}}</option>
+          </select>
+        </div>
+        <div class="field">
+          <input soho-textarea [readOnly]="true" value="{{demoForm.controls.locale.value}}"/>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <br/>
+  <hr>
+  <br/>
+
   <form>
     <div class="row">
-      <h1>Mask</h1>
-      <span class="code-tag">Live Example</span>
-      <div class="row">
-        <div class="two columns">
-          <div class="field">
-            <label soho-label for="no-mask-no-model" >No mask, no model</label>
-            <input id="no-mask-no-model" name="no-mask-no-model" alignRight="true" maxlength="5" />
-          </div>
-          <div class="field">
-            <label soho-label for="no-mask" >No mask</label>
-            <input id="no-mask" name="no-mask" alignRight="true" maxlength="5" [(ngModel)]="model.nomask"/>
-          </div>
-          <div class="field">
-            <label soho-label for="alpha-mask" >Alpha-Numeric Mask</label>
-            <input id="alpha-mask" name="alpha-mask"
-              soho-input
-              soho-mask
-              [sohoPattern]="'*****'"
-              maxlength="5"
-              [(ngModel)]="model.alphamask"/>
-          </div>
-          <div class="field">
-            <label soho-label for="custom-mask" >Custom</label>
-            <input id="custom-mask" name="custom-mask" [(ngModel)]="model.custommask" soho-input
-              soho-mask maxlength="5" [definitions]="definitions" [sohoPattern]="'UUU'"/>
-          </div>
+      <div class="two columns">
+        <div class="field">
+          <label soho-label for="no-mask-no-model" >No mask, no model</label>
+          <input id="no-mask-no-model" name="no-mask-no-model" alignRight="true" maxlength="5" />
         </div>
-        <div class="two columns">
-          <div class="field">
-            <label soho-label for="number" >+ Number (3)</label>
-            <input id="number" name="number" alignRight="true" [(ngModel)]="model.number" soho-input
-              soho-mask [process]="'number'" [integerLimit]="3" (write)="onMaskWrite($event)"/>
-          </div>
-          <div class="field">
-            <label soho-label for="decimal" >+ Decimal (6.2)</label>
-            <input id="decimal" name="decimal" alignRight="true" [(ngModel)]="model.decimal" soho-input
-              soho-mask [process]="'number'" [allowThousandsSeparator]="true" [allowDecimal]="true" [integerLimit]="6"
-              [decimalLimit]="2" [symbols]="symbols" (write)="onMaskWrite($event)"/>
-          </div>
-          <div class="field">
-            <label soho-label for="percent" >+ Percent (3.2)</label>
-            <input id="percent" name="percent" alignRight="true" [(ngModel)]="model.percent" soho-input
-              soho-mask [process]="'number'" [allowThousandsSeparator]="true" [allowDecimal]="true" [integerLimit]="3"
-              [decimalLimit]="2" [symbols]="symbols" [suffix]="'%'" (write)="onMaskWrite($event)"/>
-          </div>
-          <div class="field">
-            <label soho-label for="currency" >+ Currency (6.2)</label>
-            <input id="currency" name="currency" alignRight="true" [(ngModel)]="model.currency" soho-input
-              soho-mask [process]="'number'" [allowThousandsSeparator]="true" [allowDecimal]="true" [integerLimit]="6"
-              [decimalLimit]="2" [symbols]="symbols" [prefix]="'$'" (write)="onMaskWrite($event)"/>
-          </div>
+        <div class="field">
+          <label soho-label for="no-mask" >No mask</label>
+          <input id="no-mask" name="no-mask" alignRight="true" maxlength="5" [(ngModel)]="model.nomask"/>
         </div>
-        <div class="two columns">
-          <div class="field">
-            <label soho-label for="signed-number" >+- Number (3)</label>
-            <input id="signed-number" name="signed-number" alignRight="true" [(ngModel)]="model.signednumber" soho-input
-              soho-mask [process]="'number'" [integerLimit]="3" [allowNegative]="true" [symbols]="symbols" (write)="onMaskWrite($event)"/>
-          </div>
-          <div class="field">
-            <label soho-label for="signed-decimal" >+- Decimal (6.2)</label>
-            <input id="signed-decimal" name="signed-decimal" alignRight="true" [(ngModel)]="model.signeddecimal" soho-input
-              soho-mask [options]="options" (write)="onMaskWrite($event)"/>
-          </div>
-          <div class="field">
-            <label soho-label for="signed-percent" >+- Percent (3.2)</label>
-            <input id="signed-percent" name="signed-percent" alignRight="true" [(ngModel)]="model.signedpercent" soho-input
-              soho-mask [process]="'number'" [allowNegative]="true" [allowThousandsSeparator]="true" [allowDecimal]="true"
-              [integerLimit]="3" [decimalLimit]="2" [symbols]="symbols" [suffix]="'%'" (write)="onMaskWrite($event)"/>
-          </div>
-          <div class="field">
-            <label soho-label for="signed-currency" >+- Currency (6.2)</label>
-            <input id="signed-currency" name="signed-currency" alignRight="true" [(ngModel)]="model.signedcurrency" soho-input
-              soho-mask [process]="'number'" [allowNegative]="true" [allowThousandsSeparator]="true" [allowDecimal]="true"
-              [integerLimit]="6" [decimalLimit]="2" [symbols]="symbols" [prefix]="'$'" [pipe]="pipe" (write)="onMaskWrite($event)"/>
-          </div>
+        <div class="field">
+          <label soho-label for="alpha-mask" >Alpha-Numeric Mask</label>
+          <input id="alpha-mask" name="alpha-mask"
+            soho-input
+            soho-mask
+            [sohoPattern]="'*****'"
+            maxlength="5"
+            [(ngModel)]="model.alphamask"/>
+        </div>
+        <div class="field">
+          <label soho-label for="custom-mask" >Custom</label>
+          <input id="custom-mask" name="custom-mask" [(ngModel)]="model.custommask" soho-input
+            soho-mask maxlength="5" [definitions]="definitions" [sohoPattern]="'UUU'"/>
+        </div>
+      </div>
+      <div class="two columns">
+        <div class="field">
+          <label soho-label for="number" >+ Number (3)</label>
+          <input id="number" name="number" alignRight="true" [(ngModel)]="model.number" soho-input
+            soho-mask [process]="'number'" [integerLimit]="3" (write)="onMaskWrite($event)"/>
+        </div>
+        <div class="field">
+          <label soho-label for="decimal" >+ Decimal (6.2)</label>
+          <input id="decimal" name="decimal" alignRight="true" [(ngModel)]="model.decimal" soho-input
+            soho-mask [process]="'number'" [allowThousandsSeparator]="true" [allowDecimal]="true" [integerLimit]="6"
+            [decimalLimit]="2" [symbols]="symbols" (write)="onMaskWrite($event)"/>
+        </div>
+        <div class="field">
+          <label soho-label for="percent" >+ Percent (3.2)</label>
+          <input id="percent" name="percent" alignRight="true" [(ngModel)]="model.percent" soho-input
+            soho-mask [process]="'number'" [allowThousandsSeparator]="true" [allowDecimal]="true" [integerLimit]="3"
+            [decimalLimit]="2" [symbols]="symbols" [suffix]="'%'" (write)="onMaskWrite($event)"/>
+        </div>
+        <div class="field">
+          <label soho-label for="currency" >+ Currency (6.2)</label>
+          <input id="currency" name="currency" alignRight="true" [(ngModel)]="model.currency" soho-input
+            soho-mask [process]="'number'" [allowThousandsSeparator]="true" [allowDecimal]="true" [integerLimit]="6"
+            [decimalLimit]="2" [symbols]="symbols" [prefix]="'$'" (write)="onMaskWrite($event)"/>
+        </div>
+      </div>
+      <div class="two columns">
+        <div class="field">
+          <label soho-label for="signed-number" >+- Number (3)</label>
+          <input id="signed-number" name="signed-number" alignRight="true" [(ngModel)]="model.signednumber" soho-input
+            soho-mask [process]="'number'" [integerLimit]="3" [allowNegative]="true" [symbols]="symbols" (write)="onMaskWrite($event)"/>
+        </div>
+        <div class="field">
+          <label soho-label for="signed-decimal" >+- Decimal (9.2) (uses Locale)</label>
+          <input id="signed-decimal" name="signed-decimal" alignRight="true" [(ngModel)]="model.signeddecimal" soho-input
+            soho-mask [options]="options" (write)="onMaskWrite($event)"/>
+        </div>
+        <div class="field">
+          <label soho-label for="signed-percent" >+- Percent (3.2)</label>
+          <input id="signed-percent" name="signed-percent" alignRight="true" [(ngModel)]="model.signedpercent" soho-input
+            soho-mask [process]="'number'" [allowNegative]="true" [allowThousandsSeparator]="true" [allowDecimal]="true"
+            [integerLimit]="3" [decimalLimit]="2" [symbols]="symbols" [suffix]="'%'" (write)="onMaskWrite($event)"/>
+        </div>
+        <div class="field">
+          <label soho-label for="signed-currency" >+- Currency (9.2) (uses Locale)</label>
+          <input id="signed-currency" name="signed-currency" alignRight="true" [(ngModel)]="model.signedcurrency" soho-input
+            soho-mask [process]="'number'" [allowNegative]="true" [allowThousandsSeparator]="true" [allowDecimal]="true"
+            [integerLimit]="9" [decimalLimit]="2" [locale]="model.locale" (write)="onMaskWrite($event)"/>
         </div>
       </div>
     </div>

--- a/src/app/mask/mask.demo.html
+++ b/src/app/mask/mask.demo.html
@@ -5,26 +5,6 @@
     <span class="code-tag">Live Example</span>
   </div>
 
-  <div class="row">
-    <div class="two-thirds column">
-      <form [formGroup]="demoForm">
-        <div class="field">
-          <label soho-label for="locales">Locales</label>
-          <select soho-dropdown noSearch id="locales" name="locales" formControlName="locale">
-            <option *ngFor="let locale of locales" [value]="locale.value">{{locale.label}}</option>
-          </select>
-        </div>
-        <div class="field">
-          <input soho-textarea [readOnly]="true" value="{{demoForm.controls.locale.value}}"/>
-        </div>
-      </form>
-    </div>
-  </div>
-
-  <br/>
-  <hr>
-  <br/>
-
   <form>
     <div class="row">
       <div class="two columns">
@@ -76,6 +56,8 @@
             [decimalLimit]="2" [symbols]="symbols" [prefix]="'$'" (write)="onMaskWrite($event)"/>
         </div>
       </div>
+
+
       <div class="two columns">
         <div class="field">
           <label soho-label for="signed-number" >+- Number (3)</label>
@@ -83,8 +65,8 @@
             soho-mask [process]="'number'" [integerLimit]="3" [allowNegative]="true" [symbols]="symbols" (write)="onMaskWrite($event)"/>
         </div>
         <div class="field">
-          <label soho-label for="signed-decimal" >+- Decimal (9.2) (uses Locale)</label>
-          <input id="signed-decimal" name="signed-decimal" alignRight="true" [(ngModel)]="model.signeddecimal" soho-input
+          <label soho-label for="signed-decimal" >+- Decimal (9.2)</label>
+          <input #MaskField id="signed-decimal" name="signed-decimal" alignRight="true" [(ngModel)]="model.signeddecimal" soho-input
             soho-mask [options]="options" (write)="onMaskWrite($event)"/>
         </div>
         <div class="field">
@@ -94,12 +76,51 @@
             [integerLimit]="3" [decimalLimit]="2" [symbols]="symbols" [suffix]="'%'" (write)="onMaskWrite($event)"/>
         </div>
         <div class="field">
-          <label soho-label for="signed-currency" >+- Currency (9.2) (uses Locale)</label>
+          <label soho-label for="signed-currency" >+- Currency (9.2)</label>
           <input id="signed-currency" name="signed-currency" alignRight="true" [(ngModel)]="model.signedcurrency" soho-input
             soho-mask [process]="'number'" [allowNegative]="true" [allowThousandsSeparator]="true" [allowDecimal]="true"
-            [integerLimit]="9" [decimalLimit]="2" [locale]="model.locale" (write)="onMaskWrite($event)"/>
+            [integerLimit]="9" [decimalLimit]="2" (write)="onMaskWrite($event)"/>
         </div>
       </div>
+
+      <div class="row">
+        <br/>
+        <hr>
+        <br/>
+      </div>
+
+      <div class="row">
+        <div class="two-thirds column">
+          <form [formGroup]="demoForm">
+            <div class="field">
+              <label soho-label for="locales">Locales</label>
+              <select soho-dropdown noSearch id="locales" name="locales" formControlName="locale">
+                <option *ngFor="let locale of locales" [value]="locale.value">{{locale.label}}</option>
+              </select>
+            </div>
+            <div class="field">
+              <input soho-textarea [readOnly]="true" value="{{demoForm.controls.locale.value}}"/>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="two-thirds column">
+          <div class="field">
+            <label soho-label for="signed-decimal-locale" >+- Decimal (9.2) (uses options.Locale)</label>
+            <input id="signed-decimal-locale" name="signed-decimal-locale" alignRight="true" [(ngModel)]="model.signeddecimal" soho-input
+              soho-mask [options]="options" (write)="onMaskWrite($event)"/>
+          </div>
+          <div class="field">
+            <label soho-label for="signed-currency-locale" >+- Currency (9.2) (uses input Locale)</label>
+            <input id="signed-currency-locale" name="signed-currency-locale" alignRight="true" [(ngModel)]="model.signedcurrency" soho-input
+              soho-mask [process]="'number'" [allowNegative]="true" [allowThousandsSeparator]="true" [allowDecimal]="true"
+              [integerLimit]="9" [decimalLimit]="2" [locale]="model.locale" (write)="onMaskWrite($event)"/>
+          </div>
+        </div>
+      </div>
+
     </div>
   </form>
   <button soho-button (click)="toggleModel()">{{showModel ? 'Hide' : 'Show'}} Model</button>

--- a/src/app/mask/mask.demo.ts
+++ b/src/app/mask/mask.demo.ts
@@ -38,7 +38,6 @@ export class MaskDemoComponent {
     { value: 'es-US', label: 'Spanish (American)' }
   ];
 
-
   public model = {
     locale:               'en-US',
     nomask:               '123456',

--- a/src/app/mask/mask.demo.ts
+++ b/src/app/mask/mask.demo.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostBinding, Input, NgZone } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  HostBinding,
+  Input,
+  NgZone
+} from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
 /**
@@ -33,14 +40,14 @@ export class MaskDemoComponent {
 
 
   public model = {
-    locale: '',
+    locale:               'en-US',
     nomask:               '123456',
     number:               '123',
     decimal:              '123456.78',
     percent:              '85.23',
     currency:             '876543.21',
     signednumber:         '-123',
-    signeddecimal:        '-123456.78',
+    signeddecimal:        '-1234567.89',
     signedpercent:        '-85.23',
     signedcurrency:       '-9876543.21',
     alphamask:            'abc12',
@@ -59,7 +66,7 @@ export class MaskDemoComponent {
     integerLimit: 9,
     decimalLimit: 2,
     symbols: this._symbols,
-    locale: 'es-US'
+    locale: 'en-US'
   };
   private _options: SohoMaskOptions = {
     process: 'number',
@@ -97,24 +104,21 @@ export class MaskDemoComponent {
         // of angular ...
         this.ngZone.runOutsideAngular(() => {
           // ... setting the locale, and waiting for the locale to load ...
-          Soho.Locale.set(value).done(
-            () => {
-              // ... once loaded, back into the angular zone ...
-              this.ngZone.run(
-                () => {
-                  // ... update the display to ensure all controls are updated with the
-                  // new locale.
-                  this.model.locale = value;
+          Soho.Locale.set(value).done(() => {
+            // ... once loaded, back into the angular zone ...
+            this.ngZone.run(() => {
+              // ... update the display to ensure all controls are updated with the
+              // new locale.
+              this.model.locale = value;
 
-                  // todo: updating the options object causes the MaskAPI to be lost.
-                  // mast-input.js init() adds the MastAPI but calling updated(settings) does not.
-                  // this._options.patternOptions.locale = value;
-                  // this._options = Object.assign({}, this._options);
+              // todo: updating the options object causes the MaskAPI to be lost.
+              // mast-input.js init() adds the MastAPI but calling updated(settings) does not.
+              this._options.patternOptions.locale = value;
+              this._options = Object.assign({}, this._options);
 
-                  this.ref.markForCheck();
-                }
-              );
+              this.ref.markForCheck();
             });
+          });
         });
       }
     });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added in locale setting so that mask patterns for numeric fields can be applied.
Fixed issue where mask was not initially being applied.

**Related github/jira issue (required)**:
Closes #464 

**Steps necessary to review your pull request (required)**:
- npm run start
- go to localhost:4200/ids-enterprise-ng-demo/mask
- make sure masks are applied
