### PR TITLE
change to illustrate the issue with sort indicator

### DIFF
--- a/src/app/datagrid/datagrid-paging-data.ts
+++ b/src/app/datagrid/datagrid-paging-data.ts
@@ -134,7 +134,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          10,
     productId:   214230,
-    productName: 'Compressor 1',
+    productName: 'Compressor 11',
     activity:    'Assemble Paint',
     quantity:    6,
     price:       200.99,
@@ -146,7 +146,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          11,
     productId:   214231,
-    productName: 'Compressor 2',
+    productName: 'Compressor 12',
     activity:    'Assemble Paint',
     quantity:    6.5,
     price:       199.99,
@@ -158,7 +158,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          12,
     productId:   214232,
-    productName: 'Compressor 3',
+    productName: 'Compressor 13',
     activity:    'Assemble Paint',
     quantity:    7,
     price:       198.99,
@@ -170,7 +170,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          13,
     productId:   214233,
-    productName: 'Compressor 4',
+    productName: 'Compressor 14',
     activity:    'Assemble Paint',
     quantity:    7.5,
     price:       197.99,
@@ -182,7 +182,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          14,
     productId:   214234,
-    productName: 'Compressor 5',
+    productName: 'Compressor 15',
     activity:    'Assemble Paint',
     quantity:    8,
     price:       196.99,
@@ -194,7 +194,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          15,
     productId:   214235,
-    productName: 'Compressor 6',
+    productName: 'Compressor 16',
     activity:    'Assemble Paint',
     quantity:    8.5,
     price:       195.99,
@@ -206,7 +206,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          16,
     productId:   214236,
-    productName: 'Compressor 7',
+    productName: 'Compressor 17',
     activity:    'Assemble Paint',
     quantity:    9,
     price:       194.99,
@@ -217,7 +217,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          17,
     productId:   214237,
-    productName: 'Compressor 8',
+    productName: 'Compressor 18',
     activity:    'Assemble Paint',
     quantity:    9.5,
     price:       193.99,
@@ -229,7 +229,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          18,
     productId:   214238,
-    productName: 'Compressor 9',
+    productName: 'Compressor 19',
     activity:    'Assemble Paint',
     quantity:    10,
     price:       192.99,
@@ -241,7 +241,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          19,
     productId:   214239,
-    productName: 'Compressor 10',
+    productName: 'Compressor 20',
     activity:    'Assemble Paint',
     quantity:    10.5,
     price:       191.99,
@@ -253,7 +253,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          20,
     productId:   214240,
-    productName: 'Compressor 1',
+    productName: 'Compressor 21',
     activity:    'Assemble Paint',
     quantity:    11,
     price:       190.99,
@@ -264,7 +264,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          21,
     productId:   214241,
-    productName: 'Compressor 2',
+    productName: 'Compressor 22',
     activity:    'Assemble Paint',
     quantity:    11.5,
     price:       189.99,
@@ -276,7 +276,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          22,
     productId:   214242,
-    productName: 'Compressor 3',
+    productName: 'Compressor 23',
     activity:    'Assemble Paint',
     quantity:    12,
     price:       188.99,
@@ -288,7 +288,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          23,
     productId:   214243,
-    productName: 'Compressor 4',
+    productName: 'Compressor 24',
     activity:    'Assemble Paint',
     quantity:    12.5,
     price:       187.99,
@@ -300,7 +300,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          24,
     productId:   214244,
-    productName: 'Compressor 5',
+    productName: 'Compressor 25',
     activity:    'Assemble Paint',
     quantity:    13,
     price:       186.99,
@@ -312,7 +312,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          25,
     productId:   214245,
-    productName: 'Compressor 6',
+    productName: 'Compressor 26',
     activity:    'Assemble Paint',
     quantity:    13.5,
     price:       185.99,
@@ -324,7 +324,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          26,
     productId:   214246,
-    productName: 'Compressor 7',
+    productName: 'Compressor 27',
     activity:    'Assemble Paint',
     quantity:    14,
     price:       184.99,
@@ -336,7 +336,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          27,
     productId:   214247,
-    productName: 'Compressor 8',
+    productName: 'Compressor 28',
     activity:    'Assemble Paint',
     quantity:    14.5,
     price:       183.99,
@@ -348,7 +348,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          28,
     productId:   214248,
-    productName: 'Compressor 9',
+    productName: 'Compressor 29',
     activity:    'Assemble Paint',
     quantity:    15,
     price:       182.99,
@@ -360,7 +360,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          29,
     productId:   214249,
-    productName: 'Compressor 10',
+    productName: 'Compressor 30',
     activity:    'Assemble Paint',
     quantity:    15.5,
     price:       181.99,
@@ -372,7 +372,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          30,
     productId:   214250,
-    productName: 'Compressor 1',
+    productName: 'Compressor 31',
     activity:    'Assemble Paint',
     quantity:    16,
     price:       180.99,
@@ -383,7 +383,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          31,
     productId:   214251,
-    productName: 'Compressor 2',
+    productName: 'Compressor 32',
     activity:    'Assemble Paint',
     quantity:    16.5,
     price:       179.99,
@@ -395,7 +395,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          32,
     productId:   214252,
-    productName: 'Compressor 3',
+    productName: 'Compressor 33',
     activity:    'Assemble Paint',
     quantity:    17,
     price:       178.99,
@@ -407,7 +407,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          33,
     productId:   214253,
-    productName: 'Compressor 4',
+    productName: 'Compressor 34',
     activity:    'Assemble Paint',
     quantity:    17.5,
     price:       177.99,
@@ -419,7 +419,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          34,
     productId:   214254,
-    productName: 'Compressor 5',
+    productName: 'Compressor 35',
     activity:    'Assemble Paint',
     quantity:    18,
     price:       176.99,
@@ -431,7 +431,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          35,
     productId:   214255,
-    productName: 'Compressor 6',
+    productName: 'Compressor 36',
     activity:    'Assemble Paint',
     quantity:    18.5,
     price:       175.99,
@@ -443,7 +443,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          36,
     productId:   214256,
-    productName: 'Compressor 7',
+    productName: 'Compressor 37',
     activity:    'Assemble Paint',
     quantity:    19,
     price:       174.99,
@@ -455,7 +455,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          37,
     productId:   214257,
-    productName: 'Compressor 8',
+    productName: 'Compressor 38',
     activity:    'Assemble Paint',
     quantity:    19.5,
     price:       173.99,
@@ -467,7 +467,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          38,
     productId:   214258,
-    productName: 'Compressor 9',
+    productName: 'Compressor 39',
     activity:    'Assemble Paint',
     quantity:    20,
     price:       172.99,
@@ -479,7 +479,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          39,
     productId:   214259,
-    productName: 'Compressor 10',
+    productName: 'Compressor 40',
     activity:    'Assemble Paint',
     quantity:    20.5,
     price:       171.99,
@@ -491,7 +491,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          40,
     productId:   214260,
-    productName: 'Compressor 1',
+    productName: 'Compressor 41',
     activity:    'Assemble Paint',
     quantity:    21,
     price:       170.99,
@@ -502,7 +502,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          41,
     productId:   214261,
-    productName: 'Compressor 2',
+    productName: 'Compressor 42',
     activity:    'Assemble Paint',
     quantity:    21.5,
     price:       169.99,
@@ -514,7 +514,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          42,
     productId:   214262,
-    productName: 'Compressor 3',
+    productName: 'Compressor 43',
     activity:    'Assemble Paint',
     quantity:    22,
     price:       168.99,
@@ -526,7 +526,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          43,
     productId:   214263,
-    productName: 'Compressor 4',
+    productName: 'Compressor 44',
     activity:    'Assemble Paint',
     quantity:    22.5,
     price:       167.99,
@@ -538,7 +538,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          44,
     productId:   214264,
-    productName: 'Compressor 5',
+    productName: 'Compressor 45',
     activity:    'Assemble Paint',
     quantity:    23,
     price:       166.99,
@@ -550,7 +550,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          45,
     productId:   214265,
-    productName: 'Compressor 6',
+    productName: 'Compressor 46',
     activity:    'Assemble Paint',
     quantity:    23.5,
     price:       165.99,
@@ -562,7 +562,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          46,
     productId:   214266,
-    productName: 'Compressor 7',
+    productName: 'Compressor 47',
     activity:    'Assemble Paint',
     quantity:    24,
     price:       164.99,
@@ -574,7 +574,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          47,
     productId:   214267,
-    productName: 'Compressor 8',
+    productName: 'Compressor 48',
     activity:    'Assemble Paint',
     quantity:    24.5,
     price:       163.99,
@@ -586,7 +586,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          48,
     productId:   214268,
-    productName: 'Compressor 9',
+    productName: 'Compressor 49',
     activity:    'Assemble Paint',
     quantity:    25,
     price:       162.99,
@@ -598,7 +598,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          49,
     productId:   214269,
-    productName: 'Compressor 10',
+    productName: 'Compressor 50',
     activity:    'Assemble Paint',
     quantity:    25.5,
     price:       161.99,
@@ -610,7 +610,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          50,
     productId:   214270,
-    productName: 'Compressor 1',
+    productName: 'Compressor 51',
     activity:    'Assemble Paint',
     quantity:    26,
     price:       160.99,
@@ -621,7 +621,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          51,
     productId:   214271,
-    productName: 'Compressor 2',
+    productName: 'Compressor 52',
     activity:    'Assemble Paint',
     quantity:    26.5,
     price:       159.99,
@@ -633,7 +633,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          52,
     productId:   214272,
-    productName: 'Compressor 3',
+    productName: 'Compressor 53',
     activity:    'Assemble Paint',
     quantity:    27,
     price:       158.99,
@@ -645,7 +645,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          53,
     productId:   214273,
-    productName: 'Compressor 4',
+    productName: 'Compressor 54',
     activity:    'Assemble Paint',
     quantity:    27.5,
     price:       157.99,
@@ -657,7 +657,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          54,
     productId:   214274,
-    productName: 'Compressor 5',
+    productName: 'Compressor 55',
     activity:    'Assemble Paint',
     quantity:    28,
     price:       156.99,
@@ -669,7 +669,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          55,
     productId:   214275,
-    productName: 'Compressor 6',
+    productName: 'Compressor 56',
     activity:    'Assemble Paint',
     quantity:    28.5,
     price:       155.99,
@@ -681,7 +681,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          56,
     productId:   214276,
-    productName: 'Compressor 7',
+    productName: 'Compressor 57',
     activity:    'Assemble Paint',
     quantity:    29,
     price:       154.99,
@@ -693,7 +693,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          57,
     productId:   214277,
-    productName: 'Compressor 8',
+    productName: 'Compressor 58',
     activity:    'Assemble Paint',
     quantity:    29.5,
     price:       153.99,
@@ -705,7 +705,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          58,
     productId:   214278,
-    productName: 'Compressor 9',
+    productName: 'Compressor 59',
     activity:    'Assemble Paint',
     quantity:    30,
     price:       152.99,
@@ -717,7 +717,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          59,
     productId:   214279,
-    productName: 'Compressor 10',
+    productName: 'Compressor 60',
     activity:    'Assemble Paint',
     quantity:    30.5,
     price:       151.99,
@@ -729,7 +729,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          60,
     productId:   214280,
-    productName: 'Compressor 1',
+    productName: 'Compressor 61',
     activity:    'Assemble Paint',
     quantity:    31,
     price:       150.99,
@@ -740,7 +740,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          61,
     productId:   214281,
-    productName: 'Compressor 2',
+    productName: 'Compressor 62',
     activity:    'Assemble Paint',
     quantity:    31.5,
     price:       149.99,
@@ -752,7 +752,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          62,
     productId:   214282,
-    productName: 'Compressor 3',
+    productName: 'Compressor 63',
     activity:    'Assemble Paint',
     quantity:    32,
     price:       148.99,
@@ -764,7 +764,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          63,
     productId:   214283,
-    productName: 'Compressor 4',
+    productName: 'Compressor 64',
     activity:    'Assemble Paint',
     quantity:    32.5,
     price:       147.99,
@@ -776,7 +776,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          64,
     productId:   214284,
-    productName: 'Compressor 5',
+    productName: 'Compressor 65',
     activity:    'Assemble Paint',
     quantity:    33,
     price:       146.99,
@@ -788,7 +788,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          65,
     productId:   214285,
-    productName: 'Compressor 6',
+    productName: 'Compressor 66',
     activity:    'Assemble Paint',
     quantity:    33.5,
     price:       145.99,
@@ -800,7 +800,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          66,
     productId:   214286,
-    productName: 'Compressor 7',
+    productName: 'Compressor 67',
     activity:    'Assemble Paint',
     quantity:    34,
     price:       144.99,
@@ -812,7 +812,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          67,
     productId:   214287,
-    productName: 'Compressor 8',
+    productName: 'Compressor 68',
     activity:    'Assemble Paint',
     quantity:    34.5,
     price:       143.99,
@@ -824,7 +824,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          68,
     productId:   214288,
-    productName: 'Compressor 9',
+    productName: 'Compressor 69',
     activity:    'Assemble Paint',
     quantity:    35,
     price:       142.99,
@@ -836,7 +836,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          69,
     productId:   214289,
-    productName: 'Compressor 10',
+    productName: 'Compressor 70',
     activity:    'Assemble Paint',
     quantity:    35.5,
     price:       141.99,
@@ -848,7 +848,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          70,
     productId:   214290,
-    productName: 'Compressor 1',
+    productName: 'Compressor 71',
     activity:    'Assemble Paint',
     quantity:    36,
     price:       140.99,
@@ -859,7 +859,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          71,
     productId:   214291,
-    productName: 'Compressor 2',
+    productName: 'Compressor 72',
     activity:    'Assemble Paint',
     quantity:    36.5,
     price:       139.99,
@@ -871,7 +871,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          72,
     productId:   214292,
-    productName: 'Compressor 3',
+    productName: 'Compressor 73',
     activity:    'Assemble Paint',
     quantity:    37,
     price:       138.99,
@@ -883,7 +883,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          73,
     productId:   214293,
-    productName: 'Compressor 4',
+    productName: 'Compressor 74',
     activity:    'Assemble Paint',
     quantity:    37.5,
     price:       137.99,
@@ -895,7 +895,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          74,
     productId:   214294,
-    productName: 'Compressor 5',
+    productName: 'Compressor 75',
     activity:    'Assemble Paint',
     quantity:    38,
     price:       136.99,
@@ -907,7 +907,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          75,
     productId:   214295,
-    productName: 'Compressor 6',
+    productName: 'Compressor 76',
     activity:    'Assemble Paint',
     quantity:    38.5,
     price:       135.99,
@@ -919,7 +919,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          76,
     productId:   214296,
-    productName: 'Compressor 7',
+    productName: 'Compressor 77',
     activity:    'Assemble Paint',
     quantity:    39,
     price:       134.99,
@@ -931,7 +931,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          77,
     productId:   214297,
-    productName: 'Compressor 8',
+    productName: 'Compressor 78',
     activity:    'Assemble Paint',
     quantity:    39.5,
     price:       133.99,
@@ -943,7 +943,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          78,
     productId:   214298,
-    productName: 'Compressor 9',
+    productName: 'Compressor 79',
     activity:    'Assemble Paint',
     quantity:    40,
     price:       132.99,
@@ -955,7 +955,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          79,
     productId:   214299,
-    productName: 'Compressor 10',
+    productName: 'Compressor 80',
     activity:    'Assemble Paint',
     quantity:    40.5,
     price:       131.99,
@@ -967,7 +967,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          80,
     productId:   214300,
-    productName: 'Compressor 1',
+    productName: 'Compressor 81',
     activity:    'Assemble Paint',
     quantity:    41,
     price:       130.99,
@@ -978,7 +978,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          81,
     productId:   214301,
-    productName: 'Compressor 2',
+    productName: 'Compressor 82',
     activity:    'Assemble Paint',
     quantity:    41.5,
     price:       129.99,
@@ -990,7 +990,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          82,
     productId:   214302,
-    productName: 'Compressor 3',
+    productName: 'Compressor 83',
     activity:    'Assemble Paint',
     quantity:    42,
     price:       128.99,
@@ -1002,7 +1002,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          83,
     productId:   214303,
-    productName: 'Compressor 4',
+    productName: 'Compressor 84',
     activity:    'Assemble Paint',
     quantity:    42.5,
     price:       127.99000000000001,
@@ -1014,7 +1014,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          84,
     productId:   214304,
-    productName: 'Compressor 5',
+    productName: 'Compressor 85',
     activity:    'Assemble Paint',
     quantity:    43,
     price:       126.99000000000001,
@@ -1026,7 +1026,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          85,
     productId:   214305,
-    productName: 'Compressor 6',
+    productName: 'Compressor 86',
     activity:    'Assemble Paint',
     quantity:    43.5,
     price:       125.99000000000001,
@@ -1038,7 +1038,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          86,
     productId:   214306,
-    productName: 'Compressor 7',
+    productName: 'Compressor 87',
     activity:    'Assemble Paint',
     quantity:    44,
     price:       124.99000000000001,
@@ -1050,7 +1050,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          87,
     productId:   214307,
-    productName: 'Compressor 8',
+    productName: 'Compressor 88',
     activity:    'Assemble Paint',
     quantity:    44.5,
     price:       123.99000000000001,
@@ -1062,7 +1062,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          88,
     productId:   214308,
-    productName: 'Compressor 9',
+    productName: 'Compressor 89',
     activity:    'Assemble Paint',
     quantity:    45,
     price:       122.99000000000001,
@@ -1074,7 +1074,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          89,
     productId:   214309,
-    productName: 'Compressor 10',
+    productName: 'Compressor 90',
     activity:    'Assemble Paint',
     quantity:    45.5,
     price:       121.99000000000001,
@@ -1086,7 +1086,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          90,
     productId:   214310,
-    productName: 'Compressor 1',
+    productName: 'Compressor 91',
     activity:    'Assemble Paint',
     quantity:    46,
     price:       120.99000000000001,
@@ -1097,7 +1097,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          91,
     productId:   214311,
-    productName: 'Compressor 2',
+    productName: 'Compressor 92',
     activity:    'Assemble Paint',
     quantity:    46.5,
     price:       119.99000000000001,
@@ -1109,7 +1109,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          92,
     productId:   214312,
-    productName: 'Compressor 3',
+    productName: 'Compressor 93',
     activity:    'Assemble Paint',
     quantity:    47,
     price:       118.99000000000001,
@@ -1121,7 +1121,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          93,
     productId:   214313,
-    productName: 'Compressor 4',
+    productName: 'Compressor 94',
     activity:    'Assemble Paint',
     quantity:    47.5,
     price:       117.99000000000001,
@@ -1133,7 +1133,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          94,
     productId:   214314,
-    productName: 'Compressor 5',
+    productName: 'Compressor 95',
     activity:    'Assemble Paint',
     quantity:    48,
     price:       116.99000000000001,
@@ -1145,7 +1145,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          95,
     productId:   214315,
-    productName: 'Compressor 6',
+    productName: 'Compressor 96',
     activity:    'Assemble Paint',
     quantity:    48.5,
     price:       115.99000000000001,
@@ -1157,7 +1157,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          96,
     productId:   214316,
-    productName: 'Compressor 7',
+    productName: 'Compressor 97',
     activity:    'Assemble Paint',
     quantity:    49,
     price:       114.99000000000001,
@@ -1169,7 +1169,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          97,
     productId:   214317,
-    productName: 'Compressor 8',
+    productName: 'Compressor 98',
     activity:    'Assemble Paint',
     quantity:    49.5,
     price:       113.99000000000001,
@@ -1181,7 +1181,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          98,
     productId:   214318,
-    productName: 'Compressor 9',
+    productName: 'Compressor 99',
     activity:    'Assemble Paint',
     quantity:    50,
     price:       112.99000000000001,
@@ -1193,7 +1193,7 @@ export const PAGING_DATA: any[] = [
   {
     id:          99,
     productId:   214319,
-    productName: 'Compressor 10',
+    productName: 'Compressor 100',
     activity:    'Assemble Paint',
     quantity:    50.5,
     price:       111.99000000000001,

--- a/src/app/datagrid/datagrid-standalone-pager-demo.service.ts
+++ b/src/app/datagrid/datagrid-standalone-pager-demo.service.ts
@@ -31,8 +31,9 @@ export class DatagridStandalonePagerDemoService {
 
   sortPage(isAscending: boolean): any {
     this.data.sort((o1, o2) => o1.id - o2.id);
-    if (!isAscending)
+    if (!isAscending) {
       this.data.reverse();
+    }
 
     return this.getData('initial', isAscending);
   }

--- a/src/app/datagrid/datagrid-standalone-pager-demo.service.ts
+++ b/src/app/datagrid/datagrid-standalone-pager-demo.service.ts
@@ -27,10 +27,17 @@ export class DatagridStandalonePagerDemoService {
   nextPage(): any     { return this.getData('next');     }
   previousPage(): any { return this.getData('prev');     }
   lastPage(): any     { return this.getData('last');     }
-  sortPage(): any     { return this.getData('initial');  }
   filterPage(): any   { return this.getData('initial');  }
 
-  private getData(type: string): any {
+  sortPage(isAscending: boolean): any {
+    this.data.sort((o1, o2) => o1.id - o2.id);
+    if (!isAscending)
+      this.data.reverse();
+
+    return this.getData('initial', isAscending);
+  }
+
+  private getData(type: string, sortAscending = true): any {
     switch (type) {
       case 'initial': this.beginIndex = 0; break;
       case 'first': this.beginIndex = 0; break;
@@ -38,7 +45,6 @@ export class DatagridStandalonePagerDemoService {
       case 'next': this.beginIndex = this.beginIndex + this.pageSize; break;
       case 'prev': this.beginIndex = this.beginIndex - this.pageSize; break;
 
-      case 'sorted': console.log('sorted stub called - implement me'); break;
       case 'filtered': console.log('filtered stub called - implement me'); break;
     }
 

--- a/src/app/datagrid/datagrid-standalone-pager.demo.ts
+++ b/src/app/datagrid/datagrid-standalone-pager.demo.ts
@@ -1,4 +1,4 @@
-import { Component, NgZone, OnInit, ViewChild, } from '@angular/core';
+import { AfterViewInit, Component, NgZone, OnInit, ViewChild, } from '@angular/core';
 import { SohoDataGridComponent, } from 'ids-enterprise-ng';
 import { DatagridStandalonePagerDemoService } from './datagrid-standalone-pager-demo.service';
 
@@ -7,7 +7,7 @@ import { DatagridStandalonePagerDemoService } from './datagrid-standalone-pager-
   templateUrl: './datagrid-standalone-pager.demo.html',
   providers: [ DatagridStandalonePagerDemoService ]
 })
-export class DatagridStandalonePagerDemoComponent implements OnInit {
+export class DatagridStandalonePagerDemoComponent implements AfterViewInit, OnInit {
   @ViewChild(SohoDataGridComponent, { static: true }) sohoDataGridComponent: SohoDataGridComponent;
 
   data: any[];
@@ -33,6 +33,10 @@ export class DatagridStandalonePagerDemoComponent implements OnInit {
     this.updateTemplateVariables(result);
   }
 
+  ngAfterViewInit(): void {
+    this.sohoDataGridComponent.setSortIndicator('productName', true);
+  }
+
   onFirstPage() {
     const result = this.datagridPagingService.initialPage(this.pageSize);
     this.updateTemplateVariables(result);
@@ -54,10 +58,9 @@ export class DatagridStandalonePagerDemoComponent implements OnInit {
   }
 
   onSortPage(event: SohoDataGridSortedEvent): void {
-    const result = this.datagridPagingService.sortPage();
+    const result = this.datagridPagingService.sortPage(event.sortAsc);
     this.currentSort = event;
     this.updateTemplateVariables(result);
-
   }
 
   onFilterPage(event: SohoDataGridFilteredEvent): void {


### PR DESCRIPTION
change to illustrate the issue with sort indicator

**Steps necessary to review your pull request (required)**:
1. go to `http://localhost:4200/ids-enterprise-ng-demo/datagrid-standalone-pager`
2. Verify that ProductName column sort indicator is sorted ascending 
3. click the ProductName column to sort it descending. 
Notice it does not sort it descending. You have to click it a 2nd time to get it to sort descending. 

see EP issue https://github.com/infor-design/enterprise/issues/3391