### PR TITLE
606 - Add NG row template example

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## v7.0.0
+
+### 7.0.0 Features
+
+- `[Datagrid]` Added rowTemplate / expandable row example. `TJM` ([#https://github.com/infor-design/enterprise-ng/issues/606](https://github.com/infor-design/enterprise-ng/pull/https://github.com/infor-design/enterprise-ng/issues/606))
+
 ## v6.1.0
 
 ### 6.1.0 Breaking Changes

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -295,6 +295,9 @@ interface SohoDataGridOptions {
    * or if one or more child node got match then add parent node and only matching children nodes
    */
   allowChildExpandOnMatch?: boolean;
+
+  /* Html string for the expandable row area*/
+  rowTemplate?: string;
 }
 
 type SohoDataGridModifiedRows = { [index: number]: SohoDataGridModifiedRow };

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -97,6 +97,7 @@ import { DataGridRowReorderDemoComponent } from './datagrid/datagrid-rowreorder.
 import { DataGridSaveUserSettingsDemoComponent } from './datagrid/datagrid-save-user-settings.demo';
 import { DataGridServiceDemoComponent } from './datagrid/datagrid-service.demo';
 import { DataGridSettingsDemoComponent } from './datagrid/datagrid-settings.demo';
+import { DataGridExpandableRowDemoComponent } from './datagrid/datagrid-expandable-row.demo';
 import { DataGridStandardFormatterDemoComponent } from './datagrid/datagrid-standard-formatter.demo';
 import { DataGridTabDemoComponent } from './datagrid/datagrid-tab.demo';
 import { DataGridTestSettingsDemoComponent } from './datagrid/datagrid-test-settings.demo';
@@ -291,6 +292,7 @@ import { ApplicationMenuRoleSwitcherDemoComponent } from './application-menu/app
     DataGridSaveUserSettingsDemoComponent,
     DataGridServiceDemoComponent,
     DataGridSettingsDemoComponent,
+    DataGridExpandableRowDemoComponent,
     DataGridStandardFormatterDemoComponent,
     DataGridTabDemoComponent,
     DataGridTestSettingsDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -62,6 +62,7 @@ import { DataGridPagingServiceDemoComponent } from './datagrid/datagrid-paging-s
 import { DataGridSaveUserSettingsDemoComponent } from './datagrid/datagrid-save-user-settings.demo';
 import { DataGridServiceDemoComponent } from './datagrid/datagrid-service.demo';
 import { DataGridSettingsDemoComponent } from './datagrid/datagrid-settings.demo';
+import { DataGridExpandableRowDemoComponent } from './datagrid/datagrid-expandable-row.demo';
 import { DataGridStandardFormatterDemoComponent } from './datagrid/datagrid-standard-formatter.demo';
 import { DataGridTabDemoComponent } from './datagrid/datagrid-tab.demo';
 import { DataGridTestSettingsDemoComponent } from './datagrid/datagrid-test-settings.demo';
@@ -228,6 +229,7 @@ export const routes: Routes = [
   { path: 'datagrid-test-settings', component: DataGridTestSettingsDemoComponent },
   { path: 'datagrid-service', component: DataGridServiceDemoComponent },
   { path: 'datagrid-settings', component: DataGridSettingsDemoComponent },
+  { path: 'datagrid-expandable-row', component: DataGridExpandableRowDemoComponent },
   { path: 'datagrid-standalone-pager', component: DatagridStandalonePagerDemoComponent },
   { path: 'datagrid-treegrid', component: DataGridTreeGridDemoComponent },
   { path: 'datagrid-treegrid-dynamicfilter', component: DatagridTreegridDynamicfilteringDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -86,6 +86,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-treegrid']"><span>DataGrid - TreeGrid</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-treegrid-dynamicfilter']"><span>DataGrid - TreeGrid Dynamic Filter</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-settings']"><span>DataGrid - Updatable Settings</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['datagrid-expandable-row']"><span>DataGrid - Expandable Row</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datepicker']"><span>Date Picker</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['donut']"><span>Donut Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['dropdown-async']"><span>Dropdown - Async</span></a></div>

--- a/src/app/datagrid/datagrid-expandable-row.demo.html
+++ b/src/app/datagrid/datagrid-expandable-row.demo.html
@@ -1,0 +1,3 @@
+<div class="full-width full-height scrollable-flex">
+  <div soho-datagrid *ngIf="gridOptions" [gridOptions]="gridOptions"></div>
+</div>

--- a/src/app/datagrid/datagrid-expandable-row.demo.ts
+++ b/src/app/datagrid/datagrid-expandable-row.demo.ts
@@ -1,0 +1,77 @@
+import {
+  AfterViewChecked,
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  ViewChild
+} from '@angular/core';
+import { SohoDataGridComponent } from 'ids-enterprise-ng';
+
+import {
+  PAGING_COLUMNS,
+  PAGING_DATA
+} from './datagrid-paging-data';
+
+const customErrorFormatter = function(row, cell, value, col, item, api) {
+   value = `<svg class="icon datagrid-alert-icon icon-alert"
+          style="height: 15px; margin-right: 6px; top: -2px; position: relative;"
+          focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-alert"></use>
+        </svg><span>${value}</span>`;
+   return Soho.Formatters.Expander(row, cell, value, col, item, api);
+};
+
+@Component({
+  selector: 'app-datagrid-expandable-row-demo',
+  templateUrl: './datagrid-expandable-row.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DataGridExpandableRowDemoComponent implements AfterViewChecked, OnInit {
+  @ViewChild(SohoDataGridComponent, { static: false }) sohoDataGridComponent: SohoDataGridComponent;
+
+  constructor(
+  ) {}
+
+  gridOptions: SohoDataGridOptions = undefined;
+  ngOnInit() {
+    this.gridOptions = this.buildGridOptions();
+  }
+
+  ngAfterViewChecked() {
+  }
+
+  private buildGridOptions(): SohoDataGridOptions {
+    // Replace the first two column with an expander
+    PAGING_COLUMNS[0] = {
+      id: 'expander',
+      field: 'productId',
+      formatter: customErrorFormatter, // or just use Soho.Formatters.Expander,
+      filterType: 'text',
+      width: '15%'
+    };
+    PAGING_COLUMNS[1].hidden = true;
+
+    return {
+      columns: PAGING_COLUMNS,
+      dataset: PAGING_DATA,
+      selectable: false,
+      rowTemplate: `
+        <div class="datagrid-cell-layout">
+          <div class="img-placeholder">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-camera"></use>
+            </svg>
+          </div>
+        </div>
+        <div class="datagrid-cell-layout">
+          <p class="datagrid-row-heading">Expandable Content Area</p>
+              <p class="datagrid-row-micro-text">{{{sku}}}</p>
+                <span class="datagrid-wrapped-text">Lorem Ipsum is simply dummy text of the
+                printing and typesetting industry. Lorem Ipsum has been the industry standard
+                dummy text ever since the 1500s, when an unknown printer took a galley of
+                type and scrambled it to make a type specimen book. It has survived not only...
+                </span>
+          <a class="hyperlink" href="https://design.infor.com/" target="_blank" >Read more</a>`
+    } as SohoDataGridOptions;
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added a row template example. At the moment it is not done with NG components just a string. Remind me the approach on that , maybe we can add.

**Related github/jira issue (required)**:
Fixes #606 

**Steps necessary to review your pull request (required)**:
- checkout http://localhost:4200/ids-enterprise-ng-demo/datagrid-expandable-row
