### PR TITLE
494 added getModifiedRows() and setDirtyIndicator() functions to datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 5.4.0 Features
 
 - `[Personalize]` - Changed soho-personalize directive to include theme and personalization color information. `PWP` ([#493](https://github.com/infor-design/enterprise-ng/pull/493))
+- `[DataGrid]` - Added `getModifiers()` and `setSortIndicator()` functions to datagrid. `PWP` ([#495](https://github.com/infor-design/enterprise-ng/issues/495))
 
 ### 5.4.0 Fixes
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1418,7 +1418,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   /**
    * Return an array containing all of the currently modified rows, the type of modification
    * and the cells that are dirty and the data.
-   * @returns {array} An array showing the dirty row info.
+   * @returns An keyed object showing the dirty row info.
    */
   getModifiedRows(): SohoDataGridModifiedRows {
     return this.ngZone.runOutsideAngular(() => {
@@ -1428,14 +1428,14 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
 
   /**
    * Set a cell to dirty and add the dirty icon visually.
-   * @param {number} row The row index
-   * @param {number} cell The cell index
-   * @param {boolean} toggle True to set it and false to remove it
+   * @param row The row index
+   * @param cell The cell index
+   * @param toggle True to set it and false to remove it
    */
   setDirtyIndicator(row: number, cell: number, toggle: boolean): void {
     this.ngZone.runOutsideAngular(() => {
       this.datagrid.setDirtyIndicator(row, cell, toggle);
-    })
+    });
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1416,6 +1416,29 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   /**
+   * Return an array containing all of the currently modified rows, the type of modification
+   * and the cells that are dirty and the data.
+   * @returns {array} An array showing the dirty row info.
+   */
+  getModifiedRows(): SohoDataGridModifiedRows {
+    return this.ngZone.runOutsideAngular(() => {
+      return this.datagrid.getModifiedRows();
+    });
+  }
+
+  /**
+   * Set a cell to dirty and add the dirty icon visually.
+   * @param {number} row The row index
+   * @param {number} cell The cell index
+   * @param {boolean} toggle True to set it and false to remove it
+   */
+  setDirtyIndicator(row: number, cell: number, toggle: boolean): void {
+    this.ngZone.runOutsideAngular(() => {
+      this.datagrid.setDirtyIndicator(row, cell, toggle);
+    })
+  }
+
+  /**
    * Removes all selected rows
    */
   removeSelected() {

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -281,6 +281,28 @@ interface SohoDataGridOptions {
   allowChildExpandOnMatch?: boolean;
 }
 
+type SohoDataGridModifiedRows = { [index: number]: SohoDataGridModifiedRow };
+
+/**
+ * returned by getModifiedRows
+ */
+interface SohoDataGridModifiedRow {
+  data: any;
+  row: number;
+  type: 'dirty' | 'in-progress' | 'error';
+  cells: SohoDataGridDirtyCell[];
+}
+
+
+interface SohoDataGridDirtyCell {
+  value: any;
+  coercedVal: any;
+  escapedCoercedVal: any;
+  cellNodeText: string;
+  cell: number;
+  column: SohoDataGridColumn;
+}
+
 /**
  * Soho Data Grid Paging Options.
  *
@@ -1008,6 +1030,21 @@ interface SohoDataGridStatic {
    * @param tooltip - string value for tooltip message e.g. 'Error'
    */
   rowStatus(idx: number, status: string, tooltip: string): void;
+
+  /**
+   * Return an array containing all of the currently modified rows, the type of modification
+   * and the cells that are dirty and the data.
+   * @returns {array} An array showing the dirty row info.
+   */
+  getModifiedRows(): SohoDataGridModifiedRows;
+
+  /**
+   * Set a cell to dirty and add the dirty icon visually.
+   * @param {number} row The row index
+   * @param {number} cell The cell index
+   * @param {boolean} toggle True to set it and false to remove it
+   */
+  setDirtyIndicator(row: number, cell: number, toggle: boolean): void;
 
   /**
    * Returns the row dom jQuery node.

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -1034,15 +1034,15 @@ interface SohoDataGridStatic {
   /**
    * Return an array containing all of the currently modified rows, the type of modification
    * and the cells that are dirty and the data.
-   * @returns {array} An array showing the dirty row info.
+   * @returns An array showing the dirty row info.
    */
   getModifiedRows(): SohoDataGridModifiedRows;
 
   /**
    * Set a cell to dirty and add the dirty icon visually.
-   * @param {number} row The row index
-   * @param {number} cell The cell index
-   * @param {boolean} toggle True to set it and false to remove it
+   * @param row The row index
+   * @param cell The cell index
+   * @param toggle True to set it and false to remove it
    */
   setDirtyIndicator(row: number, cell: number, toggle: boolean): void;
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
@@ -350,6 +350,26 @@ describe('Soho DataGrid Unit Tests', () => {
     expect(comp.showDirty).toBeTruthy();
   });
 
+  it('check getModifiedRows', () => {
+    fixture.detectChanges();
+
+    const spy = spyOn((comp as any).datagrid, 'getModifiedRows');
+
+    comp.getModifiedRows();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('check setDirtyIndicator', () => {
+    fixture.detectChanges();
+
+    const spy = spyOn((comp as any).datagrid, 'setDirtyIndicator');
+
+    comp.setDirtyIndicator(0, 4, true);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
   it('check virtualized', () => {
     // fixture.detectChanges();
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
expose 2 methods from ep change to manage dirty indicators

**Related github/jira issue (required)**:
Closes #494 