### PR TITLE
Fixed alert type of 'confirm' to 'success' to match breaking change m…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### 6.0.0 Fixes
 
+- `[Alert]` - Fixed alert type of 'confirm' to 'success' to match breaking change made in EP. `MAF` ([#431](https://github.com/infor-design/enterprise-ng/issues/431))
 - `[DataGrid]` - Expose groupRowFormatter in groupable settings. ([#558](https://github.com/infor-design/enterprise-ng/issues/558))
+- `[InputValidate]` - Fixed event of 'confirm' to 'success' to match breaking change made in EP. `MAF` ([#431](https://github.com/infor-design/enterprise-ng/issues/431))
 
 ## v5.5.0
 

--- a/projects/ids-enterprise-ng/src/lib/alert/soho-alert.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/alert/soho-alert.d.ts
@@ -5,7 +5,7 @@
  * interface of the Soho jQuery alert control.
  */
 
-type SohoAlertType = 'error' | 'alert' | 'confirm' | 'info' | 'icon';
+type SohoAlertType = 'error' | 'alert' | 'success' | 'info' | 'icon';
 
 interface SohoAlertOptions {
   /** */

--- a/projects/ids-enterprise-ng/src/lib/alert/soho-alert.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/alert/soho-alert.directive.ts
@@ -156,7 +156,7 @@ export class SohoAlertDirective implements AfterViewInit {
   removeAllMessages(triggerEvents?: boolean) {
     this.removeMessage('error', triggerEvents);
     this.removeMessage('alert', triggerEvents);
-    this.removeMessage('confirm', triggerEvents);
+    this.removeMessage('success', triggerEvents);
     this.removeMessage('info', triggerEvents);
     this.removeMessage('icon', triggerEvents);
   }

--- a/projects/ids-enterprise-ng/src/lib/input-validate/soho-input-validate.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/input-validate/soho-input-validate.directive.ts
@@ -27,7 +27,7 @@ export class SohoInputValidateDirective implements AfterViewInit {
 
   @Output() error = new EventEmitter<SohoInputValidateEvent>();
   @Output() alert = new EventEmitter<SohoInputValidateEvent>();
-  @Output() confirm = new EventEmitter<SohoInputValidateEvent>();
+  @Output() success = new EventEmitter<SohoInputValidateEvent>();
   @Output() icon = new EventEmitter<SohoInputValidateEvent>();
   @Output() info = new EventEmitter<SohoInputValidateEvent>();
   @Output() valid = new EventEmitter<SohoInputValidateEvent>();
@@ -61,9 +61,9 @@ export class SohoInputValidateDirective implements AfterViewInit {
         this.alert.emit(event);
       }));
 
-      this.jQueryElement.on('confirm', (event: SohoInputValidateEvent, validation) => this.ngZone.run(() => {
+      this.jQueryElement.on('success', (event: SohoInputValidateEvent, validation) => this.ngZone.run(() => {
         event.validation = { field: validation.field[ 0 ], message: validation.message };
-        this.confirm.emit(event);
+        this.success.emit(event);
       }));
 
       this.jQueryElement.on('icon', (event: SohoInputValidateEvent, validation) => this.ngZone.run(() => {

--- a/src/app/alert/alert.demo.html
+++ b/src/app/alert/alert.demo.html
@@ -1,5 +1,5 @@
-<form soho-input-validate registerForEvents="error alert confirm info icon valid"
-  (error)="onError($event)" (alert)="onAlert($event)" (confirm)="onConfirm($event)"
+<form soho-input-validate
+  (error)="onError($event)" (alert)="onAlert($event)" (success)="onSuccess($event)"
   (info)="onInfo($event)" (icon)="onIcon($event)" (valid)="onValid($event)"
 >
   <div class="row top-padding">
@@ -10,8 +10,8 @@
         <label soho-label for="option1" [forRadioButton]="true">Error</label>
         <input soho-radiobutton type="radio" name="options-group" id="option2" value="alert" [(ngModel)]="model.type"/>
         <label soho-label for="option2" [forRadioButton]="true">Alert</label>
-        <input soho-radiobutton type="radio" name="options-group" id="option3" value="confirm" [(ngModel)]="model.type"/>
-        <label soho-label for="option3" [forRadioButton]="true">Confirm</label>
+        <input soho-radiobutton type="radio" name="options-group" id="option3" value="success" [(ngModel)]="model.type"/>
+        <label soho-label for="option3" [forRadioButton]="true">Success</label>
         <input soho-radiobutton type="radio" name="options-group" id="option4" value="info" [(ngModel)]="model.type"/>
         <label soho-label for="option4" [forRadioButton]="true">Info</label>
         <input soho-radiobutton type="radio" name="options-group" id="option5" value="icon" [(ngModel)]="model.type"/>

--- a/src/app/alert/alert.demo.ts
+++ b/src/app/alert/alert.demo.ts
@@ -31,7 +31,7 @@ export class AlertDemoComponent {
   };
   showModel = true;
   showDefinedOptions = true;
-  private types = ['error', 'alert', 'confirm', 'info', 'icon'];
+  private types = ['error', 'alert', 'success', 'info', 'icon'];
 
   onError(event: SohoInputValidateEvent) {
     console.log([ 'onError', event.validation.field.getAttribute('id'), event.validation.message ]);
@@ -41,8 +41,8 @@ export class AlertDemoComponent {
     console.log([ 'onAlert', event.validation.field.getAttribute('id'), event.validation.message ]);
   }
 
-  onConfirm(event: SohoInputValidateEvent) {
-    console.log([ 'onConfirm', event.validation.field.getAttribute('id'), event.validation.message ]);
+  onSuccess(event: SohoInputValidateEvent) {
+    console.log([ 'onSuccess', event.validation.field.getAttribute('id'), event.validation.message ]);
   }
 
   onIcon(event: SohoInputValidateEvent) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed alert type of 'confirm' to 'success' to match breaking change made in EP

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #431 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- pull this branch and build
- go to http://localhost:4200/ids-enterprise-ng-demo/alert
- should be able to add an inline message of type 'success'
- should be able to remove or clear all messages of type 'success'

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
