### PR TITLE
Soho modal memleak

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## v7.0.0
+
+### 7.0.0 Features
+
+- `[Modal]` Added a new SohoModalModule that would work almost similar to SohoModalDialogModule but fixes memory leak issues. `NBCP` ([#639](https://github.com/infor-design/enterprise-ng/pull/639))
+
 ## v6.1.0
 
 ### 6.1.0 Breaking Changes

--- a/projects/ids-enterprise-ng/src/lib/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/index.ts
@@ -44,6 +44,7 @@ export * from './mask/index';
 export * from './masthead/index';
 export * from './menu-button/index';
 export * from './message/index';
+export * from './modal/index';
 export * from './modal-dialog/index';
 export * from './notification/index';
 export * from './pager/index';

--- a/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.d.ts
@@ -150,6 +150,11 @@ interface SohoModalStatic {
   resize();
 
   /**
+   * Open the modal dialog.
+   */
+  open(): void;
+
+  /**
    * Close the modal dialog.
    *
    * @param destroy - destroy the html elements.

--- a/projects/ids-enterprise-ng/src/lib/modal/README.md
+++ b/projects/ids-enterprise-ng/src/lib/modal/README.md
@@ -1,0 +1,214 @@
+# SoHoXi Angular Component : Modal
+
+## Description
+
+This component provides access from Angular to the SoHoXi `modal` JQuery control.
+
+Modal dialogs allow users to enter a few key pieces of information without moving to a different page or task.
+
+### Usage
+
+Creating modal dialogs requires the injection of the service `SohoModalDialogService` into the hosting component.
+To access this service, you will need to inject `SohoModalDialogService` into the constructor of the relevant class.
+If this is a class managed by Angular (such as a Component) then adding the following will work:
+
+```typescript
+constructor(private modalService: SohoModalDialogService) {
+}
+```
+
+Angular requires a placeholder component to parent the
+dialog component when it is instantiated.  The location of the component
+is up to the calling application, but in this example the hosting component
+is used.
+
+```typescript
+@ViewChild('dialogPlaceholder', { read: ViewContainerRef }) placeholder: ViewContainerRef;
+```
+
+In the markup for the hosting component add:
+
+```html
+<!-- div #dialogPlaceholder will contain the child component -->
+<div #dialogPlaceholder></div>
+```
+
+To open the dialog, the `modal` is called on the `SohoModalDialogService`, as follows:
+
+```typescript
+this.dialog = this.modalService
+  .modal(ExampleModalDialogComponent, this.placeholder)
+  .open();
+```
+
+This returns a typed implementation of `SohoModalDialogRef`.
+
+**NOTE:**  Angular needs to be able to find the dynamic dialog component for it to be able to
+instantiate it, so you **MUST** add the component into the *entryComponents* of the hosting
+module. For example:
+
+```typescript
+@NgModule({
+  declarations: [ ExampleModalDialogComponent ],
+  exports: [],
+  imports: [ ..., SohoComonentsModule ],
+  providers: [],
+  entryComponents:[ ExampleModalDialogComponent ]
+  ]
+})
+export class ExampleModuleDialogModule {}
+```
+
+## Methods
+
+| Name | Description |
+| --- | --- |
+| `modal` | Creates a modal dialog, under the placeholder, based on the given component. |
+| `message` | Creates a modal dialog using the html (or jQuery) content |
+
+## SohoModalDialogRef
+
+| Name | Description |
+| --- | --- |
+| `open()` | Opens the dialog. |
+| `apply((c: T) => void)` | Executes the given function, with the instantiated component instance as an argument.  This is allow the concrete component to be interacted with. |
+| `close(boolean)` | Closes the modal dialog, if open.  The dialog is not closed fully until the 'afterClosed' event is fired. |
+| `options(SohoModalOptions)` | Applies the given Soho options to the modal, overrides all options. |
+| `frameHeight(number)` | Sets the extra frame height for the dialog. |
+| `title(string)` | Sets the title for the dialog. |
+| `buttons(SohoModalButton[])` | Sets the button to use for the modal dialog. |
+| `id(string)` | Sets the element id for the modal dialog. |
+| `trigger(SohoModalTriggerType)` | Sets the trigger for the modal dialog. |
+| `isAlert(boolean)` | Sets the isAlert option - controls the styling and assessibility. |
+| `content(string | JQuery)` | Defines the content of the dialog, if not using an Angular component. |
+| `cssClass(string)` | Extra CSS for the markup . |
+| `autoFocus(boolean)` | Auto Focus the dialog. TBC |
+| `beforeOpen(() => boolean)` | 'Registers a 'beforeOpen' callback, which can veto open. |
+| `afterOpen(Function)` | 'Registers an 'afterOpen' callback. |
+| `opened(Function)` | 'Registers an 'opened' callback - before the dialog is opend. |
+| `beforeClose((dialogRef: SohoModalDialogRef<T>) => boolean)` | 'Registers a 'beforeClose' callback, which can veto the close. |
+| `afterClose(Function)` | 'Registers an 'afterClose' callback. |
+| `closed(Function)` | 'Registers a 'closed' callback - before dialog is closed. |
+| `beforeDestroy(() => boolean))` | 'Registers a 'beforeDestroy' guard - vetoing the destruction. USE WITH CARE! |
+
+## Events
+
+| Name | Description |
+| --- | --- |
+
+## Examples
+
+### Simple Modal dialog
+
+This example show how a simple modal dialog component can be instantiated.
+
+```typescript
+  this.dialog = this.modalService
+    .modal<ModalDialogComponent>(ModalDialogComponent, this.placeholder)
+    .buttons([{text: 'OK', click: () => { this.dialog.close(); }, isDefault: true}])
+    .title('My Dialog')
+    .open());
+```
+
+### Simple Message dialog
+
+```typescript
+openMessage() {
+  this.dialog = this.modalService
+    .message('<span class="longer-message">Are you sure you want to delete this page?</span>')
+    .buttons([{text: 'Submit', click: () => { this.dialog.close(); }, isDefault: true}])
+    .title('Confirmation')
+    .open();
+}
+```
+
+### Setting the dialog result
+
+Setting the `dialogResult` can be achieved in several ways, the simpliest is to
+use the `close` method on `SohoModalDialogRef` in your button handler, which takes the
+dialog result as an argument.  This is set on the dialog reference and then passed into
+the `afterClose` event handler.
+
+Alternatively, you can call the `setDialogResult` method on the dialog reference, which
+also takes a dialog result as an argument.  This allow the closing of the dialog to be
+decoupled from the result.
+
+The `dialogResult` could be the _model_ used by the underlying component, or a simple status
+indicator, such as `OK` or `CANCELLED`.
+
+Here is an example for a simple message returning a status as a result:
+
+```typescript
+openMessage() {
+  const dialog = this.modalService
+    .message('<span class="longer-message">Are you sure you want to delete this page?</span>')
+    .buttons(
+      [{ text: 'No', click: () => { dialog.close('I pressed YES'); } },
+       { text: 'Yes', click: () => { dialog.close('I pressed NO'); }, isDefault: true }])
+    .title(this.title)
+    .open()
+    .afterClose(result => {
+      console.log(`The result was ${result}`);
+  });
+}
+```
+
+To provide access to any model present on the underlying dialog component, a reference to
+this component is passed to the `beforeClose`, `closed` and `afterClose` callbacks.  This
+reference can then be used to interogate the public properties of that `dialogComponent`.
+
+```typescript
+dialogRef.afterClose((result: any, ref: SohoModalDialogRef<ExampleModalDialogComponent>, dialogComponent: ExampleModalDialogComponent) => {
+  console.log(dialogComponent.model.someProperty);
+});
+```
+
+Access to the `dialogComponent` is also possible from the `SohoModalDialogRef` using the `componentDialog` property.
+
+### Vetoable Closure using 'beforeClose'
+
+To veto the closure of a modal dialog, the `SohoModalDialogRef` calls the `beforeClose` guard function.  If this function returns `false`
+the dialog will not be closed.  The `beforeClose` guard can be configured on a modal (or message) dialog. In this example, the closure of
+the dialog is allowed if the underlying model is valid or the dialogResult has been set to 'CANCEL' (in the cancel button).
+
+```typescript
+this.modalService
+  .modal(ExampleModalDialogComponent, this.placeholder)
+  .buttons([
+     { text: 'Cancel', click: () => { dialogRef.close('CANCEL'); } },
+     { text: 'Submit', click: () => { dialogRef.close('SUBMIT'); }, isDefault: true }])
+  .beforeClose( (dialogRef) => dialogRef.dialogComponent.isModelValid || dialogRef.dialogResult === 'CANCEL' );
+  .open();
+```
+
+The `beforeClose` guard function is defined as follows:
+
+```typescript
+(dialogRef: SohoModalDialogRef<T>) => boolean;
+```
+
+Alternatively, the dialog component can implement the `SohoModalDialogVetoableEventGuard`
+interface, see the application demos for an example.
+
+### Using `apply` to set values on the dialog instance
+
+To allow the public properties and methods of a dialog to be accessed as
+part of the dialog creation process, the `apply` method exists on `SohoModalDialogRef`
+to allow the caller full access to the instance of the given component before
+(or after) it is displayed, for example:
+
+```typescript
+this.modalService
+  .modal(ExampleModalDialogComponent, this.placeholder)
+  .buttons(buttons)
+  .apply((c) => { c.value = 'Hello World!'; })
+  .open();
+  ```
+
+The apply methods takes a function, with the following prototype:
+
+```typescript
+(component: T) => void
+```
+
+where T is the type of the dialog component.

--- a/projects/ids-enterprise-ng/src/lib/modal/README.md
+++ b/projects/ids-enterprise-ng/src/lib/modal/README.md
@@ -1,100 +1,76 @@
-# SoHoXi Angular Component : Modal
+# SohoModalModule
 
 ## Description
 
-This component provides access from Angular to the SoHoXi `modal` JQuery control.
+This module provides Angular access to the SoHoXi `modal` JQuery control.
 
-Modal dialogs allow users to enter a few key pieces of information without moving to a different page or task.
+Modals allow users to view/enter information without moving to a different page or task.
 
-### Usage
+## Usage
 
-Creating modal dialogs requires the injection of the service `SohoModalDialogService` into the hosting component.
-To access this service, you will need to inject `SohoModalDialogService` into the constructor of the relevant class.
-If this is a class managed by Angular (such as a Component) then adding the following will work:
+Creating modals requires the injection of the service `SohoModalService` into the hosting component.
+To access this service, you will need to inject `SohoModalService` into the constructor of the relevant class.
 
 ```typescript
-constructor(private modalService: SohoModalDialogService) {
+constructor(private modalService: SohoModalService) {
 }
 ```
 
-Angular requires a placeholder component to parent the
-dialog component when it is instantiated.  The location of the component
-is up to the calling application, but in this example the hosting component
-is used.
-
-```typescript
-@ViewChild('dialogPlaceholder', { read: ViewContainerRef }) placeholder: ViewContainerRef;
-```
-
-In the markup for the hosting component add:
-
-```html
-<!-- div #dialogPlaceholder will contain the child component -->
-<div #dialogPlaceholder></div>
-```
-
-To open the dialog, the `modal` is called on the `SohoModalDialogService`, as follows:
+To open the dialog, call the `modal()` and `open()` method from `SohoModalService`, as follows:
 
 ```typescript
 this.dialog = this.modalService
-  .modal(ExampleModalDialogComponent, this.placeholder)
+  .modal(ExampleModalDialogComponent)
   .open();
 ```
 
-This returns a typed implementation of `SohoModalDialogRef`.
+This returns a typed implementation of `SohoModalRef`.
 
-**NOTE:**  Angular needs to be able to find the dynamic dialog component for it to be able to
-instantiate it, so you **MUST** add the component into the *entryComponents* of the hosting
-module. For example:
+**NOTE:**  Angular needs to be able to find the passed component into the `modal()` method.
+So you **MUST** add the component into the *entryComponents* of the hosting module. For example:
 
 ```typescript
 @NgModule({
   declarations: [ ExampleModalDialogComponent ],
-  exports: [],
-  imports: [ ..., SohoComonentsModule ],
-  providers: [],
-  entryComponents:[ ExampleModalDialogComponent ]
-  ]
+  imports: [ SohoComponentsModule ],
+  entryComponents: [ ExampleModalDialogComponent ]
 })
 export class ExampleModuleDialogModule {}
 ```
 
 ## Methods
 
+### SohoModalService
+
 | Name | Description |
 | --- | --- |
-| `modal` | Creates a modal dialog, under the placeholder, based on the given component. |
-| `message` | Creates a modal dialog using the html (or jQuery) content |
+| `modal<T>(component: ModalComponent<T>, settings = {} as SohoModalOptions)` | Creates a modal dialog intance that contains the given component |
+| `message<T>(content: string, settings = {} as SohoModalOptions)` | Creates a modal dialog using the string content |
 
-## SohoModalDialogRef
+### SohoModalRef
 
 | Name | Description |
 | --- | --- |
 | `open()` | Opens the dialog. |
-| `apply((c: T) => void)` | Executes the given function, with the instantiated component instance as an argument.  This is allow the concrete component to be interacted with. |
-| `close(boolean)` | Closes the modal dialog, if open.  The dialog is not closed fully until the 'afterClosed' event is fired. |
-| `options(SohoModalOptions)` | Applies the given Soho options to the modal, overrides all options. |
-| `frameHeight(number)` | Sets the extra frame height for the dialog. |
-| `title(string)` | Sets the title for the dialog. |
-| `buttons(SohoModalButton[])` | Sets the button to use for the modal dialog. |
-| `id(string)` | Sets the element id for the modal dialog. |
-| `trigger(SohoModalTriggerType)` | Sets the trigger for the modal dialog. |
-| `isAlert(boolean)` | Sets the isAlert option - controls the styling and assessibility. |
-| `content(string | JQuery)` | Defines the content of the dialog, if not using an Angular component. |
-| `cssClass(string)` | Extra CSS for the markup . |
-| `autoFocus(boolean)` | Auto Focus the dialog. TBC |
-| `beforeOpen(() => boolean)` | 'Registers a 'beforeOpen' callback, which can veto open. |
-| `afterOpen(Function)` | 'Registers an 'afterOpen' callback. |
-| `opened(Function)` | 'Registers an 'opened' callback - before the dialog is opend. |
-| `beforeClose((dialogRef: SohoModalDialogRef<T>) => boolean)` | 'Registers a 'beforeClose' callback, which can veto the close. |
-| `afterClose(Function)` | 'Registers an 'afterClose' callback. |
-| `closed(Function)` | 'Registers a 'closed' callback - before dialog is closed. |
+| `apply(fn: (component: T) => void)` | Executes the given function, with the instantiated component instance as an argument.  This is allow the concrete component to be interacted with. |
+| `close(dialogResult?: any)` | Closes the modal dialog, if open.  The dialog is not closed fully until the 'afterClosed' event is fired. |
+| `options(options: SohoModalOptions)` | Applies the given Soho options to the modal, overrides all options. |
+| `frameHeight(frameHeight: number)` | Sets the extra frame height for the dialog. |
+| `title(title: string)` | Sets the title for the dialog. |
+| `buttons(buttons: SohoModalButton[])` | Sets the button to use for the modal dialog. |
+| `id(id: string)` | Sets the element id for the modal dialog. |
+| `trigger(trigger: SohoModalTriggerType)` | Sets the trigger for the modal dialog. |
+| `isAlert(isAlert: boolean)` | Sets the isAlert option - controls the styling and assessibility. |
+| `content(content: string | JQuery)` | Defines the content of the dialog, if not using an Angular component. |
+| `cssClass(cssClass: string)` | Extra CSS for the markup . |
+| `autoFocus(autoFocus: boolean)` | Auto Focus the dialog. TBC |
+| `opened(eventFn: Function)` | 'Registers an 'opened' callback - before the dialog is opened. |
+| `afterOpen(eventFn: Function)` | 'Registers an 'afterOpen' callback. |
+| `closed(eventFn: Function)` | 'Registers a 'closed' callback - before dialog is closed. |
+| `afterClose(eventFn: (result: any))` | 'Registers an 'afterClose' callback that gets the dialog result. |
+| `beforeOpen(() => boolean)` | 'Registers a 'beforeOpen' callback, which can veto open. USE WITH CARE! |
+| `beforeClose(() => boolean)` | 'Registers a 'beforeClose' callback, which can veto the close. |
 | `beforeDestroy(() => boolean))` | 'Registers a 'beforeDestroy' guard - vetoing the destruction. USE WITH CARE! |
-
-## Events
-
-| Name | Description |
-| --- | --- |
 
 ## Examples
 
@@ -104,10 +80,16 @@ This example show how a simple modal dialog component can be instantiated.
 
 ```typescript
   this.dialog = this.modalService
-    .modal<ModalDialogComponent>(ModalDialogComponent, this.placeholder)
-    .buttons([{text: 'OK', click: () => { this.dialog.close(); }, isDefault: true}])
+    .modal(ModalDialogComponent)
+    .buttons([
+      {
+        text: 'OK',
+        click: () => { this.dialog.close(); },
+        isDefault: true
+      }
+    ])
     .title('My Dialog')
-    .open());
+    .open();
 ```
 
 ### Simple Message dialog
@@ -116,7 +98,13 @@ This example show how a simple modal dialog component can be instantiated.
 openMessage() {
   this.dialog = this.modalService
     .message('<span class="longer-message">Are you sure you want to delete this page?</span>')
-    .buttons([{text: 'Submit', click: () => { this.dialog.close(); }, isDefault: true}])
+    .buttons([
+      {
+        text: 'Submit',
+        click: () => { this.dialog.close(); },
+        isDefault: true
+      }
+    ])
     .title('Confirmation')
     .open();
 }
@@ -125,13 +113,12 @@ openMessage() {
 ### Setting the dialog result
 
 Setting the `dialogResult` can be achieved in several ways, the simpliest is to
-use the `close` method on `SohoModalDialogRef` in your button handler, which takes the
+use the `close` method on `SohoModalRef` in your button handler, which takes the
 dialog result as an argument.  This is set on the dialog reference and then passed into
 the `afterClose` event handler.
 
-Alternatively, you can call the `setDialogResult` method on the dialog reference, which
-also takes a dialog result as an argument.  This allow the closing of the dialog to be
-decoupled from the result.
+Alternatively, you can also set it via the `dialogResult` public property of your `SohoModalRef` instance.
+This allow the closing of the dialog to be decoupled from the result.
 
 The `dialogResult` could be the _model_ used by the underlying component, or a simple status
 indicator, such as `OK` or `CANCELLED`.
@@ -149,61 +136,40 @@ openMessage() {
     .open()
     .afterClose(result => {
       console.log(`The result was ${result}`);
-  });
+    });
 }
 ```
 
-To provide access to any model present on the underlying dialog component, a reference to
-this component is passed to the `beforeClose`, `closed` and `afterClose` callbacks.  This
-reference can then be used to interogate the public properties of that `dialogComponent`.
-
-```typescript
-dialogRef.afterClose((result: any, ref: SohoModalDialogRef<ExampleModalDialogComponent>, dialogComponent: ExampleModalDialogComponent) => {
-  console.log(dialogComponent.model.someProperty);
-});
-```
-
-Access to the `dialogComponent` is also possible from the `SohoModalDialogRef` using the `componentDialog` property.
-
 ### Vetoable Closure using 'beforeClose'
 
-To veto the closure of a modal dialog, the `SohoModalDialogRef` calls the `beforeClose` guard function.  If this function returns `false`
+To veto the closure of a modal dialog, the `SohoModalRef` calls the `beforeClose` guard function.  If this function returns `false`
 the dialog will not be closed.  The `beforeClose` guard can be configured on a modal (or message) dialog. In this example, the closure of
 the dialog is allowed if the underlying model is valid or the dialogResult has been set to 'CANCEL' (in the cancel button).
 
 ```typescript
-this.modalService
-  .modal(ExampleModalDialogComponent, this.placeholder)
+this.dialogRef = this.modalService
+  .modal(ExampleModalDialogComponent)
   .buttons([
      { text: 'Cancel', click: () => { dialogRef.close('CANCEL'); } },
      { text: 'Submit', click: () => { dialogRef.close('SUBMIT'); }, isDefault: true }])
-  .beforeClose( (dialogRef) => dialogRef.dialogComponent.isModelValid || dialogRef.dialogResult === 'CANCEL' );
+  .beforeClose(() => this.dialogRef.dialogComponent.isModelValid || this.dialogRef.dialogResult === 'CANCEL' );
   .open();
 ```
 
-The `beforeClose` guard function is defined as follows:
-
-```typescript
-(dialogRef: SohoModalDialogRef<T>) => boolean;
-```
-
-Alternatively, the dialog component can implement the `SohoModalDialogVetoableEventGuard`
-interface, see the application demos for an example.
+`beforeOpen` and `beforeDestroy` also works in a similar manner.
 
 ### Using `apply` to set values on the dialog instance
 
-To allow the public properties and methods of a dialog to be accessed as
-part of the dialog creation process, the `apply` method exists on `SohoModalDialogRef`
-to allow the caller full access to the instance of the given component before
-(or after) it is displayed, for example:
+To allow access to the dialog component's public methods and properties, the `apply` method grants
+access to the instance of the given component before (or after) it is displayed, for example:
 
 ```typescript
 this.modalService
-  .modal(ExampleModalDialogComponent, this.placeholder)
+  .modal(ExampleModalDialogComponent)
   .buttons(buttons)
   .apply((c) => { c.value = 'Hello World!'; })
   .open();
-  ```
+```
 
 The apply methods takes a function, with the following prototype:
 
@@ -211,4 +177,15 @@ The apply methods takes a function, with the following prototype:
 (component: T) => void
 ```
 
-where T is the type of the dialog component.
+where T is the type of the component.
+Alternatively, you can also access the component via the `componentDialog` property.
+
+```typescript
+this.dialogRef = this.modalService
+  .modal(ExampleModalDialogComponent)
+  .buttons(buttons);
+...
+this.dialogRef.componentDialog.value = 'Hello World!';
+...
+this.dialogRef.open();
+```

--- a/projects/ids-enterprise-ng/src/lib/modal/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal/index.ts
@@ -1,0 +1,3 @@
+export * from './soho-modal.module';
+export * from './soho-modal.service';
+export * from './soho-modal.ref';

--- a/projects/ids-enterprise-ng/src/lib/modal/soho-modal.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal/soho-modal.d.ts
@@ -1,0 +1,4 @@
+/**
+ * TODO: append soho-modal-dialog.d.ts contents here after
+ * we remove that old module
+ */

--- a/projects/ids-enterprise-ng/src/lib/modal/soho-modal.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal/soho-modal.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SohoModalService } from './soho-modal.service';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  providers: [
+    SohoModalService
+  ]
+})
+export class SohoModalModule {}

--- a/projects/ids-enterprise-ng/src/lib/modal/soho-modal.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal/soho-modal.ref.ts
@@ -1,0 +1,392 @@
+import {
+  ApplicationRef,
+  ComponentRef,
+  ComponentFactoryResolver,
+  Injector,
+  NgZone
+} from '@angular/core';
+import { fromEvent, Observable } from 'rxjs';
+import { map, tap, take, takeUntil } from 'rxjs/operators';
+import { ModalComponent } from './soho-modal.service';
+
+/**
+ * Wrapper for the jQuery modal control.
+ */
+export class SohoModalRef<T> {
+
+  private componentRef?: ComponentRef<T>;
+  private jQueryElement: JQuery;
+  private modal: SohoModalStatic;
+  private _options: SohoModalOptions = {};
+  // result passed as param to close() method
+  private dialogResult: any;
+
+  // Event Observables
+  private open$: Observable<Event>;
+  private afterOpen$: Observable<Event>;
+  private close$: Observable<Event>;
+  private afterClose$: Observable<any>;
+
+  // vetoable event guards
+  private openEventGuard: (e: Event) => boolean;
+  private closeEventGuard: (e: Event) => boolean;
+  private destroyEventGuard: (e: Event) => boolean;
+
+  /**
+   * returns the component instance inside the modal
+   */
+  public get componentDialog(): T {
+    if (this.componentRef) {
+      return this.componentRef.instance;
+    }
+    return null;
+  }
+
+  /**
+   * Sets the whole options block for this modal dialog.
+   * @param options - the options to set.
+   */
+  options(options: SohoModalOptions): SohoModalRef<T> {
+    this._options = options;
+
+    // @todo update the dialog if required.
+    if (this.modal) {
+      this.modal.settings = options;
+      // @todo - need an api on modal to update settings.
+    }
+
+    return this;
+  }
+
+  /**
+   * Sets the frame height for the dialog.
+   * @param frameHeight - the extra frame height to allow.
+   */
+  frameHeight(frameHeight: number): SohoModalRef<T> {
+    this._options.frameHeight = frameHeight;
+    if (this.modal) {
+      this.modal.settings.frameHeight = frameHeight;
+      // @todo - need an api on modal to update settings.
+    }
+    return this;
+  }
+
+  /**
+   * Sets the title of the modal dialog.
+   * @param title - the title of the dialog.
+   */
+  title(title: string): SohoModalRef<T> {
+    this._options.title = title;
+    if (this.modal) {
+      this.modal.settings.title = title;
+      // @todo - need an api on modal to update settings.
+    }
+    return this;
+  }
+
+  /**
+   * Sets the buttons to use on the modal dialog.
+   * @param buttons - list of buttons to display
+   */
+  buttons(buttons: SohoModalButton[]): SohoModalRef<T> {
+    this._options.buttons = buttons;
+    if (this.modal) {
+      this.modal.settings.buttons = buttons;
+      // @todo - need an api on modal to update settings.
+    }
+    return this;
+  }
+
+  /**
+   * Sets the 'id' that the modal control uses.
+   * @param id - the id.
+   */
+  id(id: string): SohoModalRef<T> {
+    this._options.id = id;
+    if (this.modal) {
+      this.modal.settings.id = id;
+      // @todo - need an api on modal to update settings.
+    }
+    return this;
+  }
+
+  /**
+   * Sets the 'trigger' that the modal control uses.
+   * @param trigger - when to open the dialog.
+   */
+  trigger(trigger: SohoModalTriggerType): SohoModalRef<T> {
+    this._options.trigger = trigger;
+    if (this.modal) {
+      this.modal.settings.trigger = trigger;
+      // @todo - need an api on modal to update settings.
+    }
+    return this;
+  }
+
+  /**
+   * Sets the 'isAlert' that the modal control uses.
+   * @param isAlert - true if this dialog is to be styled an an alert.
+   */
+  isAlert(isAlert: boolean): SohoModalRef<T> {
+    this._options.isAlert = isAlert;
+    if (this.modal) {
+      this.modal.settings.isAlert = isAlert;
+      // @todo - need an api on modal to update settings.
+    }
+    return this;
+  }
+
+  /**
+   * Sets the fullsize configuration that the modal control uses.
+   * @param fullsize - The full size configuration to use.
+   */
+  fullsize(fullsize: SohoModalFullSize): SohoModalRef<T> {
+    this._options.fullsize = fullsize;
+    if (this.modal) {
+      this.modal.settings.fullsize = fullsize;
+    }
+    return this;
+  }
+
+  /**
+   * Sets the breakpoint configuration that the modal control uses in full size mode(s).
+   * @param breakpoint - The full size configuration to use.
+   */
+  breakpoint(breakpoint: SohoModalBreakPoint): SohoModalRef<T> {
+    this._options.breakpoint = breakpoint;
+    if (this.modal) {
+      this.modal.settings.breakpoint = breakpoint;
+    }
+    return this;
+  }
+
+  /**
+   * Sets the 'content' that the modal control uses.
+   * @param content - a selector or string representing the dialog content.
+   */
+  content(content: JQuery | string): SohoModalRef<T> {
+    this._options.content = content;
+    if (this.modal) {
+      this.modal.settings.content = content;
+      // @todo - need an api on modal to update content.
+    }
+    return this;
+  }
+
+  /**
+   * Sets the 'cssClass' of the modal control.
+   * @param cssClass - css class name
+   */
+  cssClass(cssClass: string): SohoModalRef<T> {
+    this._options.cssClass = cssClass;
+    if (this.modal) {
+      this.modal.settings.cssClass = cssClass;
+      // @todo - need an api on modal to update settings.
+    }
+    return this;
+  }
+
+  /**
+   * Sets the 'autoFocus' of the modal control.
+   * @param autoFocus -if true; the dialog will autoFocus.
+   */
+  autoFocus(autoFocus: boolean): SohoModalRef<T> {
+    this._options.autoFocus = autoFocus;
+    if (this.modal) {
+      this.modal.settings.autoFocus = autoFocus;
+      // @todo - need an api on modal to update settings.
+    }
+    return this;
+  }
+
+  /**
+   * Applies a function to the instantiated component,
+   * allowing the component to be modified, or initialised.
+   *
+   * The function is provided with a typed value for the
+   * instance.
+   *
+   * @param component - the instantated instance.
+   */
+  apply(fn: (component: T) => void): SohoModalRef<T> {
+    if (fn && this.componentDialog) {
+      fn(this.componentDialog);
+    }
+    return this;
+  }
+
+  /**
+   * Constructor.
+   */
+  constructor(
+    private appRef: ApplicationRef,
+    private componentFactoryResolver: ComponentFactoryResolver,
+    private injector: Injector,
+    private ngZone: NgZone,
+    private settings: SohoModalOptions,
+    private modalComponent?: ModalComponent<T>
+  ) {
+    this.options(settings);
+
+    if (modalComponent) {
+      // create component
+      this.componentRef = componentFactoryResolver
+        .resolveComponentFactory(modalComponent)
+        .create(this.injector);
+      appRef.attachView(this.componentRef.hostView);
+
+      // set modal content
+      this._options.content = jQuery(this.componentRef.location.nativeElement);
+    }
+  }
+
+  /**
+   * Handles destruction of component and modal
+   */
+  private destroy() {
+    // Close vetoable event listeners
+    this.jQueryElement.off('beforeopen');
+    this.jQueryElement.off('beforeclose');
+    this.jQueryElement.off('beforedestroy');
+
+    if (this.componentRef) {
+      // destroy component
+      this.ngZone.run(() => {
+        this.appRef.detachView(this.componentRef.hostView);
+        this.componentRef.destroy();
+        this.componentRef = null;
+      });
+    }
+
+    if (this.modal) {
+      // destroy modal
+      this.ngZone.runOutsideAngular(() => {
+        this.modal.destroy();
+        this.modal = null;
+      });
+    }
+  }
+
+  /**
+   * Returns true or executes the event guard if it exists
+   * @param eventFn Veto function that returns boolean
+   * @param e       Event Object from JQuery
+   */
+  private checkEventGuard(guardFn: (e: Event) => boolean, e: Event) {
+    return guardFn ? this.ngZone.run(() => guardFn(e)) : true;
+  }
+
+  /**
+   * Opens the modal
+   */
+  open(): SohoModalRef<T> {
+    this.jQueryElement = this.ngZone.runOutsideAngular(() => {
+      const element = jQuery('body');
+      element.modal(this._options);
+
+      this.modal = element.data('modal');
+      return this.modal.element;
+    });
+
+    // Create Event Observables
+    this.open$ = fromEvent(this.jQueryElement, 'open');
+    this.afterOpen$ = fromEvent(this.jQueryElement, 'afteropen');
+    this.close$ = fromEvent(this.jQueryElement, 'close');
+    this.afterClose$ = fromEvent(this.jQueryElement, 'afterclose').pipe(
+      take(1),
+      tap(() => this.destroy()),
+      map(() => this.dialogResult)
+    );
+
+    // Setup vetoable event listeners
+    this.jQueryElement.on('beforeopen', (e: Event) => this.checkEventGuard(this.openEventGuard, e));
+    this.jQueryElement.on('beforeclose', (e: Event) => this.checkEventGuard(this.closeEventGuard, e));
+    this.jQueryElement.on('beforedestroy', (e: Event) => this.checkEventGuard(this.destroyEventGuard, e));
+
+    return this;
+  }
+
+  /**
+   * Closes the modal and sets the returned result
+   * @param dialogResult - optional result received in afterClose callback
+   */
+  close(dialogResult?: any): SohoModalRef<T> {
+    this.dialogResult = dialogResult;
+    this.modal.close();
+    return this;
+  }
+
+  /**
+   * Subscribes to the modal's event hooks and keeps it until afterclose event is fired
+   * @param observable$ the observable that listens to the event
+   * @param callback    the callback function
+   */
+  private executeCallback(observable$: Observable<Event>, callback: Function) {
+    // afterClose shall close all event subscriptions
+    observable$.pipe(takeUntil(this.afterClose$))
+      .subscribe((e: Event) => this.ngZone.run(() => callback(e, this, this.componentDialog)));
+  }
+
+  /**
+   * Executes the callback for the opened event
+   * @param eventFn opened event hook
+   */
+  opened(eventFn: Function): SohoModalRef<T> {
+    this.executeCallback(this.open$, eventFn);
+    return this;
+  }
+
+  /**
+   * Executes the callback for the after open event
+   * @param eventFn after open event hook
+   */
+  afterOpen(eventFn: Function): SohoModalRef<T> {
+    this.executeCallback(this.afterOpen$, eventFn);
+    return this;
+  }
+
+  /**
+   * Executes the callback for the closed event
+   * @param eventFn closed event hook
+   */
+  closed(eventFn: Function): SohoModalRef<T> {
+    this.executeCallback(this.close$, eventFn);
+    return this;
+  }
+
+  /**
+   * Executes the callback for the after close event return the dialog result
+   * @param eventFn after close event hook
+   */
+  afterClose(eventFn: Function): SohoModalRef<T> {
+    this.afterClose$.subscribe((result) => this.ngZone.run(() => eventFn(result, this)));
+    return this;
+  }
+
+  /**
+   * Sets beforeopen vetoable event guard
+   * @param eventFn function callback
+   */
+  beforeOpen(eventFn: (e: Event) => boolean): SohoModalRef<T> {
+    this.openEventGuard = eventFn;
+    return this;
+  }
+
+  /**
+   * Sets beforeclose vetoable event guard
+   * @param eventFn function callback
+   */
+  beforeClose(eventFn: (e: Event) => boolean): SohoModalRef<T> {
+    this.closeEventGuard = eventFn;
+    return this;
+  }
+
+  /**
+   * Sets beforedestroy vetoable event guard
+   * @param eventFn function callback
+   */
+  beforeDestroy(eventFn: (e: Event) => boolean): SohoModalRef<T> {
+    this.destroyEventGuard = eventFn;
+    return this;
+  }
+}

--- a/projects/ids-enterprise-ng/src/lib/modal/soho-modal.service.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal/soho-modal.service.ts
@@ -1,0 +1,60 @@
+import {
+  ApplicationRef,
+  ComponentFactoryResolver,
+  Injectable,
+  Injector,
+  NgZone,
+} from '@angular/core';
+
+import { SohoModalRef } from './soho-modal.ref';
+
+/**
+ * This service is used to create a modal that can
+ * contain an Angular Component
+ */
+@Injectable()
+export class SohoModalService {
+
+  constructor(
+    private appRef: ApplicationRef,
+    private componentFactoryResolver: ComponentFactoryResolver,
+    private injector: Injector,
+    private ngZone: NgZone
+  ) {}
+
+  /**
+   * Creates a modal containing the given component,
+   * returning a reference to control with.
+   *
+   * The dialog won't be open yet, see SohoModalRef api for further methods.
+   *
+   * @param component - the type of the component to instantiate
+   * @param settings  - optional modal settings
+   *
+   * @return the modal reference.
+   */
+  public modal<T>(component: ModalComponent<T>, settings = {} as SohoModalOptions): SohoModalRef<T> {
+    return new SohoModalRef<T>(this.appRef, this.componentFactoryResolver, this.injector, this.ngZone, settings, component);
+  }
+
+  /**
+   * Creates a modal containing the given content string,
+   * returning a reference to control with.
+   *
+   * The dialog won't be open yet, see SohoModalRef api for further methods.
+   *
+   * @param content  - message string content
+   * @param settings - optional modal settings
+   *
+   * @return the modal reference.
+   */
+  public message<T>(content: string, settings = {} as SohoModalOptions): SohoModalRef<T> {
+    settings.content = content;
+    return new SohoModalRef<T>(this.appRef, this.componentFactoryResolver, this.injector, this.ngZone, settings);
+  }
+}
+
+/**
+ * Object with a "new"" method returning the type T.
+ */
+export type ModalComponent<T> = new (...args: any[]) => T;

--- a/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
@@ -45,6 +45,7 @@ import { SohoMaskModule } from './mask/soho-mask.module';
 import { SohoMastheadModule } from './masthead/soho-masthead.module';
 import { SohoMenuButtonModule } from './menu-button/soho-menu-button.module';
 import { SohoMessageModule } from './message/soho-message.module';
+import { SohoModalModule } from './modal/soho-modal.module';
 import { SohoModalDialogModule } from './modal-dialog/soho-modal-dialog.module';
 import { SohoNotificationModule } from './notification/soho-notification.module';
 import { SohoPagerModule } from './pager/soho-pager.module';
@@ -126,6 +127,7 @@ import { SohoWizardModule } from './wizard/soho-wizard.module';
     SohoMastheadModule,
     SohoMenuButtonModule,
     SohoMessageModule,
+    SohoModalModule,
     SohoModalDialogModule,
     SohoNotificationModule,
     SohoPagerModule,
@@ -205,6 +207,7 @@ import { SohoWizardModule } from './wizard/soho-wizard.module';
     SohoMaskModule,
     SohoMastheadModule,
     SohoMenuButtonModule,
+    SohoModalModule,
     SohoModalDialogModule,
     SohoNotificationModule,
     SohoPagerModule,

--- a/src/app/modal-dialog/example-modal-dialog.component.html
+++ b/src/app/modal-dialog/example-modal-dialog.component.html
@@ -6,4 +6,12 @@
     <label for="txt-comment" class="audible">Comments</label>
     <textarea soho-textarea id="txt-comment" name="txt-comment" class="textarea-lg" [(ngModel)]="model.comment"></textarea>
   </div>
+  <div class="field">
+    <input soho-checkbox type="checkbox" id="allow-close" [(ngModel)]="allowClose">
+    <label soho-label for="allow-close" [forCheckBox]="true">Allow Close</label>
+  </div>
+  <div class="field">
+    <input soho-checkbox type="checkbox" id="allow-destroy" [(ngModel)]="allowDestroy">
+    <label soho-label for="allow-destroy" [forCheckBox]="true">Allow Destroy</label>
+  </div>
 </div>

--- a/src/app/modal-dialog/example-modal-dialog.component.ts
+++ b/src/app/modal-dialog/example-modal-dialog.component.ts
@@ -8,8 +8,12 @@ import { Component } from '@angular/core';
   templateUrl: './example-modal-dialog.component.html'
 })
 export class ExampleModalDialogComponent {
-   public model = {
+  public allowClose = true;
+  public allowDestroy = true;
+
+  public model = {
+    bool: true,
     header: 'Default Header Text',
     comment: 'This task needs to be escalated to maximum priority and delivered by the end of this week.',
-   };
+  };
 }

--- a/src/app/modal-dialog/modal-dialog.demo.html
+++ b/src/app/modal-dialog/modal-dialog.demo.html
@@ -1,8 +1,14 @@
 <div class="row">
   <div class="twelve columns">
+    <h2 class="fieldset-title">Soho Modal (NEW)</h2>
+    <div class="row">
+      <button id="openSimpleBtn" soho-button (click)="openSimple()">Open {{ dialogRef ? 'Existing' : 'New' }} Modal</button>
+      <input soho-checkbox type="checkbox" id="allow-open-checkbox" [(ngModel)]="allowOpen">
+      <label soho-label for="allow-open-checkbox" [forCheckBox]="true">Allow Open</label>
+    </div>
+    <button id="destroyBtn" soho-button (click)="destroyModal()" *ngIf="dialogRef">Destroy Modal</button>
     <h2 class="fieldset-title">Soho Modal Dialog</h2>
     <div class="field">
-      <button id="openSimpleBtn" soho-button (click)="openSimple()">Example</button>
       <button id="openFullSize" soho-button (click)="openFullSize()">Full on Tablet</button>
       <button id="open-nested-btn" soho-button (click)="openNested()">Nested</button>
       <button id="open-message-btn" soho-button (click)="openMessage()">Message</button>

--- a/src/app/modal-dialog/modal-dialog.demo.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/core';
 
 import {
+  SohoModalService,
   SohoModalDialogService
 } from 'ids-enterprise-ng';
 
@@ -38,32 +39,39 @@ export class ModalDialogDemoComponent {
    *
    * @param dialogService - the modal dialog service.
    */
-  constructor(private modalService: SohoModalDialogService) {
-  }
+  constructor(
+    private modalService: SohoModalDialogService,
+    private newModalService: SohoModalService
+  ) {}
 
   openSimple() {
-    const dialogRef = this.modalService
-      .modal<ExampleModalDialogComponent>(ExampleModalDialogComponent, this.placeholder)
+    let comp;
+    const dialogRef = this.newModalService
+      .modal<ExampleModalDialogComponent>(ExampleModalDialogComponent)
       .buttons([
         {
           id: 'cancel-button',
           text: Soho.Locale.translate('Cancel'),
-          click: (e, modal) => { modal.isCancelled = true; dialogRef.close('CANCEL'); }
+          click: (e) => { dialogRef.close('CANCEL'); }
         },
         {
           text: 'Submit', click: (e, modal) => {
-            dialogRef.close('SUBMIT');
+            dialogRef.close(comp.model);
           }, isDefault: true
-        }])
+        }
+      ])
       .title(this.title)
       .isAlert(this.isAlert)
-      .apply((dialogComponent) => { dialogComponent.model.header = 'Header Text Update!!'; })
+      .apply((dialogComponent) => {
+        dialogComponent.model.header = 'Header Text Update!!';
+        comp = dialogComponent;
+      })
       .open();
 
     // Attach a listener to the afterClose event, which also gives you the result - if available.
-    dialogRef.afterClose((result, ref, dialogComponent) => {
-      console.log(dialogComponent.model);
-      this.closeResult = result;
+    dialogRef.afterClose((result) => {
+      console.log(result);
+      this.closeResult = result.comment;
     });
   }
 

--- a/src/app/modal-dialog/modal-dialog.demo.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.ts
@@ -62,14 +62,14 @@ export class ModalDialogDemoComponent {
         },
         {
           text: 'Submit', click: (e, modal) => {
-            this.dialogRef.close(this.dialogRef.componentDialog.model);
+            this.dialogRef.close(this.dialogRef.componentDialog.model.comment);
           }, isDefault: true
         }
       ])
       .title(this.title)
       .isAlert(this.isAlert)
-      .apply(() => {
-        this.dialogRef.componentDialog.model.header = 'Header Text Update!!';
+      .apply((componentDialog) => {
+        componentDialog.model.header = 'Header Text Update!!';
       })
       .open();
 
@@ -79,7 +79,7 @@ export class ModalDialogDemoComponent {
       .afterOpen(() => console.log('dialog afterOpen'))
       .closed(() => console.log('dialog closed'))
       .afterClose((result) => {
-        this.closeResult = result
+        this.closeResult = result;
         console.log(`dialog afterClose result: {result}`);
       })
       .beforeOpen(() => this.allowOpen)


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This has not yet fixed the remaining leaking angular component. 
From what I have observed so far, when the angular component is moved around the DOM (via jQuery methods or some native DOM manipulation methods) it breaks some references used in the angular component life cycle. That's why it was not unable to destroy itself properly using `ComponentRef.destroy()`.

Maybe the only thing that could fix this is to reimplement the whole SohoModalDialogModule and create all the modal's parts using angular components and just apply the css classes from enterprise.

**Related github/jira issue (required)**: 
#636 

**Steps necessary to review your pull request (required)**:
1. Go to http://localhost:4200/ids-enterprise-ng-demo/modal-dialog
2. Click Example button (Opens a modal)
3. Click Cancel / Submit (Closes the modal)
4. Generate a Heap Snapshot using Chrome DevTools' Memory tab
5. Filter objects using "modal" keyword
**Note:** Repeat steps 2-3 several times and you will see an increasing number of ExampleModalDialogComponent instances from the Heap Snapshot
