### PR TITLE
Allow specifying a fill color for svg of soho-button="icon", soho-icon

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 5.4.0 Features
 
 - `[Personalize]` - Changed soho-personalize directive to include theme and personalization color information. `PWP` ([#493](https://github.com/infor-design/enterprise-ng/pull/493))
+- `[Icon & Button]` - Added ability to set an extra class on the icon to set the color. `PWP` ([#498](https://github.com/infor-design/enterprise-ng/pull/498))
 
 ### 5.4.0 Fixes
 

--- a/projects/ids-enterprise-ng/src/lib/button/soho-button.component.html
+++ b/projects/ids-enterprise-ng/src/lib/button/soho-button.component.html
@@ -1,4 +1,4 @@
-<svg soho-icon *ngIf="hasIcon" [icon]="currentIcon"></svg>
+<svg soho-icon *ngIf="hasIcon" [icon]="currentIcon" [extraIconClass]="extraIconClass"></svg>
 <span>
   <ng-content></ng-content>
 </span>

--- a/projects/ids-enterprise-ng/src/lib/button/soho-button.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/button/soho-button.component.ts
@@ -108,6 +108,12 @@ export class SohoButtonComponent implements AfterViewInit, OnDestroy, OnInit {
     }
   }
 
+  /**
+   * Used to set an extra class on the soho-icon being used by soho-button.
+   * Useful to set emerald06-color azure10-color to change the icon color.
+   */
+  @Input() extraIconClass: string;
+
   get hideMenuArrow() {
     return this._buttonOptions.hideMenuArrow;
   }

--- a/projects/ids-enterprise-ng/src/lib/icon/soho-icon.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/icon/soho-icon.component.ts
@@ -24,12 +24,21 @@ export class SohoIconUseComponent {
   template: `<svg:use [icon]="icon"></svg:use>`
 })
 export class SohoIconComponent {
+
   @HostBinding('class.icon') isIcon = true;
   @HostBinding('attr.aria-hidden') ariaHidden = true;
   @HostBinding('attr.focusable') focusable = false;
   @HostBinding('attr.role') role = 'presentation';
   @Input() @HostBinding('class.icon-empty-state') isEmptyState = false;
 
+  /**
+   * Extra class that will be placed on the soho-icon element.
+   * Useful to set emerald06-color azure10-color to change the icon color.
+   */
+  @Input() set extraIconClass(extraIconClass: string) {
+    this._extraIconClass = extraIconClass;
+    this.setExtraIconsClass();
+  }
   @Input() set alert(alert: boolean) {
     this._alert = alert;
     this.setAlertIcon();
@@ -41,6 +50,7 @@ export class SohoIconComponent {
 
   private _alert: boolean;
   private _icon: string;
+  private _extraIconClass: string;
 
   constructor(
     private elementRef: ElementRef,
@@ -52,6 +62,12 @@ export class SohoIconComponent {
     // w/o overwriting other classes in the class list.
     if (this.alert && this.icon) {
       this.renderer.addClass(this.elementRef.nativeElement, this.icon);
+    }
+  }
+
+  private setExtraIconsClass() {
+    if (this._extraIconClass) {
+      this.renderer.addClass(this.elementRef.nativeElement, this._extraIconClass);
     }
   }
 

--- a/src/app/icon/icon.demo.html
+++ b/src/app/icon/icon.demo.html
@@ -429,6 +429,47 @@
 
 <div class="row">
   <div class="twelve columns">
+    <h2 class="fieldset-title">Colored Icons</h2>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns space-icons">
+
+    <svg soho-icon icon="success" extraIconClass="emerald06-color"></svg>
+    <svg soho-icon icon="alert" extraIconClass="ruby08-color"></svg>
+    <svg soho-icon icon="empty-circle" extraIconClass="azure08-color"></svg>
+    <svg soho-icon icon="error" extraIconClass="turquoise08-color"></svg>
+    <svg soho-icon icon="info" extraIconClass="amethyst10-color"></svg>
+    <svg soho-icon icon="pending" extraIconClass="emerald06-color"></svg>
+    <svg soho-icon icon="new" extraIconClass="ruby08-color"></svg>
+    <svg soho-icon icon="in-progress" extraIconClass="azure08-color"></svg>
+    <svg soho-icon icon="info-field" extraIconClass="turquoise08-color"></svg>
+
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Colored Button Icon</h2>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns space-icons">
+
+    <button soho-button="icon" icon="add" title="Add" extraIconClass="amber10-color" ></button>
+    <button soho-button="icon" icon="clock" title="Clock" extraIconClass="azure10-color"></button>
+    <button soho-button="icon" icon="copy" title="Copy" extraIconClass="turquoise07-color"></button>
+    <button soho-button="icon" icon="home" title="Home" extraIconClass="amethyst10-color"></button>
+    <button soho-button="icon" icon="mail" title="Mail" extraIconClass="emerald05-color" ></button>
+    <button soho-button="icon" icon="mail" title="Mail" extraIconClass="ruby08-color" ></button>
+
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
     <h2 class="fieldset-title"></h2>
   </div>
 </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Add ability to set an extra class on the icon to set the color

**Related github/jira issue (required)**:
Closes #440 

**Steps necessary to review your pull request (required)**:
Go to Icons and see the colored icons at the bottom of that page.
