### PR TITLE
Added `enable-tooptips` Input to datagrid.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # What's New with Enterprise-NG
 
-## v6.3.0 (TBC)
+## v7.0.0
 
-### 6.3.0 Fixes
+### 7.0.0 Fixes
 
 - `[Datagrid]` Added `enableTooltips` Input to datagrid. `BTHH` ([#674](https://github.com/infor-design/enterprise-ng/pull/674))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## v6.3.0 (TBC)
+
+### 6.3.0 Fixes
+
+- `[Datagrid]` Added `enableTooltips` Input to datagrid. `BTHH` ([#XXX](https://github.com/infor-design/enterprise-ng/pull/XXX))
+
 ## v6.2.0
 
 ### 6.2.0 Fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 6.3.0 Fixes
 
-- `[Datagrid]` Added `enableTooltips` Input to datagrid. `BTHH` ([#XXX](https://github.com/infor-design/enterprise-ng/pull/XXX))
+- `[Datagrid]` Added `enableTooltips` Input to datagrid. `BTHH` ([#674](https://github.com/infor-design/enterprise-ng/pull/674))
 
 ## v6.2.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # What's New with Enterprise-NG
 
-## v7.0.0
+## v6.3.0
 
-### 7.0.0 Fixes
+### 6.3.0 Fixes
 
 - `[Datagrid]` Added `enableTooltips` Input to datagrid. `BTHH` ([#674](https://github.com/infor-design/enterprise-ng/pull/674))
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/README.md
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/README.md
@@ -33,6 +33,7 @@ The 'datagrid' component provides a number of options to control its behaviour, 
 | rowHeight | Sets the row height in the data grid to be 'normal', 'medium' or 'short'. |
 | selectable | If true selection can be used, other if false selection is disabled. |
 | stretchColumn| The name of the column to stretch, if 'last' the last column is stretched. |
+| enableTooltips | Enable toolips on the cell values, at a cost of performance.. |
 
 Changes to these properties will dynamically update the component.
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1072,6 +1072,22 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   /**
+   * Enable toolips on the cell values, at a cost of performance.
+   */
+  @Input() set enableTooltips(value: boolean) {
+    this._gridOptions.enableTooltips = value;
+    if (this.jQueryElement) {
+      this.datagrid.settings.enableTooltips = value;
+
+      this.markForRefresh('enableTooltips', RefreshHintFlags.Rebuild);
+    }
+  }
+
+  get enableTooltips(): boolean {
+    return this._gridOptions.enableTooltips;
+  }
+
+  /**
    * Defines the source type of the grid, either:
    *
    * - "content-only" where table elements are provided in the body.
@@ -1208,7 +1224,8 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   // An internal gridOptions object that gets updated by using
   // the component's Inputs()
   private _gridOptions: SohoDataGridOptions = {
-    stretchColumn: 'last' // default value
+    stretchColumn: 'last',
+    enableTooltips: false
   };
 
   // Provides hints to the component after the next refresh.

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
@@ -485,6 +485,19 @@ describe('Soho DataGrid Unit Tests', () => {
     expect(comp.stretchColumn).toEqual('accountType');
   });
 
+  it('check enableTooltips', () => {
+    fixture.detectChanges();
+
+    // The default in the grid is false.
+    expect(comp.gridOptions.enableTooltips).toBeFalsy();
+    expect(comp.enableTooltips).toBeFalsy();
+
+    comp.enableTooltips = true;
+
+    expect(comp.gridOptions.enableTooltips).toBeTruthy();
+    expect(comp.enableTooltips).toBeTruthy();
+  });
+
   it('check commitCellEdit', () => {
     fixture.detectChanges();
     const spy = spyOn((comp as any).datagrid, 'commitCellEdit');

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
@@ -278,6 +278,7 @@ describe('Soho Datepicker Unit Tests', () => {
       fixture.detectChanges();
       expect(Soho.Locale.currentLocale.name).toEqual('en-US');
       expect(comp.onChange).toHaveBeenCalled();
+      fixture.detectChanges();
       expect(comp.model).toBe('11/18/1978', 'Model not updated to correct value.');
     });
   }));

--- a/src/app/datagrid/datagrid-demo.service.ts
+++ b/src/app/datagrid/datagrid-demo.service.ts
@@ -1,5 +1,5 @@
 
-import { of,  Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 
 import {
@@ -80,14 +80,16 @@ export class DataGridDemoService extends SohoDataGridService {
       field: 'productName',
       formatter: Soho.Formatters.Template,
       template: '<p class="datagrid-row-heading">{{productId}}</p><p class="datagrid-row-subheading">{{productName}}</p>',
-      click: (e: any, args: any) => { console.log('link was clicked', args); }
+      click: (e: any, args: any) => { console.log('link was clicked', args); },
+      textOverflow: 'ellipsis'
     });
 
     this.columns.push({
       id: 'activity',
       name: 'Activity',
       filterType: 'text',
-      field: 'activity'
+      field: 'activity',
+      textOverflow: 'ellipsis'
     });
 
     this.columns.push({
@@ -163,8 +165,10 @@ export class DataGridDemoService extends SohoDataGridService {
       });
 
     this.columns.push({ id: 'ordered', hidden: true, name: 'Ordered', field: 'ordered', formatter: Soho.Formatters.Checkbox });
-    this.columns.push({ id: '', hidden: false, name: 'Actions', field: '',
-      formatter: Soho.Formatters.Actions, menuId: 'grid-actions-menu', selected: (e, a) => { this.onActionHandler(a); } });
+    this.columns.push({
+      id: '', hidden: false, name: 'Actions', field: '',
+      formatter: Soho.Formatters.Actions, menuId: 'grid-actions-menu', selected: (e, a) => { this.onActionHandler(a); }
+    });
     this.columns.push({ id: 'nested', hidden: true, name: 'Nested Prop', field: 'setting.optionOne', formatter: Soho.Formatters.Text });
     this.columns.push({ id: 'comment', hidden: true, name: 'Comment', field: 'comment', formatter: Soho.Formatters.Textarea, width: 100 });
 

--- a/src/app/datagrid/datagrid-settings.demo.html
+++ b/src/app/datagrid/datagrid-settings.demo.html
@@ -82,7 +82,7 @@
 <div class="row top-padding">
   <div class="twelve columns demo" role="main">
     <section soho-busyindicator class="scrollable contained-scrolling-right-bottom" style="height: 100%">
-      <div soho-datagrid selectable="true" filterable="true"></div>
+      <div soho-datagrid selectable="true" filterable="true" enableTooltips="true"></div>
     </section>
   </div>
 </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added `enableTooltips` Input to `soho-datagrid` component .

**Related github/jira issue (required)**:

Closes #673.

**Steps necessary to review your pull request (required)**:

You can workaround this by setting the value on the options before the component is initialised.

**To Reproduce**

1. Clone `https://github.com/infor-design/enterprise-ng`
2. Change the column definition for `activity` in `datagrid-demo-service.ts` to
```typescript
this.columns.push({
      id: 'activity',
      name: 'Activity',
      filterType: 'text',
      field: 'activity',
      textOverflow: 'ellipsis'
    });
```
3. Change the `datagrid` in `datagrid-settings.demo-html` to include `enableTooltips`
```angular2html
<div soho-datagrid selectable="true" filterable="true" enableTooltips="true"></div>
```
4. Compile (`npm run start`) and run http://localhost:4200/ids-enterprise-ng-demo/datagrid-settings.
5. Resize the `Activity` column until an ellipsis appears.
6. No tooltip is displayed when hovering over cell.
