### PR TITLE
SOHO-614-Calendar-Add eventToolTip and iconToolTip options and add callback to contextMenu.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 6.0.0 Features
 
+- `[Calendar]` - Added eventToolTip, iconTooltip and callback for contextMenu. `VW` ([#614](https://github.com/infor-design/enterprise-ng/pull/614))
 - `[General]` Upgraded @angular/cli (to 8.0.x) and @angular/core (to 8.0.x).  `BTHH` ([Pull Request 578](https://github.com/infor-design/enterprise-ng/pull/578))
     - support for Node 10.9.0+
     - support for TypeScript 3.4.x

--- a/projects/ids-enterprise-ng/src/lib/calendar/soho-calendar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/calendar/soho-calendar.component.ts
@@ -166,6 +166,42 @@ export class SohoCalendarComponent implements AfterViewChecked, AfterViewInit, O
   }
 
   /**
+   * If false the mouseover text or day event will not be shown.
+   */
+  @Input() set eventTooltip(eventTooltip: string | SohoCalendarTooltipFunction) {
+    this._calendarOptions.eventTooltip = eventTooltip;
+    if (this.calendar) {
+      this.calendar.settings.eventTooltip = eventTooltip;
+      this.markForRefresh();
+    }
+  }
+  get eventTooltip(): string | SohoCalendarTooltipFunction {
+    if (this.calendar) {
+      return this.calendar.settings.eventTooltip;
+    }
+
+    return this._calendarOptions.eventTooltip;
+  }
+
+  /**
+   * If false the mouseover text for event icon will not be shown.
+   */
+  @Input() set iconTooltip(iconTooltip: string | SohoCalendarTooltipFunction) {
+    this._calendarOptions.iconTooltip = iconTooltip;
+    if (this.calendar) {
+      this.calendar.settings.iconTooltip = iconTooltip;
+      this.markForRefresh();
+    }
+  }
+  get iconTooltip(): string | SohoCalendarTooltipFunction {
+    if (this.calendar) {
+      return this.calendar.settings.iconTooltip;
+    }
+
+    return this._calendarOptions.iconTooltip;
+  }
+
+  /**
    * Fires when a month is rendered, allowing you to pass back events or event types to show.
    */
   @Input() set onRenderMonth(onRenderMonth: Function) {
@@ -316,6 +352,7 @@ export class SohoCalendarComponent implements AfterViewChecked, AfterViewInit, O
   @Output() monthRendered = new EventEmitter<SohoCalendarRenderMonthEvent>();
   @Output() eventClick = new EventEmitter<SohoCalendarEventClickEvent>();
   @Output() eventDblClick = new EventEmitter<SohoCalendarEventClickEvent>();
+  @Output() eventContextMenu = new EventEmitter<SohoCalendarEventClickEvent>();
 
   /**
    * Local variables
@@ -341,7 +378,8 @@ export class SohoCalendarComponent implements AfterViewChecked, AfterViewInit, O
       .on('selected', (e: any, event: SohoCalendarDateSelectedEvent) => this.onSelectedEvent(event))
       .on('monthrendered', (e: any, args: SohoCalendarRenderMonthEvent) => this.onMonthRenderedEvent(args))
       .on('eventclick', (e: any, args: SohoCalendarEventClickEvent) => this.onEventClick(args))
-      .on('eventdblclick', (e: any, args: SohoCalendarEventClickEvent) => this.onEventDblClick(args));
+      .on('eventdblclick', (e: any, args: SohoCalendarEventClickEvent) => this.onEventDblClick(args))
+        .on('contextmenu', (e: any, args: SohoCalendarEventClickEvent) => this.onEventContextMenu(args));
 
       // Initialise the Soho control.
       this.jQueryElement.calendar(this._calendarOptions);
@@ -379,6 +417,10 @@ export class SohoCalendarComponent implements AfterViewChecked, AfterViewInit, O
 
   onEventDblClick(event: SohoCalendarEventClickEvent) {
     this.ngZone.run(() => this.eventDblClick.emit(event));
+  }
+
+  onEventContextMenu(event: SohoCalendarEventClickEvent) {
+    this.ngZone.run(() => this.eventContextMenu.emit(event));
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/calendar/soho-calendar.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/calendar/soho-calendar.d.ts
@@ -29,6 +29,16 @@ interface SohoCalendarDayEvents {
 
 type SohoCalendarColors = 'ruby' | 'azure' | 'amber' | 'emerald' | 'turquoise' | 'amethyst' | 'slate' | 'graphite';
 
+interface SohoCalendarTooltipFunction {
+  eventData: SohoCalendarEventData;
+}
+
+type SohoCalendarEventData = (
+  month?: number,
+  year?: number,
+  event?: SohoCalendarEvent
+) => void;
+
 interface SohoCalendarEventType {
   id: string;
   label: string;
@@ -81,6 +91,7 @@ interface SohoCalendarEventClickEvent {
   month?: number;
   year?: number;
   event?: SohoCalendarEvent;
+  originalEvent?: JQuery.TriggeredEvent;
 }
 
 interface SohoCalendarRenderMonthEvent {
@@ -97,6 +108,8 @@ interface SohoCalendarOptions {
   month?: number;
   year?: number;
   showViewChanger?: boolean;
+  eventTooltip?: string | SohoCalendarTooltipFunction;
+  iconTooltip?: string | SohoCalendarTooltipFunction;
   onRenderMonth?: Function; // (node: any, response: (SohoCalendarEvent, SohoCalendarEventType) => void) => void;
   onSelected?: Function; // (node: TNode, args: SohoCalendarDaySelectedEvent) => void;
   template?: string;
@@ -170,6 +183,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
   calendar(options?: SohoCalendarOptions): JQuery;
   on(events: 'selected', handler: JQuery.EventHandlerBase<any, SohoCalendarDateSelectedEvent>): this;
   on(events: 'monthrendered', handler: JQuery.EventHandlerBase<any, SohoCalendarRenderMonthEvent>): this;
-  on(events: 'eventclick', handler: JQuery.EventHandlerBase<any, SohoCalendarRenderMonthEvent>): this;
-  on(events: 'eventdblclick', handler: JQuery.EventHandlerBase<any, SohoCalendarRenderMonthEvent>): this;
+  on(events: 'eventclick', handler: JQuery.EventHandlerBase<any, SohoCalendarEventClickEvent>): this;
+  on(events: 'eventdblclick', handler: JQuery.EventHandlerBase<any, SohoCalendarEventClickEvent>): this;
+  on(events: 'contextmenu', handler: JQuery.EventHandlerBase<any, SohoCalendarEventClickEvent>): this;
 }

--- a/src/app/calendar/calendar-updated.demo.html
+++ b/src/app/calendar/calendar-updated.demo.html
@@ -7,6 +7,8 @@
     (monthRendered)="onRenderMonth($event)"
     (selected)="onSelected($event)"
     (dblclick)="onDblClick($event)"
+     [eventTooltip]="eventTooltip"
+     [iconTooltip]="iconTooltip"
 >
   <div soho-calendar-monthview></div>
 </div>

--- a/src/app/calendar/calendar-updated.demo.ts
+++ b/src/app/calendar/calendar-updated.demo.ts
@@ -25,6 +25,14 @@ export class CalendarUpdatedDemoComponent {
     private monthViewService: CalendarDemoService
   ) { }
 
+  public iconToolTip = (eventData: any) => {
+    console.log('iconToolTip');
+  }
+
+  public eventTooltip = (eventData: any) => {
+    console.log('iconToolTip');
+  }
+
   onRenderMonth(event: SohoCalendarRenderMonthEvent) {
     console.log('onRenderMonth', event);
     if (this.eventsLoaded) {

--- a/src/app/calendar/calendar.demo.html
+++ b/src/app/calendar/calendar.demo.html
@@ -9,6 +9,9 @@
     (selected)="onSelected($event)"
     (eventClick)="onEventClicked($event)"
     (eventDblClick)="onEventDblClicked($event)"
+     (eventContextMenu)="onCalendarEventContextMenu($event)"
+     [eventTooltip]="eventTooltip"
+     [iconTooltip]="iconTooltip"
 >
   <div soho-calendar-monthview></div>
 </div>

--- a/src/app/calendar/calendar.demo.ts
+++ b/src/app/calendar/calendar.demo.ts
@@ -24,6 +24,8 @@ export class CalendarDemoComponent {
   public showViewChanger = false;
   public eventTypes: [];
   public events: [];
+  public iconTooltip = 'status';
+  public eventTooltip = 'comments';
 
   public onRenderMonthCallback = (node: Node, response: Function) => {
     this.monthViewService.getCalendarEventTypes().subscribe((types) => {
@@ -57,5 +59,12 @@ export class CalendarDemoComponent {
   onEventDblClicked(event: SohoCalendarEventClickEvent) {
     this.toastService.show({ title: 'Calendar Test', message: 'Event "' + event.event.subject + '" Double Clicked' });
     console.log('onEventDblClick', event);
+  }
+
+  onCalendarEventContextMenu(event: SohoCalendarEventClickEvent) {
+    if (event) {
+      this.toastService.show({ title: 'Calendar Test', message: 'Event "' + event.event.subject + '" ContextMenu' });
+      console.log('onEventContextMenu', event);
+    }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adding eventToolTip to display tooltip on calendar event.
Adding iconToolTip to display icon tooltip on calendar event.
Adding contextMenu callback to display context menu on calendar event.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/SOHO-2518 and 
https://github.com/infor-design/enterprise-ng/issues/614

**Steps necessary to review your pull request (required)**:
http://localhost:4200/ids-enterprise-ng-demo/calendar-monthview
Hover over an event - it should show event tooltip
Hover over an event icon - it should show icon tooltip
Right click on an event - it should show a toast message 

