### PR TITLE
474 - Added a flex toolbar and datagrid example

### DIFF
--- a/src/app/toolbar-flex/toolbar-flex-datagrid.demo.html
+++ b/src/app/toolbar-flex/toolbar-flex-datagrid.demo.html
@@ -1,5 +1,5 @@
 <div class="full-width scrollable-flex full-height">
-  <div soho-toolbar-flex [style.height]="'auto'">
+  <div soho-toolbar-flex>
     <soho-toolbar-flex-section [isTitle]="true">
       <nav class="breadcrumb">
         <ol aria-label="breadcrumb">
@@ -25,10 +25,10 @@
 
     <soho-toolbar-flex-more-button> </soho-toolbar-flex-more-button>
   </div>
-  <div class="scrollable-flex-content no-scroll" [style.height]="'100%'">
-    <div class="scrollable-flex" [style.height]="'100%'">
+  <div class="scrollable-flex-content no-scroll">
+    <div class="scrollable-flex height-100">
       <div class="scrollable-flex-content">
-        <div soho-datagrid electable="true" filterable="true"></div>
+        <div soho-datagrid selectable="multiple" filterable="true"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR continues on @bthharper 's work on adding a new toolbar flex example showing the toolbar above a datagrid (that also can scroll). The fix is on https://github.com/infor-design/enterprise/pull/2509

**Related github/jira issue (required)**:
Fixes #474 

**Steps necessary to review your pull request (required)**:
- pull this branch
- pull https://github.com/infor-design/enterprise/pull/2509 and build and link
- go to http://localhost:4200/ids-enterprise-ng-demo/toolbar-flex-datagrid
- toolbar should look nice
- and grid should scroll if the page is resized and part is cut off
