### PR TITLE
fix for soho-toobar more button memory leak

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Modal]` - Redundant `modal-dialog` markup removed on hash based route navigation. ([#308](https://github.com/infor-design/enterprise/issues/308))
 - `[Message]` - Close method does not close dialog. ([#554](https://github.com/infor-design/enterprise-ng/pull/554))
 - `[Popupmenu, MenuButton]` - Added `removeOnDestroy` to `popupmenu` and `menu-button` components. `PWP` ([#541](https://github.com/infor-design/enterprise/issues/541))
+- `[Toolbar]` - Fix for memroy leak where .more button listeners were not being removed. `PWP` ([#560](https://github.com/infor-design/enterprise-ng/issues/560))
 
 ### 5.5.0 Chore & Maintenance
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "core-js": "^2.5.4",
     "d3": "4.13.0",
     "fix": "0.0.6",
-    "ids-enterprise": "4.20.0-beta.0",
+    "ids-enterprise": "4.20.0-beta.1",
     "jquery": "^3.4.1",
     "lscache": "^1.2.0",
     "rxjs": "~6.5.1",

--- a/projects/ids-enterprise-ng/src/lib/toolbar/soho-toolbar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/toolbar/soho-toolbar.component.ts
@@ -466,6 +466,7 @@ export class SohoToolbarComponent implements AfterViewChecked, AfterViewInit, On
     // call outside the angular zone so change detection isn't triggered by the soho component.
     this.ngZone.runOutsideAngular(() => {
       if (this.jQueryElement) {
+        this.jQueryElement.find('.more').off();
         this.jQueryElement.off();
       }
       if (this.toolbar) {


### PR DESCRIPTION
Fixed Memory leak causes by not turning of event listeners for the more button.

**Related github/jira issue (required)**:
closes #560 

**Steps necessary to review your pull request (required)**:
1. open the angular demo app
2. expand T (for Toolbar)
3. click on the first 5 toolbar demos and click the ... (more) button.
4. Move to a demo that doesn't have a toolbar
5. take a heap snapshot, search for soho-toolbar, there should be on 2 in memory
