### PR TITLE
654 - Fix the types on datagrid export functions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,10 @@
 # What's New with Enterprise-NG
 
-## v7.0.0
+## v6.2.0
 
-### 7.1.0 Fixes
+### 6.2.0 Fixes
 
-- `[Datagrid]` Adds made the last two options on exportToExcel optional. Note that passing in a third option is incorrect and will give you no headers. `TJM` ([#654](https://github.com/infor-design/enterprise-ng/pull/654))
+- `[Datagrid]` Made the last two options on exportToExcel optional. Note that passing in a third option is incorrect and will give you no headers in the exported file, so generally shouldnt be used. `TJM` ([#654](https://github.com/infor-design/enterprise-ng/pull/654))
 
 ## v6.1.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## v7.0.0
+
+### 7.1.0 Fixes
+
+- `[Datagrid]` Adds made the last two options on exportToExcel optional. Note that passing in a third option is incorrect and will give you no headers. `TJM` ([#654](https://github.com/infor-design/enterprise-ng/pull/654))
+
 ## v6.1.0
 
 ### 6.1.0 Breaking Changes

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1745,9 +1745,9 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
    * Trigger export of grid data to Excel.
    * @param fileName The prefix name to be used for the exported file.
    * @param worksheetName The name to be used for the worksheet.
-   * @param customDs A datasource to override the default.
+   * @param customDs A datasource to override the default (deprecated)
    */
-  exportToExcel(fileName: string, worksheetName: string, customDs: Object[]): void {
+  exportToExcel(fileName: string, worksheetName?: string, customDs?: Object[]): void {
     this.ngZone.runOutsideAngular(() => {
       this.datagrid.exportToExcel(fileName, worksheetName, customDs);
     });
@@ -1759,7 +1759,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
    * @param customDs A datasource to override the default.
    * @param separator The separator to use in the cvs file, defaults to 'sep=,'
    */
-  exportToCsv(fileName: string, customDs: Object[], separator: string = 'sep=,'): void {
+  exportToCsv(fileName: string, customDs?: Object[], separator: string = 'sep=,'): void {
     this.ngZone.runOutsideAngular(() => {
       this.datagrid.exportToCsv(fileName, customDs, separator);
     });

--- a/src/app/datagrid/datagrid-service.demo.html
+++ b/src/app/datagrid/datagrid-service.demo.html
@@ -7,6 +7,7 @@
       <button soho-button (click)="toggleFilterRow()">Toggle Filter Row</button>
       <button soho-button (click)="clearFilter()">Clear Filter</button>
       <button soho-button (click)="sortColumn()">Sort Column</button>
+      <button soho-button (click)="export()">Export (xls)</button>
     </div>
   </div>
 </div>

--- a/src/app/datagrid/datagrid-service.demo.ts
+++ b/src/app/datagrid/datagrid-service.demo.ts
@@ -66,4 +66,9 @@ export class DataGridServiceDemoComponent {
 
   addRow() {
   }
+
+  export() {
+    this.dataGrid.exportToExcel('my-export');
+    this.dataGrid.exportToCsv('my-export');
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The export functions in datagrid did not mark the dataset as optional. The problem with this is if you DO pass it you will not get the headers in the files. This fixes this problem.

**Related github/jira issue (required)**:
Fixes #654 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-service
- click export to xls
- both a csv and xls file will download
- everything will compile.