### PR TITLE
2348 - Fix example page was showing js error with field options

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 5.4.0 Fixes
 
 - `[Datagrid]` - Adds a onBeforeSelect call back setting to the types. `TJM` ([#472](https://github.com/infor-design/enterprise-ng/issues/472))
+- `[Field Options]` Fixed an issue where example page was showing js error. ([#2348](https://github.com/infor-design/enterprise/issues/2348))
 - `[Icons]` - Change name of icon 'confirm' to 'success' to match breaking change made in EP. `PWP` ([#477](https://github.com/infor-design/enterprise-ng/pull/477)) See [EP 4.15.0 changelog](https://github.com/infor-design/enterprise/blob/master/docs/CHANGELOG.md#v4150-fixes) for more details.
 - `[Keyboard]` - Adds a `Soho.keyboard.pressedKeys` to see what the currently pressed keys are. `TJM` ([#472](https://github.com/infor-design/enterprise-ng/issues/472))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # What's New with Enterprise-NG
 
+## v5.5.0
+
+### 5.5.0 Features
+
+### 5.5.0 Fixes
+
+- `[Field Options]` Fixed an issue where example page was showing js error. ([#2348](https://github.com/infor-design/enterprise/issues/2348))
+
+### 5.5.0 Chore & Maintenance
+
 ## v5.4.0
 
 ### 5.4.0 Features
@@ -13,7 +23,6 @@
 ### 5.4.0 Fixes
 
 - `[Datagrid]` - Adds a onBeforeSelect call back setting to the types. `TJM` ([#472](https://github.com/infor-design/enterprise-ng/issues/472))
-- `[Field Options]` Fixed an issue where example page was showing js error. ([#2348](https://github.com/infor-design/enterprise/issues/2348))
 - `[Icons]` - Change name of icon 'confirm' to 'success' to match breaking change made in EP. `PWP` ([#477](https://github.com/infor-design/enterprise-ng/pull/477)) See [EP 4.15.0 changelog](https://github.com/infor-design/enterprise/blob/master/docs/CHANGELOG.md#v4150-fixes) for more details.
 - `[Keyboard]` - Adds a `Soho.keyboard.pressedKeys` to see what the currently pressed keys are. `TJM` ([#472](https://github.com/infor-design/enterprise-ng/issues/472))
 

--- a/src/app/field-options/field-options.demo.html
+++ b/src/app/field-options/field-options.demo.html
@@ -50,13 +50,15 @@
     -->
 
     <div class="field">
+      <ul soho-popupmenu id="lookup-popupmenu">
+        <li soho-popupmenu-item><a soho-popupmenu-label>Cut</a></li>
+        <li soho-popupmenu-item><a soho-popupmenu-label>Copy</a></li>
+        <li soho-popupmenu-item><a soho-popupmenu-label>Paste</a></li>
+      </ul>
+
       <label soho-label for="product-lookup">Lookup</label>
       <input soho-lookup soho-field-options name="product-lookup" type="text">
-      <button soho-button="icon" icon="more" class="btn-actions btn-menu" soho-context-menu menu="popupmenu" trigger="click"></button>
-      <ul soho-popupmenu>
-        <li soho-popupmenu-item><a soho-popupmenu-label>Show History</a></li>
-        <li soho-popupmenu-item><a soho-popupmenu-label>Edit Record</a></li>
-      </ul>
+      <button soho-button="icon" icon="more" class="btn-actions btn-menu" soho-context-menu menu="lookup-popupmenu" trigger="click"></button>
     </div>
 
   </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed example page was showing js error with field options.

**Related github/jira issue (required)**:
Closes infor-design/enterprise#2348

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demoapp
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/field-options
- Open developer tools
- Mouse over to `Lookup` field
- Field options button (three dots) should show
- Click on this (field options button) to open popup menu
- See console should not be any js error