### PR TITLE
2140 - Fixed error was showing when destroy context menu with datagrid

### DIFF
--- a/src/app/datagrid/datagrid-service.demo.ts
+++ b/src/app/datagrid/datagrid-service.demo.ts
@@ -28,7 +28,12 @@ export class DataGridServiceDemoComponent {
   }
 
   onSelected(e: SohoDataGridSelectedEvent) {
-    this.toastService.show({title: 'Selected', message: `${e.rows[0].data.productId}`});
+    if (e.rows && e.rows.length) {
+      this.toastService.show({
+        title: 'Selected',
+        message: e.rows.map(row => row.data ? row.data.productId : false).join(', ')
+      });
+    }
   }
 
   onOpenFilterRow(e: SohoDataGridOpenFilterRowEvent) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed error was showing when destroy context menu with datagrid.

**Related github/jira issue (required)**:
Closes infor-design/enterprise#2140
Related infor-design/enterprise-ng#392

**Steps necessary to review your pull request (required)**:
- After merge https://github.com/infor-design/enterprise/pull/2133
- Pull branch and run app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-service
- Open developer tools
- Scroll over to the `Action` column
- Click any button `...` to open a menu
- Select `Action One` item and see console one event fire
- Do it again, should fire only one event every time
- Also see console there should not be any error
