### PR TITLE
confirm icon name was changed to success in EP

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # What's New with Enterprise-NG
 
+## v5.4.0
+
+### 5.4.0 Features
+
+### 5.4.0 Fixes
+
+- `[Icons]` - Change name of icon 'confirm' to 'success' to match breaking change made in EP. `PWP` ([#477](https://github.com/infor-design/enterprise-ng/pull/477))
+    - See EP changelog for more details -  https://github.com/infor-design/enterprise/blob/master/docs/CHANGELOG.md#v4150-fixes
+
 ## v5.3.0
 
 ### 5.3.0 Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 5.4.0 Fixes
 
 - `[Icons]` - Change name of icon 'confirm' to 'success' to match breaking change made in EP. `PWP` ([#477](https://github.com/infor-design/enterprise-ng/pull/477))
-    - See EP changelog for more details -  https://github.com/infor-design/enterprise/blob/master/docs/CHANGELOG.md#v4150-fixes
+    - See [EP 4.15.0 changelog](https://github.com/infor-design/enterprise/blob/master/docs/CHANGELOG.md#v4150-fixes) for more details
 
 ## v5.3.0
 

--- a/src/app/icon/icon.demo.html
+++ b/src/app/icon/icon.demo.html
@@ -391,7 +391,7 @@
   <div class="twelve columns space-icons">
 
     <svg soho-icon icon="empty-generic" [isEmptyState]="true"></svg>
-    <svg soho-icon icon="empty-error-loading" [isEmptyState]="true"></svg>z
+    <svg soho-icon icon="empty-error-loading" [isEmptyState]="true"></svg>
     <svg soho-icon icon="empty-new-project" [isEmptyState]="true"></svg>
     <svg soho-icon icon="empty-no-alerts" [isEmptyState]="true"></svg>
     <svg soho-icon icon="empty-no-analytics" [isEmptyState]="true"></svg>
@@ -414,10 +414,9 @@
 <div class="row">
   <div class="twelve columns space-icons">
 
-    <svg soho-icon icon="confirm" alert="true"></svg>
+    <svg soho-icon icon="success" alert="true"></svg>
     <svg soho-icon icon="alert" alert="true"></svg>
     <svg soho-icon icon="empty-circle" alert="true"></svg>
-    <svg soho-icon icon="dirty" alert="true"></svg>
     <svg soho-icon icon="error" alert="true"></svg>
     <svg soho-icon icon="info" alert="true"></svg>
     <svg soho-icon icon="pending" alert="true"></svg>

--- a/src/app/stepprocess/stepprocess-data-driven.demo.html
+++ b/src/app/stepprocess/stepprocess-data-driven.demo.html
@@ -10,14 +10,14 @@
 
       <li soho-step-list-item *ngIf="step.content">
         <a soho-step-list-item-anchor stepId="{{step.id}}">
-          <svg soho-icon icon="{{step.icon}}"></svg>
+          <svg soho-icon icon="{{step.icon}}" alert="true"></svg>
           <span soho-step-list-item-title>{{step.title}}</span>
         </a>
       </li>
 
       <li soho-step-list-item *ngIf="!step.content">
         <a soho-step-list-item-anchor stepId="{{step.id}}" *ngIf="step.substeps">
-          <svg soho-icon icon="{{step.icon}}"></svg>
+          <svg soho-icon icon="{{step.icon}}" alert="true"></svg>
           <span soho-step-list-item-title>{{step.title}}</span>
           <svg soho-icon icon="caret-down" class="icon-tree"></svg>
         </a>

--- a/src/app/stepprocess/stepprocess-data-driven.demo.ts
+++ b/src/app/stepprocess/stepprocess-data-driven.demo.ts
@@ -26,18 +26,18 @@ export class StepProcessDataDrivenDemoComponent implements OnInit, AfterViewInit
           { id: 'step1Sub2', title: 'Step 1 Sub 2', icon:'empty-circle', content: 'Step 1 Sub 2 content' }, // tslint:disable-line
         ]
       }, // tslint:disable-line
-      { id: 'step2', title: 'Step 2', icon: 'confirm', content: 'Step 2 content' }, // tslint:disable-line
+      { id: 'step2', title: 'Step 2', icon: 'success', content: 'Step 2 content' }, // tslint:disable-line
       { id: 'step3', title: 'Step 3', icon: 'empty-circle',
         substeps: [
           { id: 'step3Sub1', title: 'Step 3 Sub 1', icon:'empty-circle', content: 'Step 3 Sub 1 content' }, // tslint:disable-line
           { id: 'step3Sub2', title: 'Step 3 Sub 2', icon:'error', content: 'Step 3 Sub 2 content' }, // tslint:disable-line
-          { id: 'step3Sub3', title: 'Step 3 Sub 3', icon:'confirm', content: 'Step 3 Sub 3 content' }, // tslint:disable-line
+          { id: 'step3Sub3', title: 'Step 3 Sub 3', icon:'success', content: 'Step 3 Sub 3 content' }, // tslint:disable-line
         ]
       }, // tslint:disable-line
       { id: 'step4', title: 'Step 4', icon: 'empty-circle', content: 'Step 4 content' }, // tslint:disable-line
       { id: 'step5', title: 'Step 5', icon: 'half-empty-circle',
         substeps: [
-          { id: 'step5Sub1', title: 'Step 5 Sub 1', icon:'confirm', content: 'Step 5 Sub 1 content' }, // tslint:disable-line
+          { id: 'step5Sub1', title: 'Step 5 Sub 1', icon:'success', content: 'Step 5 Sub 1 content' }, // tslint:disable-line
           { id: 'step5Sub2', title: 'Step 5 Sub 2', icon:'empty-circle', content: 'Step 5 Sub 2 content' }, // tslint:disable-line
           { id: 'step5Sub3', title: 'Step 5 Sub 3', icon:'error', content: 'Step 5 Sub 3 content' }, // tslint:disable-line
           { id: 'step5Sub4', title: 'Step 5 Sub 4', icon:'empty-circle', content: 'Step 5 Sub 4 content' }, // tslint:disable-line
@@ -46,8 +46,8 @@ export class StepProcessDataDrivenDemoComponent implements OnInit, AfterViewInit
         ] }, // tslint:disable-line
       { id: 'step6', title: 'Step 6', icon:'empty-circle', content: 'Step 6 content' }, // tslint:disable-line
       { id: 'step7', title: 'Step 7', icon:'error', content: 'Step 7 content' }, // tslint:disable-line
-      { id: 'step8', title: 'Step 8', icon:'confirm', content: 'Step 8 content' }, // tslint:disable-line
-      { id: 'step9', title: 'Step 9', icon:'confirm', content: 'Step 9 content' }, // tslint:disable-line
+      { id: 'step8', title: 'Step 8', icon:'success', content: 'Step 8 content' }, // tslint:disable-line
+      { id: 'step9', title: 'Step 9', icon:'success', content: 'Step 9 content' }, // tslint:disable-line
     ];
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Change name of icon 'confirm' to 'success' to match breaking change made in EP

**Related github/jira issue (required)**:
closes #476

**Steps necessary to review your pull request (required)**:
- open ng demo app 
- in menu open - I > Icons
- scroll to bottom, icon with checkmark should be green
