### PR TITLE
Locale: Add typings support for parseDate dateFormat parameter when it is def…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 6.1.0 Chore & Maintenance
 
+- `[Locale]` - Added typings support for the parseDate dateFormat parameter when defined as an object. `MAF` ([#640](https://github.com/infor-design/enterprise-ng/issues/640))
+
 ### 6.1.0 Fixes
 
 ## v6.0.0

--- a/projects/ids-enterprise-ng/src/lib/locale/soho-locale.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/locale/soho-locale.d.ts
@@ -52,6 +52,13 @@ interface SohoLocaleCalendar {
   firstDayofWeek: number;
 }
 
+interface SohoLocaleParseDateOptions {
+  dateFormat?: string;
+  pattern?: string;
+  locale?: string;
+  calendarName?: string;
+}
+
 interface SohoLocaleStatic {
   cultures: any;
   culturesPath: string;
@@ -86,7 +93,7 @@ interface SohoLocaleStatic {
   getCulturesPath(): string;
   isRTL(): boolean;
   numbers(): SohoLocaleNumberData;
-  parseDate(dateString: string, dateFormat?: string, isStrict?: boolean): Date;
+  parseDate(dateString: string, dateFormat?: string | SohoLocaleParseDateOptions, isStrict?: boolean): Date;
   parseNumber(input: string): number;
   set(locale: string): any;
   getLocale(locale: string, filename?: string): any;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added typings support for the parseDate dateFormat parameter when defined as an object.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #640

