### PR TITLE
Datagrid: Expose groupRowFormatter in groupable settings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### 6.0.0 Features
 
-- `[DataGrid]` - Expose groupRowFormatter in groupable settings. ([#558](https://github.com/infor-design/enterprise-ng/issues/558))
-
 ### 6.0.0 Fixes
+
+- `[DataGrid]` - Expose groupRowFormatter in groupable settings. ([#558](https://github.com/infor-design/enterprise-ng/issues/558))
 
 ## v5.5.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # What's New with Enterprise-NG
 
+## v6.0.0
+
+### 6.0.0 Features
+
+- `[DataGrid]` - Expose groupRowFormatter in groupable settings. ([#558](https://github.com/infor-design/enterprise-ng/issues/558))
+
+### 6.0.0 Fixes
+
 ## v5.5.0
 
 ### 5.5.0 Features

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -1226,6 +1226,9 @@ interface SohoDataGridGroupable {
 
   // Type of aggregation.
   aggregator: SohoDataGridAggregator;
+
+  // Formatter for group row
+  groupRowFormatter?: SohoDataGridColumnFormatterFunction;
 }
 
 type SohoDataGridAggregator = 'sum' | 'max' | 'list' | string;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Expose groupRowFormatter in groupable settings, so user could specify a custom formatter for group row.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise-ng/issues/558

**Steps necessary to review your pull request (required)**:
n/a
