### PR TITLE
70 - Add an example of saving the user settings

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -94,6 +94,7 @@ import { DataGridPagingIndeterminateDemoComponent } from './datagrid/datagrid-pa
 import { DatagridStandalonePagerDemoComponent } from './datagrid/datagrid-standalone-pager.demo';
 import { DataGridPagingServiceDemoComponent } from './datagrid/datagrid-paging-service.demo';
 import { DataGridRowReorderDemoComponent } from './datagrid/datagrid-rowreorder.demo';
+import { DataGridSaveUserSettingsDemoComponent } from './datagrid/datagrid-save-user-settings.demo';
 import { DataGridServiceDemoComponent } from './datagrid/datagrid-service.demo';
 import { DataGridSettingsDemoComponent } from './datagrid/datagrid-settings.demo';
 import { DataGridStandardFormatterDemoComponent } from './datagrid/datagrid-standard-formatter.demo';
@@ -285,6 +286,7 @@ import { ApplicationMenuRoleSwitcherDemoComponent } from './application-menu/app
     DatagridStandalonePagerDemoComponent,
     DataGridPagingServiceDemoComponent,
     DataGridRowReorderDemoComponent,
+    DataGridSaveUserSettingsDemoComponent,
     DataGridServiceDemoComponent,
     DataGridSettingsDemoComponent,
     DataGridStandardFormatterDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -59,6 +59,7 @@ import { DataGridMixedSelectionDemoComponent } from './datagrid/datagrid-mixed-s
 import { DataGridPagingIndeterminateDemoComponent } from './datagrid/datagrid-paging-indeterminate.demo';
 import { DatagridStandalonePagerDemoComponent } from './datagrid/datagrid-standalone-pager.demo';
 import { DataGridPagingServiceDemoComponent } from './datagrid/datagrid-paging-service.demo';
+import { DataGridSaveUserSettingsDemoComponent } from './datagrid/datagrid-save-user-settings.demo';
 import { DataGridServiceDemoComponent } from './datagrid/datagrid-service.demo';
 import { DataGridSettingsDemoComponent } from './datagrid/datagrid-settings.demo';
 import { DataGridStandardFormatterDemoComponent } from './datagrid/datagrid-standard-formatter.demo';
@@ -221,6 +222,7 @@ export const routes: Routes = [
   { path: 'datagrid-mixed-selection',               component: DataGridMixedSelectionDemoComponent },
   { path: 'datagrid-paging-indeterminate',          component: DataGridPagingIndeterminateDemoComponent },
   { path: 'datagrid-paging-service',                component: DataGridPagingServiceDemoComponent },
+  { path: 'datagrid-save-user-settings',            component: DataGridSaveUserSettingsDemoComponent },
   { path: 'datagrid-test-settings',                 component: DataGridTestSettingsDemoComponent },
   { path: 'datagrid-service',                       component: DataGridServiceDemoComponent },
   { path: 'datagrid-settings',                      component: DataGridSettingsDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -76,6 +76,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-paging-service']"><span>DataGrid - Paging Service</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-paging-indeterminate']"><span>DataGrid - Paging Indeterminate</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-rowreorder']"><span>DataGrid - Row Reorder</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['datagrid-save-user-settings']"><span>DataGrid - Save User Settings</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-standalone-pager']"><span>DataGrid - Standalone Pager</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-standard-formatter']"><span>DataGrid - Standard Formatter</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-service']"><span>DataGrid - Service</span></a></div>

--- a/src/app/datagrid/datagrid-paging-data.ts
+++ b/src/app/datagrid/datagrid-paging-data.ts
@@ -1,12 +1,12 @@
 /* tslint:disable */
 export const PAGING_COLUMNS: SohoDataGridColumn[] = [
   { id: 'selectionCheckbox', sortable: false, resizable: false, width: 50, formatter: Soho.Formatters.SelectionCheckbox, align: 'center', exportable: false },
-  { id: 'productId',   name: 'Product Id',   field: 'productId',   sortable: false, filterType: 'integer', width: 140, formatter: Soho.Formatters.Readonly },
+  { id: 'productId',   name: 'Product Id',   field: 'productId',   sortable: false, filterType: 'text', formatter: Soho.Formatters.Readonly },
   { id: 'productName', name: 'Product Name', field: 'productName', sortable: false, filterType: 'text', filterConditions: ['equals', 'contains'], width: 150, formatter: Soho.Formatters.Hyperlink },
-  { id: 'activity',    name: 'Activity',     field: 'activity',    sortable: false, filterType: 'text',    width: 125, hidden: true },
-  { id: 'quantity',    name: 'Quantity',     field: 'quantity',    sortable: false,                        width: 125 },
-  { id: 'price',       name: 'Price',        field: 'price',       sortable: false, filterType: 'decimal', width: 125, formatter: Soho.Formatters.Decimal },
-  { id: 'orderDate',   name: 'Order Date',   field: 'orderDate',   sortable: false, filterType: 'date',    formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy' }
+  { id: 'activity',    name: 'Activity',     field: 'activity',    sortable: false, filterType: 'text',  hidden: true },
+  { id: 'quantity',    name: 'Quantity',     field: 'quantity',    sortable: false, filterType: 'integer' },
+  { id: 'price',       name: 'Price',        field: 'price',       sortable: false, filterType: 'decimal', formatter: Soho.Formatters.Decimal },
+  { id: 'orderDate',   name: 'Order Date',   field: 'orderDate',   sortable: false, filterType: 'date',  formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy' }
 ];
 /* tslint:enable */
 

--- a/src/app/datagrid/datagrid-save-user-settings.demo.html
+++ b/src/app/datagrid/datagrid-save-user-settings.demo.html
@@ -1,0 +1,10 @@
+<div class="full-width full-height scrollable-flex">
+
+  <soho-toolbar>
+    <soho-toolbar-title>
+      <span soho-toolbar-section-title>Soho Data Grid - Save User Settings</span>
+    </soho-toolbar-title>
+  </soho-toolbar>
+
+  <div soho-datagrid *ngIf="gridOptions" [gridOptions]="gridOptions"></div>
+</div>

--- a/src/app/datagrid/datagrid-save-user-settings.demo.ts
+++ b/src/app/datagrid/datagrid-save-user-settings.demo.ts
@@ -1,0 +1,66 @@
+import {
+  AfterViewChecked,
+  ChangeDetectionStrategy, ChangeDetectorRef,
+  Component,
+  NgZone,
+  OnInit,
+  ViewChild
+} from '@angular/core';
+import { SohoDataGridComponent } from 'ids-enterprise-ng';
+
+import {
+  PAGING_COLUMNS,
+  PAGING_DATA
+} from './datagrid-paging-data';
+
+@Component({
+  selector: 'app-datagrid-save-user-settings-demo',
+  templateUrl: './datagrid-save-user-settings.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DataGridSaveUserSettingsDemoComponent implements AfterViewChecked, OnInit {
+  @ViewChild(SohoDataGridComponent, { static: false }) sohoDataGridComponent: SohoDataGridComponent;
+
+  constructor(
+  ) {}
+
+  gridOptions: SohoDataGridOptions = undefined;
+  selectedRow = 0;
+  updateSelectedRow = false;
+
+  ngOnInit() {
+    this.gridOptions = this.buildGridOptions();
+  }
+
+  ngAfterViewChecked() {
+    if (this.sohoDataGridComponent && this.updateSelectedRow) {
+      this.sohoDataGridComponent.selectRows([this.selectedRow]);
+      this.updateSelectedRow = false;
+    }
+  }
+
+  private buildGridOptions(): SohoDataGridOptions {
+    return {
+      columns: PAGING_COLUMNS,
+      dataset: PAGING_DATA,
+      selectable: 'multiple',
+      paging: true,
+      columnReorder: true,
+      pagesize: 20,
+      pagesizes: [ 5, 10, 25, 100 ],
+      sortable: false,
+      filterable: true,
+      rowHeight: 'short',
+      rowReorder: true,
+      saveUserSettings: {
+        columns: true,
+        rowHeight: true,
+        sortOrder: true,
+        pagesize: true,
+        activePage: true,
+        filter: true
+      }
+    } as SohoDataGridOptions;
+  }
+
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Based on a teams discussion and #70 made a start up example of saving user settings.

**Related github/jira issue (required)**:
#70 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-save-user-settings
- reorder and resize columns
- reload the page
- filter 
- reload the page