### PR TITLE
Added support for id property

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 6.5.0 Fixes
 
+- `[Alert]` Added support for the id property. `DPB` ([#725](https://github.com/infor-design/enterprise-ng/issues/725]))
 - `[ContextualActionPanel]` Fixed default settings. `BTHH` ([#720](https://github.com/infor-design/enterprise-ng/issues/720]))
 - `[ModalDialog]` Added 'centreTitle' to SohoModalOptions. `BTHH`  ([#721](https://github.com/infor-design/enterprise-ng/pull/721]))
 

--- a/projects/ids-enterprise-ng/src/lib/alert/soho-alert.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/alert/soho-alert.directive.ts
@@ -36,6 +36,12 @@ export class SohoAlertDirective implements AfterViewInit {
     }
   }
 
+  /** Set id with the SohoAlertType. */
+  @Input()
+  public set id(id: string) {
+    this._options.id = id;
+  }
+
   /** Set message with the SohoAlertType. */
   @Input()
   public set type(type: SohoAlertType) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Need support for the id property on SohoAlertOptions

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise-ng/issues/725

**Steps necessary to review your pull request (required)**:
Not applicable. Change is providing an input to set the id property on SohoAlertOptions

