### PR TITLE
options to remove old popup menus from the dom

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Datagrid]` Fixed an issue where code-block editor focus was not working. ([#526](https://github.com/infor-design/enterprise-ng/issues/526))
 - `[Field Options]` - Fixed an issue where example page was showing js error. ([#2348](https://github.com/infor-design/enterprise/issues/2348))
 - `[Modal]` - Redundant `modal-dialog` markup removed on hash based route navigation. ([#308](https://github.com/infor-design/enterprise/issues/308))
+- `[Popupmenu, MenuButton]` - Added `removeOnDestroy` to `popupmenu` and `menu-button` components. `PWP` ([#541](https://github.com/infor-design/enterprise/issues/541))
 
 ### 5.5.0 Chore & Maintenance
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -5,10 +5,11 @@
 Setting `[attachToBody]="true"` on a menu also requires that you set `[removeOnDestroy]="true"`.
 
 Using `attachToBody` is a requirement for menus when running on iOS/safari. But the issue is these menus keep getting created in the dom but never get cleaned up.
-Using option of `[removeOnDestroy]="true"` will cause the menu elements to get cleaned up when destroyed. 
+Using option of `[removeOnDestroy]="true"` will cause the menu elements to get cleaned up when destroyed.
 
 *See:* datagrid-dynamic.demo.html for an example
-```
+
+```angular2html
 <div *ngIf="displayContextMenu" class="popupmenu-wrapper" role="application" aria-hidden="true">
   <ul soho-popupmenu
     ...

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,24 @@
+# Performance issues
+
+## Menus where `attachToBody` setting is used
+
+Setting `[attachToBody]="true"` on a menu also requires that you set `[removeOnDestroy]="true"`.
+
+Using `attachToBody` is a requirement for menus when running on iOS/safari. But the issue is these menus keep getting created in the dom but never get cleaned up.
+Using option of `[removeOnDestroy]="true"` will cause the menu elements to get cleaned up when destroyed. 
+
+*See:* datagrid-dynamic.demo.html for an example
+```
+<div *ngIf="displayContextMenu" class="popupmenu-wrapper" role="application" aria-hidden="true">
+  <ul soho-popupmenu
+    ...
+    [attachToBody]="true"
+    [removeOnDestroy]="true"
+    ...
+  >
+    <li *ngFor="let item of menuItems">
+      <a soho-popupmenu-label href="#">{{item.label}}</a>
+    </li>
+  </ul>
+</div>
+```

--- a/projects/ids-enterprise-ng/src/lib/menu-button/soho-menu-button.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/menu-button/soho-menu-button.component.ts
@@ -146,6 +146,18 @@ export class SohoMenuButtonComponent implements AfterViewInit, AfterViewChecked,
     return this.options.attachToBody;
   }
 
+  @Input() set removeOnDestroy(value: boolean) {
+    this.options.removeOnDestroy = value;
+    if (this.menuButton) {
+      this.menuButton.settings.removeOnDestroy = value;
+      this.markForRefresh();
+    }
+  }
+
+  get removeOnDestroy(): boolean {
+    return this.options.removeOnDestroy;
+  }
+
   constructor(
     private element: ElementRef,
     private ref: ChangeDetectorRef,
@@ -178,10 +190,10 @@ export class SohoMenuButtonComponent implements AfterViewInit, AfterViewChecked,
 
       // Add listeners to emit events
       this.jQueryElement
-        .on('selected', (e: JQuery.TriggeredEvent, args: JQuery) => this.onSelected(e, args))
-        .on('beforeopen', (e: JQuery.TriggeredEvent, args: JQuery) => this.onBeforeOpen(e, args))
-        .on('close', (e: JQuery.TriggeredEvent, args: JQuery) => this.onClose(e, args))
-        .on('open', (e: JQuery.TriggeredEvent, args: JQuery) => this.onOpen(e, args));
+      .on('selected', (e: JQuery.TriggeredEvent, args: JQuery) => this.onSelected(e, args))
+      .on('beforeopen', (e: JQuery.TriggeredEvent, args: JQuery) => this.onBeforeOpen(e, args))
+      .on('close', (e: JQuery.TriggeredEvent, args: JQuery) => this.onClose(e, args))
+      .on('open', (e: JQuery.TriggeredEvent, args: JQuery) => this.onOpen(e, args));
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/pager/soho-standalone-pager.component.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/pager/soho-standalone-pager.component.spec.ts
@@ -68,7 +68,6 @@ describe('Standalone Pager Unit Tests', () => {
     expect((comp as any).options.showPageSizeSelector).toEqual(true);
     expect((comp as any).options.pagesize).toEqual(10);
     expect((comp as any).options.pagesizes).toEqual([ 5, 10, 15, 20 ]);
-    expect((comp as any).options.attachPageSizeMenuToBody).toEqual(false);
 
     // detect changes to cause bar chart to be built.
     fixture.detectChanges();
@@ -103,7 +102,9 @@ describe('Standalone Pager Unit Tests', () => {
     expect((comp as any).pager.settings.showPageSizeSelector).toEqual(false);
     expect((comp as any).pager.settings.pagesize).toEqual(20);
     expect((comp as any).pager.settings.pagesizes).toEqual([ 5, 10, 15, 20 ]);
-    expect((comp as any).pager.settings.attachPageSizeMenuToBody).toEqual(true);
+
+    // attachPageSizeMenuToBody was changed to add attachToBody on pager.
+    // expect((comp as any).pager.settings.attachPageSizeMenuToBody).toEqual(true);
 
     expect((comp as any).updateRequired).toEqual(false);
     expect(updatedSpy).toHaveBeenCalledTimes(1);

--- a/projects/ids-enterprise-ng/src/lib/popupmenu/soho-popupmenu.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/popupmenu/soho-popupmenu.component.ts
@@ -274,6 +274,21 @@ export class SohoPopupMenuComponent implements AfterViewInit, OnDestroy {
     return this._popupMenuOptions.offset;
   }
 
+  @Input() set removeOnDestroy(removeOnDestroy: boolean) {
+    this._popupMenuOptions.removeOnDestroy = removeOnDestroy;
+    if (this.popupmenu) {
+      this.popupmenu.settings.removeOnDestroy = removeOnDestroy;
+    }
+  }
+
+  get removeOnDestroy(): boolean {
+    if (this.popupmenu) {
+      return this.popupmenu.settings.removeOnDestroy;
+    }
+
+    return this._popupMenuOptions.removeOnDestroy;
+  }
+
   // -------------------------------------------
   // Component Output
   // -------------------------------------------
@@ -389,7 +404,6 @@ export class SohoPopupMenuComponent implements AfterViewInit, OnDestroy {
       }
       if (this.popupmenu) {
         this.popupmenu.destroy();
-        this.popupmenu = null;
       }
     });
   }

--- a/projects/ids-enterprise-ng/src/lib/popupmenu/soho-popupmenu.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/popupmenu/soho-popupmenu.d.ts
@@ -45,12 +45,15 @@ interface SohoPopupMenuOptions {
   returnFocus?: boolean;
 
   /** By default, menus open up underneath their target element.
-    Set this to true to use mouse coordinates for positioning a menu inside of its target element. */
+   Set this to true to use mouse coordinates for positioning a menu inside of its target element. */
   useCoordsForClick?: boolean;
 
   placementOpts?: SohoPopupmenuPlacementOpts;
 
   offset?: SohoPopupmenuOffset;
+
+  /** If set to true, menu will be removed from the DOM when destroyed */
+  removeOnDestroy?: boolean;
 }
 
 /**
@@ -87,7 +90,7 @@ interface SohoPopupMenuStatic {
 
   close(isCancelled?: boolean, noFocus?: boolean): void;
 
-   /**
+  /**
    * Opens the popupmenu, including repopulating data and setting up visual delays, if necessary.
    *
    * @param {JQuery.TriggeredEvent} e the event that caused the menu to open

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -170,6 +170,7 @@
   <!-- P -->
   <div class="accordion-header"><a href="javascript:void(0);"><span>P</span></a></div>
   <div class="accordion-pane">
+    <div class="accordion-header list-item"><a [routerLink]="['pager-standalone']"><span>Pager - Standalone</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['personalize-color-api']"><span>Personalize Color API</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['pie']"><span>Pie Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['popupmenu']"><span>Popup Menu Options</span></a></div>

--- a/src/app/datagrid/datagrid-dynamic.demo.html
+++ b/src/app/datagrid/datagrid-dynamic.demo.html
@@ -35,6 +35,7 @@
     trigger="immediate"
     [eventObj]="contextMenuEvent"
     [attachToBody]="true"
+    [removeOnDestroy]="true"
     (selected)="onMenuItemSelected($event)"
     (beforeopen)="onBeforeContextMenuOpen($event)"
     (close)="onContextMenuClose($event)"

--- a/src/app/pager/pager-standalone.demo.html
+++ b/src/app/pager/pager-standalone.demo.html
@@ -18,6 +18,8 @@
         [lastPageTooltip]="model.lastPageTooltip"
 
         [showPageSizeSelector]="!model.hidePageSizeSelector"
+        [attachPageSizeMenuToBody]="model.attachPageSizeMenuToBody"
+
         [pageSize]="model.pageSize"
         [pageSizes]="model.pageSizes"
 
@@ -69,7 +71,10 @@
           <input soho-checkbox type="checkbox" id="hide-pagesize" [(ngModel)]="model.hidePageSizeSelector" [ngModelOptions]="{standalone: true}">
           <label soho-label for="hide-pagesize" [forCheckBox]="true">Hide Page Size Selector</label>
         </div>
-
+        <div class="field">
+          <input soho-checkbox type="checkbox" id="attach-page-size-menu-to-body" [(ngModel)]="model.attachPageSizeMenuToBody" [ngModelOptions]="{standalone: true}">
+          <label soho-label for="attach-page-size-menu-to-body" [forCheckBox]="true">Attach Page Size Menu To Body</label>
+        </div>
       </form>
 
     </div>

--- a/src/app/pager/pager-standalone.demo.ts
+++ b/src/app/pager/pager-standalone.demo.ts
@@ -23,6 +23,8 @@ export class PagerStandaloneDemoComponent {
     nextPageTooltip    : 'click to got to the last page of records',
 
     hidePageSizeSelector: false,
+    attachPageSizeMenuToBody: false,
+
     pageSize: 10,
     pageSizes: [5, 10, 15, 20],
   };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Add `removeOnDestroy` option to `menu-button` and `popupmenu` to clean up their dom markup

To verify run datagrid-dynamic.demo and right-click around on the datagrid to bring the context menu up over and over again. Look at the developer/elements panel to validate that the dom doesn't grow as you open and close the right click menu.

This change depends on a soho PR being merged and available in an npm package: 
https://github.com/infor-design/enterprise/pull/2483