### PR TITLE
Changed column editor to use function expression

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -83,8 +83,8 @@ export class SohoAngularEditorAdapter implements ExtendedSohoDataGridCellEditor 
     // @todo talk to Tim about removing this requirement.
     this.input = $(this.componentRef.location.nativeElement).find('input:first');
     this.className = this.componentRef.instance
-        && this.componentRef.instance.className
-        ? this.componentRef.instance.className : '.editor';
+      && this.componentRef.instance.className
+      ? this.componentRef.instance.className : '.editor';
   }
 
   val(value?: any): any {
@@ -2160,7 +2160,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
     // Create an injector that will provide the arguments for the
     // component.
     // const injector = ReflectiveInjector.resolveAndCreate([{ provide: 'args', useValue: args }], this.injector);
-    const injector = Injector.create({ providers: [{ provide: 'args', useValue: args }], parent: this.injector});
+    const injector = Injector.create({ providers: [{ provide: 'args', useValue: args }], parent: this.injector });
 
     // Create the component, in the container.
     const component = factory.create(injector, [], container);
@@ -2288,15 +2288,15 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
         .on('selected', (e: any, args: SohoDataGridSelectedRow[]) => this.onSelected({ e, rows: args }))
         .on('settingschanged', (e: any, args: SohoDataGridSettingsChangedEvent) => { this.onSettingsChanged(args); })
         .on('sorted', (e: any, args: SohoDataGridSortedEvent) => { this.onSorted(args); });
-      });
+    });
 
-      // Initialise the SohoXi control.
-      this.jQueryElement.datagrid(this._gridOptions);
+    // Initialise the SohoXi control.
+    this.jQueryElement.datagrid(this._gridOptions);
 
-      // Once the control is initialised, extract the control
-      // plug-in from the element.  The element name is
-      // defined by the plug-in, but in this case is 'datagrid'.
-      this.datagrid = this.jQueryElement.data('datagrid');
+    // Once the control is initialised, extract the control
+    // plug-in from the element.  The element name is
+    // defined by the plug-in, but in this case is 'datagrid'.
+    this.datagrid = this.jQueryElement.data('datagrid');
 
     // If "auto" and there's a service, get the columns from it.
     // (may want to check if columns have already been set? Error?)
@@ -2395,7 +2395,10 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
     // Add an adapter for all the columns using an component as an editor.
     this._gridOptions.columns.forEach((c) => {
       if (c.editorComponent) {
-        c.editor = (row?: any, cell?: any, value?: any, container?: JQuery, col?: SohoDataGridColumn, e?: any, api?: any, item?: any) => {
+        // Use a `function expression` rather than an `arrow function` as the editor is used
+        // as constructor.
+        // tslint:disable-next-line: max-line-length
+        c.editor = function (row?: any, cell?: any, value?: any, container?: JQuery, col?: SohoDataGridColumn, e?: any, api?: any, item?: any) {
           return new SohoAngularEditorAdapter(c.editorComponent, { row, cell, value, container: container[0], col, e, api, item });
         };
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the inability to edit columns in a datagrid using angular editor components.  This issue looks to be caused by a "tightening" of the rules in the JavaScript VM/TS Compiler.

**Related github/jira issue (required)**:

Closes #621 

**Steps necessary to review your pull request (required)**:

Clone repository
```sh
npm i
npm build:lib
npm run start
```
Navigate to http://localhost:4200/ids-enterprise-ng-demo/datagrid-code-block-editor
Click on a cell in the Code Block column.
The cell should become editable.
