### PR TITLE
672- Fix duplicate change event

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 6.3.0 Fixes
 
 - `[Datagrid]` Added `enableTooltips` Input to datagrid. `BTHH` ([#674](https://github.com/infor-design/enterprise-ng/pull/674))
+- `[FileUpload]` Fixed duplicate change event. `TJM` ([#672](https://github.com/infor-design/enterprise-ng/pull/672))
 
 ## v6.2.0
 

--- a/src/app/fileupload/fileupload.demo.html
+++ b/src/app/fileupload/fileupload.demo.html
@@ -6,7 +6,7 @@
           <label soho-label for={{name1}}>Normal Input</label>
           <input
             soho-fileupload [disabled]="fileUploadDisabled" [readonly]="fileUploadReadOnly"
-            id="{{name1}}" name={{name1}} accept="true"
+            id="{{name1}}" name={{name1}} accept="true" (change)="onChange($event)"
           />
         </div>
 

--- a/src/app/fileupload/fileupload.demo.ts
+++ b/src/app/fileupload/fileupload.demo.ts
@@ -64,4 +64,8 @@ export class FileUploadDemoComponent implements OnInit {
   onPristine(event: SohoTrackDirtyEvent) {
     console.log('onPristine');
   }
+
+  onChange(event: any) {
+    console.log('onChange', event);
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes duplicate change event by "zonifiying" file upload.

**Related github/jira issue (required)**:
Fixes #672 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4200/ids-enterprise-ng-demo/fileupload
- watch console
- select a value in the first picker
- should be one entry

Note: I see that the X is not firing a close event. Put i fix in for that on my EP branch so that will be available when this version resolves.
