### PR TITLE
Submit erroneously activates more button

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,6 @@
     "[markdown]": {
         "editor.formatOnSave": false
     },
-    "prettier.eslintIntegration": true,
     "eslint.validate": [
         "javascript",
         "javascriptreact",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### 7.0.0 Fixes
 
-- `[DataGrid]` Added `showSelectAllCheckBox` option.  `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))
-- `[FlexToobar]` Stopped 'more' button being activated on form submit.   `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))
+- `[DataGrid]` Added `showSelectAllCheckBox` option.  `BTHH` ([Pull Request 740](https://github.com/infor-design/enterprise-ng/pull/740))
+- `[FlexToobar]` Stopped 'more' button being activated on form submit.   `BTHH` ([Pull Request 743](https://github.com/infor-design/enterprise-ng/pull/743))
 
 ### 7.0.0 Features
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 7.0.0 Fixes
 
 - `[DataGrid]` Added `showSelectAllCheckBox` option.  `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))
+- `[FlexToobar]` Stopped 'more' button being activated on form submit.   `BTHH` ([Pull Request xxx](https://github.com/infor-design/enterprise-ng/pull/xxx))
 
 ### 7.0.0 Features
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -10,7 +10,7 @@ If **Node.js** and **npm** are not already on your machine, install them. These 
 
 This quick start guide uses **@angular/cli** to create, build and run the application.
 
-At the time of writing the version of **@angular/cli** used was 8.2.0 with **angular** 8.2.0.
+At the time of writing the version of **@angular/cli** used was 9.0.1 with **angular** 9.0.2.
 
 ## Step 0 : Install Pre-Prerequisites
 
@@ -28,6 +28,8 @@ Using a terminal/console window, use **@angular/cli** to initialise the project,
 
 ```sh
 ng new ids-enterprise-ng-quickstart
+? Would you like to add Angular routing? No
+? Which stylesheet format would you like to use? CSS
 cd ids-enterprise-ng-quickstart
 ```
 
@@ -43,7 +45,7 @@ In a terminal window, in the project folder, type
 npm install ids-enterprise-ng -S
 ```
 
-NOTE: You can also npm link to a local version of the `ids-enterprise-ng` using `npm link`.  If you do this you must add `"preserveSymLinks":true`to the root `angular.json` file, as follows:
+NOTE: You can also npm link to a local version of the `ids-enterprise-ng` using `npm link`.  If you do this you must add `"preserveSymLinks":true` to the root `angular.json` file, as follows:
 
 ```json
 "projects": {
@@ -144,28 +146,34 @@ ng test
 
 This will open a Chrome window, and run the tests from there.
 
-## Add polyfills
+## IE11
 
 If you plan on using IE11, then it is advisable to include a number of polyfills used to plug holes in IEs JavaScript support.
 
-Edit the file `src/polyfills.js`, and uncomment all the import lines below
+First, edit `./browsersupport`, enabling ie11 support.
+
+```properties
+IE 9-11 # For IE 9-11 support, remove .not'.
+```
+
+Edit the file `src/polyfills.js`, and uncomment all the import lines below:
 
 ```typescript
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-import 'core-js/es6/symbol';
-import 'core-js/es6/object';
-import 'core-js/es6/function';
-import 'core-js/es6/parse-int';
-import 'core-js/es6/parse-float';
-import 'core-js/es6/number';
-import 'core-js/es6/math';
-import 'core-js/es6/string';
-import 'core-js/es6/date';
-import 'core-js/es6/array';
-import 'core-js/es6/regexp';
-import 'core-js/es6/map';
-import 'core-js/es6/weak-map';
-import 'core-js/es6/set';
+import 'core-js/es/symbol';
+import 'core-js/es/object';
+import 'core-js/es/function';
+import 'core-js/es/parse-int';
+import 'core-js/es/parse-float';
+import 'core-js/es/number';
+import 'core-js/es/math';
+import 'core-js/es/string';
+import 'core-js/es/date';
+import 'core-js/es/array';
+import 'core-js/es/regexp';
+import 'core-js/es/map';
+import 'core-js/es/weak-map';
+import 'core-js/es/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 import 'classlist.js';  // Run `npm install --save classlist.js`.
@@ -189,11 +197,26 @@ Add ```SohoComponentsModule``` to the imports.
   declarations: [],
   imports: [
     BrowserModule,
+    ...,
     SohoComponentsModule
   ]
   ...
 )}
 ```
+
+## Disable IVY
+
+The IVY compiler is not currently compatible with the SVG icons used by the applicationm, so for now disable the ivy compiler.
+
+Edit `tsconfig.json` and add `"enableIvy": false`, as follows:
+
+```json
+"angularCompilerOptions": {
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true,
+    "enableIvy": false
+  }
+  ```
 
 ## Add a SoHoXi Component
 
@@ -201,7 +224,6 @@ Add a button to `app.component.html`, by appending the following code snippet:
 
 ```html
 <soho-icons></soho-icons>
-
 <button soho-button icon="alert" (click)="clicked()">{{'Alert' | sohoTranslate}}</button>
 ```
 
@@ -213,6 +235,8 @@ public clicked() {
 }
 ```
 
+## Locale Setup
+
 Set the locale path in `app.component.ts`:
 
 ```typescript
@@ -221,6 +245,33 @@ constructor() {
     Soho.Locale.set('en-US');
   }
 ```
+
+NOTE: In the checked in code, the quickstart uses an APP_INITIALIZER to set the locale BEFORE the components are rendered, which is the recommended way of setting and loading locale data.  This allows the locale to be based on the browsers locale, via a service or explicitly in the app.module:
+
+```typescript
+@NgModule({
+  declarations: [
+    AppComponent
+  ],
+    imports: [
+        BrowserModule,
+        SohoLocaleModule,
+        SohoButtonModule,
+        SohoLocaleInitializerModule,
+        SohoComponentsModule
+    ],
+  providers: [
+    {
+      provide: LOCALE_ID,
+      useValue: 'ar-EG'
+    }
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+```
+
+## Run the application
 
 Then from a command line run (you can use `ng serve`):
 

--- a/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
@@ -174,7 +174,7 @@ export class SohoToolbarFlexSearchFieldComponent implements AfterViewChecked, Af
  */
 @Component({
   selector: 'soho-toolbar-flex-more-button', // tslint:disable-line
-  template: `<button class="btn-actions">
+  template: `<button class="btn-actions" type="button" [attr.disabled]="isDisabled ? 'disabled' : null">
     <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
       <use xlink:href="#icon-more"></use>
     </svg>
@@ -186,6 +186,7 @@ export class SohoToolbarFlexSearchFieldComponent implements AfterViewChecked, Af
 export class SohoToolbarFlexMoreButtonComponent {
   @HostBinding('class.more') isMoreButton = true;
   @HostBinding('class.toolbar-section') isToolbarSection = true;
+  @Input() @HostBinding('class.page-changer') isPageChanger = false;
   @Input() isDisabled = false;
   @Input() ajaxBeforeFunction: Function;
   @Input() menuId: string;

--- a/projects/ids-enterprise-ng/src/lib/toolbar/soho-toolbar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/toolbar/soho-toolbar.component.ts
@@ -101,7 +101,7 @@ export class SohoToolbarSearchFieldComponent implements AfterViewChecked, AfterV
     private changeDetector: ChangeDetectorRef,
     private element: ElementRef,
     private ngZone: NgZone
-  ) {}
+  ) { }
 
   ngAfterViewInit() {
     this.ngZone.runOutsideAngular(() => {
@@ -168,7 +168,7 @@ export class SohoToolbarSearchFieldComponent implements AfterViewChecked, AfterV
 @Component({
   selector: 'soho-toolbar-more-button',
   template: `
-              <button class="btn-actions page-changer" type="button" [attr.disabled]="isDisabled ? 'disabled' : null">
+              <button class="btn-actions" type="button" [attr.disabled]="isDisabled ? 'disabled' : null">
                 <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
                   <use xlink:href="#icon-more"></use>
                 </svg>
@@ -186,6 +186,7 @@ export class SohoToolbarSearchFieldComponent implements AfterViewChecked, AfterV
 })
 export class SohoToolbarMoreButtonComponent {
   @HostBinding('class.more') get isMoreButton() { return true; }
+  @Input() @HostBinding('class.page-changer') isPageChanger = false;
   @Input() isDisabled = false;
 }
 
@@ -419,7 +420,7 @@ export class SohoToolbarComponent implements AfterViewChecked, AfterViewInit, On
     private changeDetector: ChangeDetectorRef,
     private element: ElementRef,
     private ngZone: NgZone
-  ) {}
+  ) { }
 
   ngAfterViewInit() {
     this.ngZone.runOutsideAngular(() => {
@@ -441,7 +442,7 @@ export class SohoToolbarComponent implements AfterViewChecked, AfterViewInit, On
         this.ngZone.run(() => this.afterActivated.emit(event)));
 
       this.jQueryElement.on('selected', (event: JQuery.TriggeredEvent, item: HTMLButtonElement | HTMLAnchorElement) =>
-        this.ngZone.run(() => this.selected.emit({event, item})));
+        this.ngZone.run(() => this.selected.emit({ event, item })));
 
       // Returns original button info on mouseover event
       this.jQueryElement.find('.more').on('mouseover', 'li.submenu', ((event: JQuery.TriggeredEvent) => {

--- a/src/app/toolbar-flex/toolbar-flex-basic.demo.html
+++ b/src/app/toolbar-flex/toolbar-flex-basic.demo.html
@@ -1,5 +1,6 @@
-<div class="row top-padding">
-  <div class="twelve columns">
+<form onsubmit="onSubmit()">
+  <div class="row top-padding">
+    <div class="twelve columns">
 
     <!-- BEGIN Toolbar with All Buttons (Buttonset Favoring) -->
     <soho-toolbar-flex
@@ -30,7 +31,6 @@
         </ul>
 
         <button soho-button="icon" icon="settings" [disabled]="true">Settings</button>
-
         <button soho-button="icon" icon="delete">Delete</button>
       </soho-toolbar-flex-section>
 
@@ -49,8 +49,8 @@
     <!-- END Toolbar with All Buttons (Buttonset Favoring) -->
 
   </div>
-</div>
-<div class="row top-padding">
+  </div>
+  <div class="row top-padding">
   <div class="twelve columns">
 
     <!-- BEGIN Toolbar with All Buttons (Title Favoring) -->
@@ -100,8 +100,8 @@
     <!-- END Toolbar with All Buttons (Title Favoring) -->
 
   </div>
-</div>
-<div class="row top-padding">
+  </div>
+  <div class="row top-padding">
   <div class="twelve columns">
 
     <!-- BEGIN Toolbar similar to Header Toolbar -->
@@ -122,8 +122,8 @@
     <!-- END Toolbar similar to Header Toolbar -->
 
   </div>
-</div>
-<div class="row top-padding">
+  </div>
+  <div class="row top-padding">
   <div class="twelve columns">
 
     <!-- BEGIN Toolbar with Title Eyebrow -->
@@ -154,4 +154,15 @@
     <!-- END Toolbar with Title Eyebrow -->
 
   </div>
+
+  <div class="row top-padding">
+    <div class="twelve columns">
+
+        <fieldset>
+          <label for="simpleInput">Press OK in the input:</label>
+          <input soho-input id="simpleInput"/>
+        </fieldset>
+    </div>
 </div>
+  </div>
+</form>

--- a/src/app/toolbar-flex/toolbar-flex-basic.demo.ts
+++ b/src/app/toolbar-flex/toolbar-flex-basic.demo.ts
@@ -14,4 +14,8 @@ export class ToolbarFlexBasicDemoComponent {
     }
     alert(data);
   }
+
+  public onSubmit() {
+    console.log('submit');
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When pressing `Enter` in an input inside a form containing a flex toolbar more button, the more button is erroneously activated.

**Related github/jira issue (required)**:

Closes #742.

**Steps necessary to review your pull request (required)**:

```sh
npm i
npm run build
npm run lint
npm run test
npm run start
```

Navigate to http://localhost:4200/ids-enterprise-ng-demo/toolbar-flex-basic, move focus to the input and press `Enter`.   The more menu should not appear.
