### PR TITLE
Add support for locale option on SohoDatePickerOptions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### 6.0.0 Chore & Maintenance
 
 - `[Datagrid]` - Added an example showing adding a new row on last cell and hitting enter and types for onKeyDown. `TJM` ([#536](https://github.com/infor-design/enterprise-ng/pull/536))
+- `[Datepicker]` - Added support for the locale option. `MAF` ([#631](https://github.com/infor-design/enterprise-ng/issues/631))
 - `[HomePage]` - Added `soho-homepage-sizer` directive to set the homepage's element height. `PWP` ([#571](https://github.com/infor-design/enterprise-ng/pull/571))
 - `[HomePage]` - Added `refresh` method types to the homepage API. `TJM` ([#2632](https://github.com/infor-design/enterprise/pull/2632))
 

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -239,6 +239,16 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<any> imple
   }
 
   /**
+   * The name of the locale to use for this instance. If not set, the current locale will be used.
+   */
+  @Input() set locale(locale: string) {
+    this._options.locale = locale;
+    if (this.datepicker) {
+      this.markForRefresh();
+    }
+  }
+
+  /**
    * Calendar's name. Currently just 'gregorian' or 'islamic-umalqura'
    */
   @Input() set calendarName(calendarName: SohoDatePickerCalendarName) {

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.d.ts
@@ -65,6 +65,9 @@ interface SohoDatePickerOptions {
   /** Use range of two dates options. */
   range?:  SohoDatePickerRange;
 
+  /** The name of the locale to use for this instance. If not set, the current locale will be used. */
+  locale?: string;
+
   /** Calendar name. */
   calendarName?:  SohoDatePickerCalendarName;
 

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
@@ -22,6 +22,7 @@ import { SohoDatePickerModule, SohoDatePickerComponent } from './index';
       [showLegend]="_showLegend"
       [showMonthYearPicker]="_showMonthYearPicker"
       [legend]="_legend"
+      [locale]="_locale"
       [calendarName]="_calendarName"
       [mode]="_mode"
       [range]="_range"
@@ -144,6 +145,14 @@ class TestDatePickerComponent {
     this._legend = legend;
     if (this.datepicker) {
       this.datepicker.legend = this._legend;
+    }
+  }
+
+  public _locale: string;
+  @Input() set locale(locale: string) {
+    this._locale = locale;
+    if (this.datepicker) {
+      this.datepicker.locale = this._locale;
     }
   }
 
@@ -293,6 +302,7 @@ describe('Soho Datepicker Unit Tests', () => {
       showLegend: false,
       showMonthYearPicker: false,
       legend: [{ name: 'Mondays', color: '#EFA880', dayOfWeek: [1] }],
+      locale: 'ar-SA',
       calendarName: 'islamic-umalqura',
       disable: {
         dates: '',
@@ -329,6 +339,7 @@ describe('Soho Datepicker Unit Tests', () => {
       comp.showLegend = false;
       comp.showMonthYearPicker = false;
       comp.legend = [{ name: 'Mondays', color: '#EFA880', dayOfWeek: [1] }];
+      comp.locale = 'ar-SA';
       comp.calendarName = 'islamic-umalqura';
       comp.disable = {
         dates: '',

--- a/src/app/datepicker/datepicker.demo.html
+++ b/src/app/datepicker/datepicker.demo.html
@@ -135,6 +135,14 @@
                [(ngModel)]="model.validrange" (change)="onChange($event)"/>
       </div>
     </div>
+    <div class="four columns">
+      <div class="field">
+        <label for="setViaOptions" class="label">ar-SA islamic-umalqura in current locale</label>
+        <input soho-datepicker name="islamic-umalqura-date" id="islamic-umalqura-date"
+          [options]="umalquraOptions"
+          [(ngModel)]="model.umalqura" (change)="onChange($event)"/>
+      </div>
+    </div>
   </div>
   <div class="row">
     <div class="four columns">

--- a/src/app/datepicker/datepicker.demo.ts
+++ b/src/app/datepicker/datepicker.demo.ts
@@ -23,7 +23,8 @@ export class DatepickerDemoComponent implements OnInit {
     datetime: '',
     datetime2: '05.04.2018 16:15',
     range: '12/12/2016 - 12/26/2016',
-    range2: '1/12/2017 - 1/16/2017'
+    range2: '1/12/2017 - 1/16/2017',
+    umalqura: ''
   };
   public showModel = false;
   public datepickerDisabled = false;
@@ -61,6 +62,14 @@ export class DatepickerDemoComponent implements OnInit {
     showMonthYearPicker: true,
     legend: [{name: 'Weekends', color: '#EFA836', dayOfWeek: [0, 6]}],
     calendarName:  'gregorian'
+  };
+
+  public umalquraOptions: SohoDatePickerOptions = {
+    mode: 'standard',
+    dateFormat: 'yyyy/MM/dd',
+    showMonthYearPicker: true,
+    calendarName:  'islamic-umalqura',
+    locale: 'ar-SA'
   };
 
   constructor() { }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Add support for the locale option on the SohoDatePickerOptions.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/631

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- pull this branch and build
- go to http://localhost:4200/ids-enterprise-ng-demo/datepicker
- select the datepicker icon for the ar-SA islamic-umalqura in current locale field
- the islamic-umalqura calendar should display

![image](https://user-images.githubusercontent.com/20212079/66066990-44526a00-e510-11e9-96c1-3993658e90ea.png)

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
