### PR TITLE
465 codeblock tooltip

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[AppMenu]` - Added new settings for application menu switcher expand/collapse. `VW` ([#443](https://github.com/infor-design/enterprise-ng/issues/443))
 - `[DataGrid]` - Added 'resetColumns' and 'personalizeColumns' to the datagrid component. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))
 - `[DataGrid]` - Added 'entereditmode', 'exiteditmode' and 'beforeentereditmode' event outputs from component.  `BTHH` ([#410](https://github.com/infor-design/enterprise-ng/issues/410))
+- `[DataGrid]` - Added NG support for EP tooltip callback function .  `PWP` ([#470](https://github.com/infor-design/enterprise-ng/pull/470))
 - `[Datepicker]` - Adds an example to show custom validation to the datepicker test page. `TJM` ([#411](https://github.com/infor-design/enterprise-ng/issues/411)
 - `[DemoApp]` - Added `PersonalizeMenuComponent` example. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))
 - `[DemoApp]` - Added open status persistence to the demo's application menu. `BTHH` ([Pull Request 425](https://github.com/infor-design/enterprise-ng/pull/425))

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -755,6 +755,9 @@ interface SohoDataGridColumn {
 
   /** If false the column will be disabled in personalization dialog */
   hideable?: boolean;
+
+  /** call back to handle custom tooltips for the column header */
+  tooltip?: (cell: number, value: any) => string;
 }
 
 interface SohoDataGridColumnNumberFormat {

--- a/src/app/datagrid/datagrid-code-block-editor.demo.ts
+++ b/src/app/datagrid/datagrid-code-block-editor.demo.ts
@@ -259,10 +259,11 @@ export const COLUMNS: SohoDataGridColumn[] = [
     editor: Soho.Editors.Input
   },
 
-  { id: 'codeBlock', name: 'Code Block',
+  { id: 'codeBlock',
+    name: 'Code Block',
+    field: 'codeBlock',
     sortable: false,
     formatter: CodeBlockFormatter,
-    field: 'codeBlock',
     filterType: 'text',
     expandOnActivate: true,
     textOverflow: 'ellipsis',

--- a/src/app/datagrid/datagrid-code-block-editor.demo.ts
+++ b/src/app/datagrid/datagrid-code-block-editor.demo.ts
@@ -218,16 +218,24 @@ export class CodeBlockEditorComponent  implements SohoDataGridCellEditor {
   styleUrls: ['../code-block/code-block.formatter.css']
 })
 export class DataGridCodeBlockEditorDemoComponent implements OnInit {
-  gridOptions = null;
+  gridOptions: SohoDataGridOptions = null;
 
   ngOnInit(): void {
+    const tooltipCallback = (cell: number, value: any): string => {
+      return 'Test: ' + value;
+    };
+
+    COLUMNS[1].tooltip = tooltipCallback;
+    COLUMNS[2].tooltip = tooltipCallback;
+
     this.gridOptions = {
       columns: COLUMNS, // tslint:disable-line
       dataset: CODE_BLOCK_DATA,
       selectable: 'single',
       idProperty: 'productId',
       editable: true,
-      filterable: true
+      filterable: true,
+      enableTooltips: true
     };
   }
 }
@@ -254,6 +262,7 @@ export const COLUMNS: SohoDataGridColumn[] = [
   { id: 'codeBlock', name: 'Code Block',
     sortable: false,
     formatter: CodeBlockFormatter,
+    field: 'codeBlock',
     filterType: 'text',
     expandOnActivate: true,
     textOverflow: 'ellipsis',

--- a/src/app/datagrid/datagrid-code-block-editor.demo.ts
+++ b/src/app/datagrid/datagrid-code-block-editor.demo.ts
@@ -212,34 +212,6 @@ export class CodeBlockEditorComponent  implements SohoDataGridCellEditor {
   }
 }
 
-@Component({
-  selector: 'app-datagrid-code-block-editor',
-  templateUrl: './datagrid-code-block-editor.demo.html',
-  styleUrls: ['../code-block/code-block.formatter.css']
-})
-export class DataGridCodeBlockEditorDemoComponent implements OnInit {
-  gridOptions: SohoDataGridOptions = null;
-
-  ngOnInit(): void {
-    const tooltipCallback = (cell: number, value: any): string => {
-      return 'Test: ' + value;
-    };
-
-    COLUMNS[1].tooltip = tooltipCallback;
-    COLUMNS[2].tooltip = tooltipCallback;
-
-    this.gridOptions = {
-      columns: COLUMNS, // tslint:disable-line
-      dataset: CODE_BLOCK_DATA,
-      selectable: 'single',
-      idProperty: 'productId',
-      editable: true,
-      filterable: true,
-      enableTooltips: true
-    };
-  }
-}
-
 export const COLUMNS: SohoDataGridColumn[] = [
   {
     id: 'companyId',
@@ -271,3 +243,31 @@ export const COLUMNS: SohoDataGridColumn[] = [
     editorComponentInputs: {}
   }
 ];
+
+@Component({
+  selector: 'app-datagrid-code-block-editor',
+  templateUrl: './datagrid-code-block-editor.demo.html',
+  styleUrls: ['../code-block/code-block.formatter.css']
+})
+export class DataGridCodeBlockEditorDemoComponent implements OnInit {
+  gridOptions: SohoDataGridOptions = null;
+
+  ngOnInit(): void {
+    const tooltipCallback = (cell: number, value: any): string => {
+      return 'Test: ' + value;
+    };
+
+    COLUMNS[1].tooltip = tooltipCallback;
+    COLUMNS[2].tooltip = tooltipCallback;
+
+    this.gridOptions = {
+      columns: COLUMNS, // tslint:disable-line
+      dataset: CODE_BLOCK_DATA,
+      selectable: 'single',
+      idProperty: 'productId',
+      editable: true,
+      filterable: true,
+      enableTooltips: true
+    };
+  }
+}

--- a/src/app/demodata/code-block-data.ts
+++ b/src/app/demodata/code-block-data.ts
@@ -7,7 +7,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'location': 'Terrencefort, TX',
     'contact': 'Lida Snyder',
     'customerSince': '04/25/2016',
-    'favorite': true
+    'favorite': true,
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 2,
@@ -16,7 +17,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '702-389-9973',
     'location': 'Davontemouth, UT',
     'contact': 'Bull Cunningham',
-    'customerSince': '05/02/2016'
+    'customerSince': '05/02/2016',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 3,
@@ -26,7 +28,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'location': 'Hermistonhaven, AZ',
     'contact': 'Johnny Fields',
     'customerSince': '08/28/2016',
-    'favorite': true
+    'favorite': true,
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 4,
@@ -35,7 +38,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '299-166-7016',
     'location': 'North Beau, NV',
     'contact': 'Nina Mendez',
-    'customerSince': '01/25/2015'
+    'customerSince': '01/25/2015',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 5,
@@ -44,7 +48,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '299-166-7016',
     'location': 'New Abdul, TX',
     'contact': 'Paul Strayer',
-    'customerSince': '04/21/2016'
+    'customerSince': '04/21/2016',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 6,
@@ -53,7 +58,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '299-166-7067',
     'location': 'Smithsville, UT',
     'contact': 'John Nasmith',
-    'customerSince': '06/25/2016'
+    'customerSince': '06/25/2016',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 7,
@@ -62,7 +68,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '202-504-5299',
     'location': 'Ryesmith, AK',
     'contact': 'Spring Adams',
-    'customerSince': '07/25/2015'
+    'customerSince': '07/25/2015',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 8,
@@ -72,7 +79,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'location': 'Lancaster, TX',
     'contact': 'Mary Adams',
     'customerSince': '04/25/2016',
-    'favorite': true
+    'favorite': true,
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 9,
@@ -81,7 +89,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '202-389-9973',
     'location': 'Shark City, UT',
     'contact': 'Donald Cunningham',
-    'customerSince': '05/01/2016'
+    'customerSince': '05/01/2016',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 10,
@@ -91,7 +100,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'location': 'Hermistonhaven, AZ',
     'contact': 'Johnny Smith',
     'customerSince': '08/21/2016',
-    'favorite': true
+    'favorite': true,
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 11,
@@ -100,7 +110,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '299-166-7016',
     'location': 'North Beau, NV',
     'contact': 'Paulo Mendez',
-    'customerSince': '03/25/2014'
+    'customerSince': '03/25/2014',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 12,
@@ -109,7 +120,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '299-126-7016',
     'location': 'New Manilla, TX',
     'contact': 'Paul Strayer',
-    'customerSince': '04/21/2016'
+    'customerSince': '04/21/2016',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 13,
@@ -118,7 +130,8 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '399-166-7067',
     'location': 'Joanestown, UT',
     'contact': 'Andy Nasmith',
-    'customerSince': '06/25/2015'
+    'customerSince': '06/25/2015',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   },
   {
     'id': 14,
@@ -127,6 +140,7 @@ export const CODE_BLOCK_DATA: any[] = [
     'phone': '202-504-5299',
     'location': 'River Ridge, PA',
     'contact': 'Winter Adams',
-    'customerSince': '01/25/2015'
+    'customerSince': '01/25/2015',
+    'codeBlock': 'CORE-1001-99 CORP-102-102'
   }
 ];


### PR DESCRIPTION
Datagrid column contains a CodeBlockFormatter and a CodeBlockEditor. The grid has the option of enableTooltips set to true. The tooltip for the column is incorrect.

**Related github/jira issue (required)**:
closes #465

**Steps necessary to review your pull request (required)**:
- Go to the 'datagrid-code-block-editor' demo in ng app
- Mouse hover over a Code Block cell to display the cell tooltip
