### PR TITLE
536 - Add an example showing onkeydown to add a new row

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 6.0.0 Features
 
+- `[Datagrid]` - Added an example showing adding a new row on last cell and hitting enter and types for onKeyDown. `TJM` ([#536](https://github.com/infor-design/enterprise-ng/pull/536))
 - `[HomePage]` - Added `soho-homepage-sizer` directive to set the homepage's element height. `PWP` ([#571](https://github.com/infor-design/enterprise-ng/pull/571))
 
 ### 6.0.0 Fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 6.0.0 Fixes
 
 - `[DataGrid]` - Expose groupRowFormatter in groupable settings. ([#558](https://github.com/infor-design/enterprise-ng/issues/558))
+- `[Dropdown]` - Removed unused and deprecated reloadOnSource settings to reduce lint errors. ([#536](https://github.com/infor-design/enterprise-ng/issues/536))
 
 ## v5.5.0
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1081,6 +1081,10 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   @Output()
   expandrow = new EventEmitter<SohoDataGridToggleRowEvent>();
 
+  // This event is fired when a key is pressed
+  @Output()
+  keydown = new EventEmitter<SohoDataGridKeyDownEvent>();
+
   // This event is fired when edit mode is exited.
   @Output()
   exiteditmode = new EventEmitter<SohoDataGridEditModeEvent>();
@@ -1789,6 +1793,16 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   /**
+   * Event fired after a key is pressed
+   */
+  private onKeyDown(e: JQuery.Event, args: SohoDataGridKeyDownArgs, response: Function) {
+    const event = { e, args, response };
+    this.ngZone.run(() => {
+      this.keydown.next(event);
+    });
+  }
+
+  /**
    * Event fired after a child row has been expanded.
    * @param idProperty string id
    */
@@ -2215,6 +2229,11 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
         this.onEditCell(editor);
       };
 
+      // Add the keydown callback.
+      this._gridOptions.onKeyDown = (e: JQuery.Event, args: SohoDataGridKeyDownArgs, response: Function) => {
+        this.onKeyDown(e, args, response);
+      };
+
       // Initialise any event handlers.
       this.jQueryElement
         .on('addrow', (e: any, args: SohoDataGridAddRowEvent) => { this.onRowAdd(args); })
@@ -2362,4 +2381,14 @@ export interface SohoDataGridToggleRowEvent extends SohoDataGridRowExpandEvent {
   // The data grid component originating the call.
   grid: SohoDataGridComponent;
   args?: any;
+}
+
+/**
+ * Details of the 'keydown' event
+ */
+export interface SohoDataGridKeyDownEvent {
+  // The data grid component originating the call.
+  e: JQuery.Event;
+  args?: SohoDataGridKeyDownArgs;
+  response?: Function;
 }

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -239,6 +239,11 @@ interface SohoDataGridOptions {
   onEditCell?: SohoDataGridEditCellFunction;
 
   /**
+  * Vetoable Key Down Callback
+  */
+  onKeyDown?: SohoDataGridKeyDownFunction;
+
+  /**
   * A callback function that fires when expanding rows.
   * To be used when expandableRow is true.
   * The function gets eventData about the row and grid and a response
@@ -341,6 +346,20 @@ interface SohoDataGridPostRenderCellArgs {
   api: SohoDataGridStatic;
 }
 
+/**
+ * The arguments object passed to the onKeyDown callback.
+ */
+interface SohoDataGridKeyDownArgs {
+  /** Info about the active cell. */
+  activeCell: any;
+
+  /** The row index. */
+  row: number;
+
+  /** The cell index. */
+  cell: number;
+}
+
 interface SohoDataGridEditCellFunctionArgs extends SohoDataGridPostRenderCellArgs {
   container: any;
   e: any;
@@ -392,6 +411,12 @@ type SohoDataGridPostRenderCellFunction = (
 
 type SohoDataGridEditCellFunction = (
   editor: any
+) => void;
+
+type SohoDataGridKeyDownFunction = (
+  e: JQuery.Event,
+  args: SohoDataGridKeyDownArgs,
+  response: Function
 ) => void;
 
 type SohoDataGridSourceFunction = (
@@ -1310,23 +1335,29 @@ interface SohoDataGridEditModeEvent {
   row: number;
 
   /** Column number. */
-  cell: number,
+  cell: number;
 
   /** Row data */
-  item: any,
+  item: any;
 
   /** HTMLElement of the owning cell */
-  target: HTMLElement,
+  target: HTMLElement;
 
   /** The cell value. */
-  value: any,
+  value: any;
 
   /** The original cell value. */
-  oldValue: any,
+  oldValue: any;
 
   /** The column definition. */
-  column: SohoDataGridColumn,
+  column: SohoDataGridColumn;
 
   /** The cell editor object. */
-  editor: SohoDataGridCellEditor
+  editor: SohoDataGridCellEditor;
+}
+
+interface SohoDataGridKeyDownEvent {
+  e: JQuery.Event;
+  args: SohoDataGridKeyDownArgs;
+  response: Function;
 }

--- a/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
@@ -186,23 +186,6 @@ export class SohoDropDownComponent implements AfterViewInit, AfterViewChecked, O
   }
 
   /**
-   * @deprecated as of v4.9.0
-   * use `reload` instead.
-   */
-  @Input()
-  public set reloadSourceOnOpen(reloadSourceOnOpen: boolean) {
-    this.options.reloadSourceOnOpen = reloadSourceOnOpen;
-    if (this.dropdown) {
-      this.dropdown.settings.reloadSourceOnOpen = reloadSourceOnOpen;
-      this.markForRefresh();
-    }
-  }
-
-  public get reloadSourceOnOpen(): boolean {
-    return this.options.reloadSourceOnOpen;
-  }
-
-  /**
    * Determines the frequency of reloading data from an external source
    */
   @Input()

--- a/src/app/datagrid/datagrid-editors.demo.html
+++ b/src/app/datagrid/datagrid-editors.demo.html
@@ -15,6 +15,7 @@
   <div class="twelve columns demo" role="main">
     <div soho-datagrid *ngIf="gridOptions"
     [gridOptions]="gridOptions"
+    (keydown)="onKeyDown($event)"
     (beforeentereditmode)="onBeforeEnterEditMode($event)"
     (entereditmode)="onEnterEditMode($event)"
     (exiteditmode)="onExitEditMode($event)">

--- a/src/app/datagrid/datagrid-editors.demo.ts
+++ b/src/app/datagrid/datagrid-editors.demo.ts
@@ -316,5 +316,15 @@ export class DataGridEditorsDemoComponent implements OnInit {
     console.log(event);
   }
 
+  private cnt = 1;
 
+  // Note: If we called this onKeyDown we would get the NG keydown firing as well.
+  public onKeyDown(event: SohoDataGridKeyDownEvent) {
+    if (event.e && event.e.which === 13 &&
+      this.sohoDataGridComponent.dataset.length - 1 === event.args.row && event.args.cell === 4) {
+      this.sohoDataGridComponent.addRow({id: (parseInt('214229', 10) + this.cnt).toString() }, 'bottom');
+      this.cnt++;
+      return event.response(false);
+    }
+  }
 }

--- a/src/app/validation/validation-form.demo.html
+++ b/src/app/validation/validation-form.demo.html
@@ -8,34 +8,35 @@
 <div class="example-section" role="main">
 
   <div class="one-half column">
-    <form id="validation-form">
+    <form id="validation-form" [formGroup]="demoForm">
       <div class="field ">
         <label for="email_addr" class="required">Email Address</label>
-        <input id="email_addr" name="email_addr" type="text " data-validate="required" placeholder="someone@someplace.com" [(ngModel)]="email_addr"
-        />
+        <input id="email_addr" name="email_addr" type="text" data-validate="required"   placeholder="someone@someplace.com" [(ngModel)]="email_addr"
+        formControlName="email_addr"/>
       </div>
       <div class="field ">
         <label for="credit_card" class="required">Credit Card</label>
         <input id="credit_card" name="credit_card" type="text" data-validate="required" placeholder="xxxx-xxxx-xxxx-xxxx" [(ngModel)]="credit_card"
-        />
+        formControlName="credit_card"/>
       </div>
       <div class="field ">
         <label for="credit_code1">Credit Code (not required)</label>
-        <input id="credit_code1" name="credit_code1" type="number" [(ngModel)]="credit_code1" />
+        <input id="credit_code1" name="credit_code1" type="number" [(ngModel)]="credit_code1" formControlName="credit_code1" />
       </div>
       <div class="field ">
         <label for="credit_code2" class="required">Credit Code</label>
-        <input id="credit_code2" name="credit_code2" type="number" data-validate="required" [(ngModel)]="credit_code2" />
+        <input id="credit_code2" name="credit_code2" type="number" data-validate="required" [(ngModel)]="credit_code2"  formControlName="credit_code2"/>
       </div>
 
       <div class="field">
         <label for="required" class="label required">Required Text Area</label>
-        <textarea soho-textarea name="required" [(ngModel)]="requiredText" data-validate="required"></textarea>
+        <textarea soho-textarea name="required" [(ngModel)]="requiredText" data-validate="required" formControlName="required"></textarea>
       </div>
 
       <div class="field">
-        <button soho-button="primary" (click)="onClickTrigger($event)">Trigger Validation</button>
-        <button soho-button="primary" (click)="onClickReset()">Reset </button>
+        <button soho-button="secondary" (click)="onClickTrigger($event)">Trigger Validation</button>
+        <button soho-button="secondary" (click)="onClickReset()">Reset</button>
+        <button soho-button="secondary" (click)="onReset($event)">Reset Form</button>
       </div>
 
     </form>

--- a/src/app/validation/validation-form.demo.ts
+++ b/src/app/validation/validation-form.demo.ts
@@ -2,19 +2,21 @@ import {
   Component,
   ElementRef,
   QueryList,
-  ViewChildren
-} from '@angular/core';
-
-import { SohoInputValidateDirective } from 'ids-enterprise-ng';
+  ViewChildren,
+  ChangeDetectorRef
+} from "@angular/core";
+import { FormGroup, FormBuilder, Validators } from "@angular/forms";
+import { SohoInputValidateDirective } from "ids-enterprise-ng";
 
 @Component({
-  selector: 'app-validation-form-demo',
-  templateUrl: './validation-form.demo.html'
+  selector: "app-validation-form-demo",
+  templateUrl: "./validation-form.demo.html"
 })
 export class ValidationFormDemoComponent {
-
-  @ViewChildren(SohoInputValidateDirective) validateDirectives: QueryList<SohoInputValidateDirective>;
-
+  @ViewChildren(SohoInputValidateDirective) validateDirectives: QueryList<
+    SohoInputValidateDirective
+  >;
+  demoForm: FormGroup;
   email_addr: string;
   credit_card: string;
   credit_code1: number;
@@ -22,23 +24,37 @@ export class ValidationFormDemoComponent {
   requiredText: string;
   states: string;
 
-  constructor(private elementRef: ElementRef) {
+  constructor(
+    private elementRef: ElementRef,
+    private formBuilder: FormBuilder,
+    private changeDetector: ChangeDetectorRef
+  ) {
+    this.createForm();
   }
-
-  onSubmit() {
-    // TODO: Do something here?
-    console.log('in onSubmit');
+  createForm() {
+    this.demoForm = this.formBuilder.group({
+      email_addr: [this.email_addr, [Validators.required]],
+      credit_card: [this.credit_card, [Validators.required]],
+      credit_code1: [this.credit_code1],
+      credit_code2: [this.credit_code2, [Validators.required]],
+      required: [this.requiredText, [Validators.required]]
+    });
   }
 
   public onClickTrigger(event) {
-    this.validateDirectives.forEach((item) => {
+    this.validateDirectives.forEach(item => {
       item.validate(event);
     });
   }
 
   public onClickReset() {
-    this.validateDirectives.forEach((item) => {
-      item.removeMessage({ id: 'required', type: 'error' });
+    this.validateDirectives.forEach(item => {
+      item.removeMessage({ id: "required", type: "error" });
     });
+  }
+
+  public onReset(event) {
+    this.demoForm.reset();
+    ($('form') as any).resetForm();
   }
 }

--- a/src/app/validation/validation-form.demo.ts
+++ b/src/app/validation/validation-form.demo.ts
@@ -4,18 +4,17 @@ import {
   QueryList,
   ViewChildren,
   ChangeDetectorRef
-} from "@angular/core";
-import { FormGroup, FormBuilder, Validators } from "@angular/forms";
-import { SohoInputValidateDirective } from "ids-enterprise-ng";
+} from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { SohoInputValidateDirective } from 'ids-enterprise-ng';
 
 @Component({
-  selector: "app-validation-form-demo",
-  templateUrl: "./validation-form.demo.html"
+  selector: 'app-validation-form-demo',
+  templateUrl: './validation-form.demo.html'
 })
 export class ValidationFormDemoComponent {
-  @ViewChildren(SohoInputValidateDirective) validateDirectives: QueryList<
-    SohoInputValidateDirective
-  >;
+  @ViewChildren(SohoInputValidateDirective) validateDirectives: QueryList<SohoInputValidateDirective>;
+
   demoForm: FormGroup;
   email_addr: string;
   credit_card: string;
@@ -49,11 +48,11 @@ export class ValidationFormDemoComponent {
 
   public onClickReset() {
     this.validateDirectives.forEach(item => {
-      item.removeMessage({ id: "required", type: "error" });
+      item.removeMessage({ id: 'required', type: 'error' });
     });
   }
 
-  public onReset(event) {
+  public onReset() {
     this.demoForm.reset();
     ($('form') as any).resetForm();
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added some types for datagrid onkeydown and an example showing adding a new row.
Also threw in a quick example of resetform (but the types aren't perfect for this yet)

**Related github/jira issue (required)**:
Fixes #536 

**Steps necessary to review your pull request (required)**:
- pull and link https://github.com/infor-design/enterprise/pull/2642
- run the demo app and build
- go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-editors
- navigate to the last cell with the arrow keys (favorite)
- hit enter and new line will be created