### PR TITLE
Add page-changer class to button not flex element

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
@@ -174,7 +174,8 @@ export class SohoToolbarFlexSearchFieldComponent implements AfterViewChecked, Af
  */
 @Component({
   selector: 'soho-toolbar-flex-more-button', // tslint:disable-line
-  template: `<button class="btn-actions" type="button" [attr.disabled]="isDisabled ? 'disabled' : null">
+  template: `<button class="btn-actions" [ngClass]="{'page-changer': isPageChanger}"
+                     type="button" [attr.disabled]="isDisabled ? 'disabled' : null">
     <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
       <use xlink:href="#icon-more"></use>
     </svg>
@@ -186,7 +187,7 @@ export class SohoToolbarFlexSearchFieldComponent implements AfterViewChecked, Af
 export class SohoToolbarFlexMoreButtonComponent {
   @HostBinding('class.more') isMoreButton = true;
   @HostBinding('class.toolbar-section') isToolbarSection = true;
-  @Input() @HostBinding('class.page-changer') isPageChanger = false;
+  @Input() isPageChanger = false;
   @Input() isDisabled = false;
   @Input() ajaxBeforeFunction: Function;
   @Input() menuId: string;

--- a/src/app/toolbar-flex/toolbar-flex-datagrid.demo.html
+++ b/src/app/toolbar-flex/toolbar-flex-datagrid.demo.html
@@ -23,7 +23,7 @@
       <button soho-button="icon" icon="delete">Delete</button>
     </soho-toolbar-flex-section>
 
-    <soho-toolbar-flex-more-button> </soho-toolbar-flex-more-button>
+    <soho-toolbar-flex-more-button [isPageChanger]="true"> </soho-toolbar-flex-more-button>
   </div>
   <div class="scrollable-flex-content no-scroll">
     <div class="scrollable-flex height-100">


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed issue with page-changer class being added to wrong element in soho-toolbar-flex-more-button.

```html
<soho-toolbar-flex-more-button [isPageChanger]="true"> </soho-toolbar-flex-more-button>
```

```html
<soho-toolbar-flex-more-button ng-reflect-is-page-changer="true" class="more toolbar-section">
  <button class="btn-actions page-changer no-overflowed-items" type="button" ng-reflect-klass="btn-actions" ng-reflect-ng-class="[object Object]" tabindex="-1" aria-haspopup="true" 
aria-controls="popupmenu-6">
  <svg aria-hidden="true" class="icon" focusable="false" role="presentation">
  <use xlink:href="#icon-more">
  </use>
  </svg>
  <span class="audible">More Actions</span>
  </button>
</soho-toolbar-flex-more-button>
```
**Related github/jira issue (required)**:

N/A

**Steps necessary to review your pull request (required)**:

```sh
npm i
npm run build
npm run lint
npm run test
npm run start
```

Navigate to `http://localhost:4200/ids-enterprise-ng-demo`.  Make sure the more button has the `page-changer` class.

