### PR TITLE
Added events for eventDblClick and eventClick

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,7 +50,7 @@
 - `[AppMenu]` - Added 'isPersonalizable' input for setting the is-personalization class on the EP app-menu element. `PWP`
 - `[AppMenu]` - Added new events for accordion expansion that will include the element so it can be lazily loaded. `PWP` ([#434](https://github.com/infor-design/enterprise-ng/issues/434))
 - `[AppMenu]` - Added new settings for application menu switcher expand/collapse. `VW` ([#443](https://github.com/infor-design/enterprise-ng/issues/443))
-- `[Calendar]` - Hookedup up new `eventClick` and `eventDblClick` event. `PWP` ([#542](https://github.com/infor-design/enterprise-ng/issues/542))
+- `[Calendar]` - Hooked up new `eventClick` and `eventDblClick` event. `PWP` ([#542](https://github.com/infor-design/enterprise-ng/issues/542))
 - `[DataGrid]` - Added 'resetColumns' and 'personalizeColumns' to the datagrid component. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))
 - `[DataGrid]` - Added 'entereditmode', 'exiteditmode' and 'beforeentereditmode' event outputs from component. `BTHH` ([#410](https://github.com/infor-design/enterprise-ng/issues/410))
 - `[DataGrid]` - Added NG support for EP tooltip callback function . `PWP` ([#470](https://github.com/infor-design/enterprise-ng/pull/470))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@
 - `[AppMenu]` - Added 'isPersonalizable' input for setting the is-personalization class on the EP app-menu element. `PWP`
 - `[AppMenu]` - Added new events for accordion expansion that will include the element so it can be lazily loaded. `PWP` ([#434](https://github.com/infor-design/enterprise-ng/issues/434))
 - `[AppMenu]` - Added new settings for application menu switcher expand/collapse. `VW` ([#443](https://github.com/infor-design/enterprise-ng/issues/443))
+- `[Calendar]` - Hookedup up new `eventClick` and `eventDblClick` event. `PWP` ([#542](https://github.com/infor-design/enterprise-ng/issues/542))
 - `[DataGrid]` - Added 'resetColumns' and 'personalizeColumns' to the datagrid component. `BTHH` ([#413](https://github.com/infor-design/enterprise-ng/issues/413))
 - `[DataGrid]` - Added 'entereditmode', 'exiteditmode' and 'beforeentereditmode' event outputs from component. `BTHH` ([#410](https://github.com/infor-design/enterprise-ng/issues/410))
 - `[DataGrid]` - Added NG support for EP tooltip callback function . `PWP` ([#470](https://github.com/infor-design/enterprise-ng/pull/470))

--- a/projects/ids-enterprise-ng/src/lib/calendar/soho-calendar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/calendar/soho-calendar.component.ts
@@ -314,6 +314,8 @@ export class SohoCalendarComponent implements AfterViewChecked, AfterViewInit, O
   // -------------------------------------------
   @Output() selected = new EventEmitter<SohoCalendarDateSelectedEvent>();
   @Output() monthRendered = new EventEmitter<SohoCalendarRenderMonthEvent>();
+  @Output() eventClick = new EventEmitter<SohoCalendarEventClickEvent>();
+  @Output() eventDblClick = new EventEmitter<SohoCalendarEventClickEvent>();
 
   /**
    * Local variables
@@ -337,7 +339,9 @@ export class SohoCalendarComponent implements AfterViewChecked, AfterViewInit, O
       // Add listeners to emit events
       this.jQueryElement
       .on('selected', (e: any, event: SohoCalendarDateSelectedEvent) => this.onSelectedEvent(event))
-      .on('monthrendered', (e: any, args: SohoCalendarRenderMonthEvent) => this.onMonthRenderedEvent(args));
+      .on('monthrendered', (e: any, args: SohoCalendarRenderMonthEvent) => this.onMonthRenderedEvent(args))
+      .on('eventclick', (e: any, args: SohoCalendarEventClickEvent) => this.onEventClick(args))
+      .on('eventdblclick', (e: any, args: SohoCalendarEventClickEvent) => this.onEventDblClick(args));
 
       // Initialise the Soho control.
       this.jQueryElement.calendar(this._calendarOptions);
@@ -359,7 +363,6 @@ export class SohoCalendarComponent implements AfterViewChecked, AfterViewInit, O
       this.updated();
       this.updateRequired = false;
     }
-
   }
 
   onSelectedEvent(event: SohoCalendarDateSelectedEvent) {
@@ -368,6 +371,14 @@ export class SohoCalendarComponent implements AfterViewChecked, AfterViewInit, O
 
   onMonthRenderedEvent(event: SohoCalendarRenderMonthEvent) {
     this.ngZone.run(() => this.monthRendered.emit(event));
+  }
+
+  onEventClick(event: SohoCalendarEventClickEvent) {
+    this.ngZone.run(() => this.eventClick.emit(event));
+  }
+
+  onEventDblClick(event: SohoCalendarEventClickEvent) {
+    this.ngZone.run(() => this.eventDblClick.emit(event));
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/calendar/soho-calendar.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/calendar/soho-calendar.d.ts
@@ -77,6 +77,12 @@ interface SohoCalendarDateSelectedEvent {
   year?: number;
 }
 
+interface SohoCalendarEventClickEvent {
+  month?: number;
+  year?: number;
+  event?: SohoCalendarEvent
+}
+
 interface SohoCalendarRenderMonthEvent {
   api: any;
   elem: JQuery,
@@ -164,5 +170,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
   calendar(options?: SohoCalendarOptions): JQuery;
   on(events: 'selected', handler: JQuery.EventHandlerBase<any, SohoCalendarDateSelectedEvent>): this;
   on(events: 'monthrendered', handler: JQuery.EventHandlerBase<any, SohoCalendarRenderMonthEvent>): this;
+  on(events: 'eventclick', handler: JQuery.EventHandlerBase<any, SohoCalendarRenderMonthEvent>): this;
+  on(events: 'eventdblclick', handler: JQuery.EventHandlerBase<any, SohoCalendarRenderMonthEvent>): this;
 }
 

--- a/src/app/calendar/calendar.demo.html
+++ b/src/app/calendar/calendar.demo.html
@@ -7,7 +7,8 @@
 
     (monthRendered)="onRenderMonth($event)"
     (selected)="onSelected($event)"
-    (dblclick)="onDblClick($event)"
+    (eventClick)="onEventClicked($event)"
+    (eventDblClick)="onEventDblClicked($event)"
 >
   <div soho-calendar-monthview></div>
 </div>

--- a/src/app/calendar/calendar.demo.ts
+++ b/src/app/calendar/calendar.demo.ts
@@ -33,11 +33,11 @@ export class CalendarDemoComponent {
         response(this.events, this.eventTypes);
       });
     });
-  };
+  }
 
   public onCalendarDateSelectedCallback = (node: Node, args: SohoCalendarDateSelectedEvent) => {
     console.log('onCalendarEventSelectedCallback', args);
-  };
+  }
 
   constructor(private monthViewService: CalendarDemoService, private toastService: SohoToastService) {}
 

--- a/src/app/calendar/calendar.demo.ts
+++ b/src/app/calendar/calendar.demo.ts
@@ -4,7 +4,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { CalendarDemoService } from './calendar.demo.service';
-import { SohoCalendarComponent } from 'ids-enterprise-ng';
+import { SohoCalendarComponent, SohoToastService } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'app-calendar-demo',
@@ -33,13 +33,13 @@ export class CalendarDemoComponent {
         response(this.events, this.eventTypes);
       });
     });
-  }
+  };
 
   public onCalendarDateSelectedCallback = (node: Node, args: SohoCalendarDateSelectedEvent) => {
     console.log('onCalendarEventSelectedCallback', args);
-  }
+  };
 
-  constructor(private monthViewService: CalendarDemoService) {}
+  constructor(private monthViewService: CalendarDemoService, private toastService: SohoToastService) {}
 
   onRenderMonth(event: SohoCalendarRenderMonthEvent) {
     console.log('onRenderMonth', event);
@@ -49,7 +49,13 @@ export class CalendarDemoComponent {
     console.log('onSelected', event);
   }
 
-  onDblClick(event: MouseEvent) {
-    console.log('onDblClick', event);
+  onEventClicked(event: SohoCalendarEventClickEvent) {
+    this.toastService.show({title: 'Calendar Test', message: 'Event "' + event.event.subject + '" Clicked' });
+    console.log('onEventClick', event);
+  }
+
+  onEventDblClicked(event: SohoCalendarEventClickEvent) {
+    this.toastService.show({title: 'Calendar Test', message: 'Event "' + event.event.subject + '" Double Clicked' });
+    console.log('onEventDblClick', event);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
So we can open an event by double clicking on it.

**Steps necessary to review your pull request (required)**:
- run standard calendar demo. double click an event.
- See toast message with event data.
