### PR TITLE
Added `switch` input to checkbox

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
     - support for Node 10.9.0+
     - support for TypeScript 3.4.x
     - `UPGRADING.md` has been updated with details on upgrading your application to angular 8.
+- `[Checkbox]` Added option to render checkbox as a `switch`. `BTHH` ([#](https://))
 
 ### 6.0.0 Chore & Maintenance
 

--- a/projects/ids-enterprise-ng/src/lib/checkbox/soho-checkbox-reactive-form.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/checkbox/soho-checkbox-reactive-form.spec.ts
@@ -23,7 +23,6 @@ import { SohoCheckBoxModule } from './soho-checkbox.module';
 import { SohoLabelModule } from '../label/soho-label.module';
 import { SohoCheckBoxComponent } from './soho-checkbox.component';
 import { ReactiveFormsModule } from '@angular/forms';
-import { fakeAsync, tick } from '@angular/core/testing';
 
 @Component({
   template: `
@@ -34,7 +33,7 @@ import { fakeAsync, tick } from '@angular/core/testing';
 class SohoCheckBoxReactiveFormTestComponent {
   public value = true;
 
-  @ViewChild(SohoCheckBoxComponent, {static: false}) dropdown: SohoCheckBoxComponent;
+  @ViewChild(SohoCheckBoxComponent, { static: false }) dropdown: SohoCheckBoxComponent;
 
   public formGroup: FormGroup;
 

--- a/projects/ids-enterprise-ng/src/lib/checkbox/soho-checkbox.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/checkbox/soho-checkbox.component.ts
@@ -13,6 +13,12 @@ import {
   Output,
 } from '@angular/core';
 
+/**
+ * Wrapper for soho checkboxes.
+ *
+ * Note the control must have type="checkbox" for the values to be passed
+ * to and from any ng model instances.
+ */
 @Component({
   selector: '[soho-checkbox]', // tslint:disable-line
   template: `<ng-content></ng-content>`,
@@ -26,19 +32,27 @@ export class SohoCheckBoxComponent implements AfterViewInit, OnDestroy {
   @Input() partial: boolean;
 
   /**
+   * Indicate that the checkbox is displayed as a switch.
+   */
+  @Input() switch = false;
+
+  /**
    * Bind attributes to the host input element
    */
   @HostBinding('attr.type') get isCheckBoxType() {
     return 'checkbox';
   }
   @HostBinding('class.checkbox') get isCheckBox() {
-    return true;
+    return !this.switch;
   }
   @HostBinding('class.partial') get isPartialCheckBox() {
     return this.partial ? true : false;
   }
   @HostBinding('attr.aria-checked') get isPartialAriaChecked() {
     return this.partial ? 'mixed' : null;
+  }
+  @HostBinding('class.switch') get isSwitch() {
+    return this.switch;
   }
 
   @HostBinding('attr.checked') @Input() checked: boolean;

--- a/src/app/checkbox/checkbox.demo.html
+++ b/src/app/checkbox/checkbox.demo.html
@@ -20,6 +20,14 @@
           <input soho-checkbox type="checkbox" [attr.id]="id2" name="checkbox2" [(ngModel)]="model.checkBox2Value">
           <label soho-label [attr.for]="id2" [forCheckBox]="true">Checked</label>
         </div>
+
+        <div class="field">
+            <div class="switch">
+              <input soho-checkbox type="checkbox" [switch]="true" [attr.id]="id6" name="switch2" [(ngModel)]="model.checkBox2Value">
+              <label soho-label [attr.for]="id6" [forCheckBox]="true">Switched</label>
+            </div>
+          </div>
+
       </div>
       <div class="one-half column">
         <div class="field">

--- a/src/app/checkbox/checkbox.demo.ts
+++ b/src/app/checkbox/checkbox.demo.ts
@@ -25,6 +25,7 @@ export class CheckBoxDemoComponent implements OnInit {
   public id3 = 'checkbox3';
   public id4 = 'checkbox4';
   public id5 = 'checkbox5';
+  public id6 = 'checkbox6';
 
   public checkBoxDisabled = false;
   constructor() { }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

`soho-checkbox` does not support displaying the checkbox as a switch.

**Related github/jira issue (required)**:

Fixes #118.

**Steps necessary to review your pull request (required)**:

Clone repo **https://github.com/infor-design/enterprise-ng.git**.

```sh
npm i
npm run build:lib
npm run start
Navigate to http://localhost:4200/ids-enterprise-ng-demo/checkbox

npm run lint
npm run test:lib
```
<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
