### PR TITLE
Handle unselected event for Tree node

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # What's New with Enterprise-NG
 
+- `[Tree]` Expose unselected event. `MC` ([#https://github.com/infor-design/enterprise-ng/issues/670](https://github.com/infor-design/enterprise-ng/pull/https://github.com/infor-design/enterprise-ng/issues/670))
+
 ## v6.2.0
 
 ### 6.2.0 Fixes

--- a/projects/ids-enterprise-ng/src/lib/tree/soho-tree.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tree/soho-tree.component.ts
@@ -166,6 +166,12 @@ export class SohoTreeComponent implements AfterViewInit, OnInit, OnDestroy {
    * */
   @Output() selected = new EventEmitter<SohoTreeEvent>();
 
+  /**
+   * This event is fired when a node is unselected, the SohoTreeNode
+   * unselected is passed in the argument passed to the handler.
+   * */
+  @Output() deselected = new EventEmitter<SohoTreeEvent>();
+
   @Output() sortstart = new EventEmitter<SohoTreeEvent>();
 
   @Output() sortend = new EventEmitter<SohoTreeEvent>();
@@ -469,6 +475,7 @@ export class SohoTreeComponent implements AfterViewInit, OnInit, OnDestroy {
     // Initialize any event handlers.
     this.jQueryElement
       .on('selected', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.selected.next(args))
+      .on('unselected', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.deselected.next(args))
       .on('expand', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.expand.next(args))
       .on('collapse', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.collapse.next(args))
       .on('sortstart', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.sortstart.next(args))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Simply add a "deselected" output event for exposing "unselected" events from sohoxi Tree component.

I have tried name it as "unselected" output event, but it does not work, and after change it to "deselected", it works.

**Related github/jira issue (required)**:
SohoTreeComponent should trigger "deselected" event when a node becomes unchecked #670 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
