### PR TITLE
closes #585 dropdown keydown support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 6.2.0 Fixes
 
 - `[Datagrid]` Made the last two options on exportToExcel optional. Note that passing in a third option is incorrect and will give you no headers in the exported file, so generally shouldnt be used. `TJM` ([#654](https://github.com/infor-design/enterprise-ng/pull/654))
+- `[Dropdown]` Added keydown output EventEmitter. `NBCP` ([#658](https://github.com/infor-design/enterprise-ng/pull/658))
 
 ## v6.1.0
 

--- a/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
@@ -312,6 +312,12 @@ export class SohoDropDownComponent implements AfterViewInit, AfterViewChecked, O
   updatedEvent: EventEmitter<Object> = new EventEmitter<JQuery.TriggeredEvent>();
 
   /**
+   * This event is fired when a key is pressed
+   */
+  @Output()
+  keydown = new EventEmitter<Event>();
+
+  /**
    * Bind attributes to the host select element
    */
 
@@ -367,6 +373,8 @@ export class SohoDropDownComponent implements AfterViewInit, AfterViewChecked, O
     this.ngZone.runOutsideAngular(() => {
       // assign element to local variable
       this.jQueryElement = jQuery(this.element.nativeElement);
+
+      this.options.onKeyDown = (e: Event) => this.ngZone.run(() => this.keydown.next(e));
 
       // initialise the dropdown control
       this.jQueryElement.dropdown(this.options);

--- a/src/app/dropdown/dropdown.demo.html
+++ b/src/app/dropdown/dropdown.demo.html
@@ -6,7 +6,7 @@
       <div class="row">
         <div class="field">
           <label for="states" class="label">States</label>
-          <select soho-dropdown noSearch name="states" [(ngModel)]="model.single">
+          <select soho-dropdown noSearch name="states" [(ngModel)]="model.single" (keydown)="onKeyDown($event)">
             <option value="AL">Alabama</option>
             <option value="CA">California</option>
             <option value="DE" >Delaware</option>

--- a/src/app/dropdown/dropdown.demo.ts
+++ b/src/app/dropdown/dropdown.demo.ts
@@ -49,6 +49,10 @@ export class DropdownDemoComponent {
     this.options.pop();
   }
 
+  onKeyDown(e: Event) {
+    console.log('keydown', e)
+  }
+
   toggleModel() {
     this.showModel = !this.showModel;
   }

--- a/src/app/dropdown/dropdown.demo.ts
+++ b/src/app/dropdown/dropdown.demo.ts
@@ -50,7 +50,7 @@ export class DropdownDemoComponent {
   }
 
   onKeyDown(e: Event) {
-    console.log('keydown', e)
+    console.log('keydown', e);
   }
 
   toggleModel() {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This implements the new keydown Output EventEmitter for soho-dropdown. Following after the added changes in 2a25735

**Related github/jira issue (required)**:
#585

**Steps necessary to review your pull request (required)**:
A simple example made in http://localhost:4200/ids-enterprise-ng-demo/dropdown, just press a key on the 1st dropdown and it shall print in the console.

