### PR TITLE
657 - Add new types for tree and datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # What's New with Enterprise-NG
 
+## v6.4.0
+
+### 6.4.0 Fixes
+
+- `[Tree]` Expose unselected event. `MC` ([#https://github.com/infor-design/enterprise-ng/issues/670](https://github.com/infor-design/enterprise-ng/pull/https://github.com/infor-design/enterprise-ng/issues/670))
+- `[Datagrid]` Correct the cssClass type on columns to accept a function. `TJM`  ([#657](https://github.com/infor-design/enterprise-ng/issues/657))
+
 ## v6.3.0
 
 ### 6.3.0 Fixes

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -618,6 +618,14 @@ type SohoDataGridColumnIsEditableFunction = (
   rowData: Object
 ) => boolean;
 
+type SohoDataGridColumnCssClassFunction = (
+  row: number,
+  cell: any,
+  fieldValue: any,
+  columnDef: SohoDataGridColumn,
+  rowData: Object
+) => string;
+
 type SohoDataGridColumnColSpanFunction = (
   row: number,
   cell: any,
@@ -718,7 +726,7 @@ interface SohoDataGridColumn {
   options?: SohoGridCellOption[];
 
   /** css class  */
-  cssClass?: string;
+  cssClass?: SohoDataGridColumnCssClassFunction | string;
 
   /** @todo fix type from any.  */
   dateShowFormat?: any;

--- a/projects/ids-enterprise-ng/src/lib/tree/soho-tree.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tree/soho-tree.component.ts
@@ -166,6 +166,12 @@ export class SohoTreeComponent implements AfterViewInit, OnInit, OnDestroy {
    * */
   @Output() selected = new EventEmitter<SohoTreeEvent>();
 
+  /**
+   * This event is fired when a node is unselected, the SohoTreeNode
+   * unselected is passed in the argument passed to the handler.
+   * */
+  @Output() unselected = new EventEmitter<SohoTreeEvent>();
+
   @Output() sortstart = new EventEmitter<SohoTreeEvent>();
 
   @Output() sortend = new EventEmitter<SohoTreeEvent>();
@@ -469,6 +475,7 @@ export class SohoTreeComponent implements AfterViewInit, OnInit, OnDestroy {
     // Initialize any event handlers.
     this.jQueryElement
       .on('selected', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.selected.next(args))
+      .on('unselected', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.unselected.next(args))
       .on('expand', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.expand.next(args))
       .on('collapse', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.collapse.next(args))
       .on('sortstart', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.sortstart.next(args))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Add the ability for the column cssClass to take a function that returns the string as exists in the EP components.

Replaced https://github.com/infor-design/enterprise-ng/pull/671 with request fixes since no response there.

Establish a new change log for 6.4.x

**Related github/jira issue (required)**:
Fixes #657 
Replaces https://github.com/infor-design/enterprise-ng/pull/671

**Steps necessary to review your pull request (required)**:
- Just examine the PR
