### PR TITLE
change widget-title selector to not require a div tag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 5.4.0 Fixes
 
 - `[Datagrid]` - Adds a onBeforeSelect call back setting to the types. `TJM` ([#472](https://github.com/infor-design/enterprise-ng/issues/472))
+- `[HomePage]` - remove element node (div) from widget title selector `PWP` ([#507](https://github.com/infor-design/enterprise-ng/pull/507))
 - `[Icons]` - Change name of icon 'confirm' to 'success' to match breaking change made in EP. `PWP` ([#477](https://github.com/infor-design/enterprise-ng/pull/477)) See [EP 4.15.0 changelog](https://github.com/infor-design/enterprise/blob/master/docs/CHANGELOG.md#v4150-fixes) for more details.
 - `[Keyboard]` - Adds a `Soho.keyboard.pressedKeys` to see what the currently pressed keys are. `TJM` ([#472](https://github.com/infor-design/enterprise-ng/issues/472))
 

--- a/projects/ids-enterprise-ng/src/lib/homepage/soho-widget-title.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/homepage/soho-widget-title.component.ts
@@ -6,7 +6,7 @@ import {
   Input } from '@angular/core';
 
 @Component({
-  selector: 'div[soho-widget-title]', // tslint:disable-line
+  selector: '[soho-widget-title]', // tslint:disable-line
   template: `<ng-content></ng-content>`
 })
 export class SohoWidgetTitleComponent {

--- a/src/app/homepage/homepage-scenario-a.demo.html
+++ b/src/app/homepage/homepage-scenario-a.demo.html
@@ -2,19 +2,19 @@
 
   <div soho-widget>
     <div soho-widget-header>
-      <div soho-widget-title [tabIndex]="0"><h2>Widget 1x1 (Dom Order 1)</h2></div>
+      <h2 soho-widget-title [tabIndex]="0">Widget 1x1 (Dom Order 1)</h2>
     </div>
   </div>
 
   <div soho-widget widgetWidth="double">
     <div soho-widget-header>
-      <div soho-widget-title [tabIndex]="1"><h2>Widget 2x1 (Dom Order 2)</h2></div>
+      <h2 soho-widget-title [tabIndex]="1">Widget 2x1 (Dom Order 2)</h2>
     </div>
   </div>
 
   <div soho-widget>
     <div soho-widget-header>
-      <div soho-widget-title [tabIndex]="2"><h2>Widget 1x1 (Dom Order 3)</h2></div>
+      <h2 soho-widget-title [tabIndex]="2">Widget 1x1 (Dom Order 3)</h2>
     </div>
   </div>
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Allow widget-title to be used with different tags. Right now only div is allowed.
