### PR TITLE
414 - Fix js error was showing after removing item with soho popupmenu

### DIFF
--- a/src/app/menu-button/menu-button.demo.html
+++ b/src/app/menu-button/menu-button.demo.html
@@ -35,6 +35,7 @@
       <li soho-popupmenu-item><a soho-popupmenu-label>Pie Chart</a></li>
       <li soho-popupmenu-item><a soho-popupmenu-label>Line Chart</a></li>
       <li soho-popupmenu-item><a soho-popupmenu-label>Bubble Chart</a></li>
+      <li soho-popupmenu-item *ngIf="showLastOption"><a soho-popupmenu-label (click)="showLastOption = !showLastOption">Click this to remove myself</a></li>
     </ul>
 
     <button soho-menu-button icon="line-chart" pie-chart="" title="Charts" menu="charts-menu2"

--- a/src/app/menu-button/menu-button.demo.ts
+++ b/src/app/menu-button/menu-button.demo.ts
@@ -9,6 +9,7 @@ export class MenuButtonDemoComponent implements OnInit, AfterViewInit {
   @ViewChild('ajax')ajaxMenuButton: SohoMenuButtonComponent;
   public menuButtons: Array<any>;
 
+  public showLastOption: boolean;
   public toggle: boolean;
 
   private SUBMENU_RESPONSE_HTML = `
@@ -70,6 +71,7 @@ export class MenuButtonDemoComponent implements OnInit, AfterViewInit {
    }
 
   ngOnInit() {
+    this.showLastOption = true;
     this.menuButtons = [
       {
         label: 'Add',


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed js error was showing after removing menu item with Soho Popupmenu.

**Related github/jira issue (required)**:
Closes #414

**Steps necessary to review your pull request (required)**:
- After ([PR 2330](https://github.com/infor-design/enterprise/pull/2330)) merged
- Pull and build this branch
- Go to http://localhost:4200/ids-enterprise-ng-demo/menu-button
- Open developer tools
- Click the charts menu to open
- Click last item `Click this to remove myself`
- See the console, should not be any error
