### PR TITLE
Add missing methods for datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 7.0.0 Fixes
 
+- `[DataGrid]` Added missing and/or fixed methods `validateAll`, `validateRow`, and `showRowError`.  `TJM` ([Issue #704](https://github.com/infor-design/enterprise-ng/issues/704))
 - `[DataGrid]` Added `showSelectAllCheckBox` option.  `BTHH` ([Pull Request 740](https://github.com/infor-design/enterprise-ng/pull/740))
 - `[FlexToobar]` Stopped 'more' button being activated on form submit.   `BTHH` ([Pull Request 743](https://github.com/infor-design/enterprise-ng/pull/743))
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1395,6 +1395,10 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
     });
   }
 
+  /**
+   * Removes a row matching the data passed in from the data and grid.
+   * @param data the row of data to remove
+   */
   removeRow(data: any) {
     this.ngZone.runOutsideAngular(() => {
       this.datagrid.removeRow(data);
@@ -1494,6 +1498,23 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
    */
   clearAllErrors(): void {
     this.ngZone.runOutsideAngular(() => this.datagrid.clearAllErrors());
+  }
+
+  /** Validate all rows and cells in the entire grid if they have validation on the column */
+  showRowError(row: number, message: string, type: SohoAlertType): void {
+    this.ngZone.runOutsideAngular(() => this.datagrid.showRowError(row, message, type));
+  }
+
+  /** Validate all cells in a specific row */
+  validateRow(row: number): void {
+    this.ngZone.runOutsideAngular(() => this.datagrid.validateRow(row));
+  }
+
+  /**
+   * Set and show a message/error on the given row.
+   */
+  validateAll(): void {
+    this.ngZone.runOutsideAngular(() => this.datagrid.validateAll());
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -945,6 +945,9 @@ interface SohoDataGridStatic {
   /** Validate all rows and cells in the entire grid if they have validation on the column */
   validateAll(): void;
 
+  /** Validate all cells in a specific row */
+  validateRow(row: number): void;
+
   /** Used to set the sort indicator on a column when disableClientSort is set to true */
   setSortIndicator(columnId: string, ascending: boolean): void;
 
@@ -1089,6 +1092,11 @@ interface SohoDataGridStatic {
    * Clear all errors, alerts and info messages in entire datagrid.
    */
   clearAllErrors(): void;
+
+  /**
+   * Set and show a message/error on the given row.
+   */
+  showRowError(row: number, message:string, type: SohoAlertType): void;
 
   /**
    * Commit the cell that's currently in edit mode.

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
@@ -792,7 +792,7 @@ describe('Soho DataGrid Render', () => {
     done();
   });
 
-  fit('fires `rowRemove` when removeSelected called.', done => {
+  it('fires `rowRemove` when removeSelected called.', done => {
     fixture.detectChanges();
 
     // Try removing row number 1 (second item)

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
@@ -789,15 +789,10 @@ describe('Soho DataGrid Render', () => {
       expect(event.item).toEqual('');
       done();
     });
-
-    // el = de.query(By.css('div[soho-datagrid] ')).nativeElement;
-
-    // el.click();
-
     done();
   });
 
-  xit('fires `rowRemove` when removeSelected called.', done => {
+  fit('fires `rowRemove` when removeSelected called.', done => {
     fixture.detectChanges();
 
     // Try removing row number 1 (second item)

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.spec.ts
@@ -791,30 +791,4 @@ describe('Soho DataGrid Render', () => {
     });
     done();
   });
-
-  it('fires `rowRemove` when removeSelected called.', done => {
-    fixture.detectChanges();
-
-    // Try removing row number 1 (second item)
-    const removedRow = component.data[1];
-
-    component.datagrid.rowRemove.subscribe(
-      (event: SohoDataGridRowRemoveEvent) => {
-        // Make sure the correct row is removed.
-        expect(event.oldValue.productId).toEqual(removedRow.productId);
-        expect(event.row).toBe(1);
-        expect(event.target).not.toBe(null);
-
-        done();
-      }
-    );
-
-    fixture.detectChanges();
-
-    component.datagrid.selectRows([1]);
-
-    fixture.detectChanges();
-
-    component.datagrid.removeSelected();
-  });
 });

--- a/src/app/datagrid/datagrid-editors.demo.html
+++ b/src/app/datagrid/datagrid-editors.demo.html
@@ -1,18 +1,32 @@
-<div class="row">
+<div class="row top-padding">
   <div class="twelve columns">
-    <h2 class="fieldset-title">Soho Data Grid - Editors</h2>
+    <p class="text-secondary">Soho Data Grid - Editors Demo</p>
+    <p>
+      Some cells in this example can be edited. There is an array of grid API actions in the demo actions menu that can be tested.
+    </p>
   </div>
 </div>
 
-<div class="field">
-  <button soho-button (click)="export($event)">Export to Excel</button>
-  <button soho-button (click)="showErrors()">Show Errors</button>
-  <button soho-button (click)="clearStatus()">Clear Status</button>
-</div>
-
-<br>
 <div class="row top-padding">
   <div class="twelve columns demo" role="main">
+    <soho-toolbar>
+      <soho-toolbar-title>
+        <span soho-toolbar-section-title></span>
+      </soho-toolbar-title>
+      <soho-toolbar-button-set>
+        <button soho-menu-button menu="action-popupmenu"
+          (selected)="onActionSelected($event)">Demo Actions</button>
+          <ul soho-popupmenu id="action-popupmenu">
+            <li soho-popupmenu-item><a soho-popupmenu-label data-action="export">Export to Excel</a></li>
+            <li soho-popupmenu-item><a soho-popupmenu-label data-action="show-errors">Show Dirty Row Errors</a></li>
+            <li soho-popupmenu-item><a soho-popupmenu-label data-action="clear-status">Clear Status and Errors</a></li>
+            <li soho-popupmenu-item><a soho-popupmenu-label data-action="show-row-error">Show Row Error</a></li>
+            <li soho-popupmenu-item><a soho-popupmenu-label data-action="validate-row">Validate Row 2</a></li>
+            <li soho-popupmenu-item><a soho-popupmenu-label data-action="validate-all">Validate All Rows</a></li>
+          </ul>
+      </soho-toolbar-button-set>
+    </soho-toolbar>
+
     <div soho-datagrid *ngIf="gridOptions"
     [gridOptions]="gridOptions"
     (keydown)="onKeyDown($event)"

--- a/src/app/datagrid/datagrid-editors.demo.ts
+++ b/src/app/datagrid/datagrid-editors.demo.ts
@@ -23,11 +23,8 @@ export const EDITORS_DATA: any[] = [
   {
     id:          1,
     productId:   214221,
-    productName: 'Compressor 2',
     activity:    'Assemble Paint',
-    quantity:    1.5,
     price:       209.99,
-    status:      'Late',
     orderDate:   '2015-01-02T06:00:00.000Z',
     action:      'Action',
     favorite:    false
@@ -49,7 +46,6 @@ export const EDITORS_DATA: any[] = [
     productId:   214223,
     productName: 'Compressor 4',
     activity:    'Assemble Paint',
-    quantity:    2.5,
     price:       207.99,
     status:      'Inactive',
     orderDate:   '2015-01-04T06:00:00.000Z',
@@ -204,6 +200,18 @@ export const EDITORS_COLUMNS: any[] = [
   },
 
   {
+    id: 'productName',
+    name: 'Product Name',
+    field: 'productName',
+    sortable: false,
+    filterType: 'text',
+    width: 150,
+    formatter: Soho.Formatters.Hyperlink,
+    required: true,
+    validate: 'required'
+  },
+
+  {
     id: 'status',
     name: 'Status',
     field: 'status',
@@ -222,7 +230,9 @@ export const EDITORS_COLUMNS: any[] = [
     sortable: false,
     filterType: 'number',
     width: 105,
-    editor: Soho.Editors.Input
+    editor: Soho.Editors.Input,
+    required: true,
+    validate: 'required'
   },
 
   {
@@ -234,9 +244,8 @@ export const EDITORS_COLUMNS: any[] = [
     showEmpty: true,
     formatter: Soho.Formatters.Favorite,
     editor: Soho.Editors.Favorite
-  },
+  }
 
-  //{ id: 'productName', name: 'Product Name', field: 'productName', sortable: false, filterType: 'text',    width: 150, formatter: Soho.Formatters.Hyperlink },
   //{ id: 'activity',    name: 'Activity',     field: 'activity',    sortable: false, filterType: 'text',    width: 150, formatter: Soho.Formatters.Text, editor: Soho.Editors.Lookup, editorOptions: LOOKUP_OPTIONS },
   //{ id: 'price',       name: 'Price',        field: 'price',       sortable: false, filterType: 'decimal', width: 125, formatter: Soho.Formatters.Decimal },
   //{ id: 'orderDate',   name: 'Order Date',   field: 'orderDate',   sortable: false, filterType: 'date',                formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy' }
@@ -273,7 +282,7 @@ export class DataGridEditorsDemoComponent implements OnInit {
     // an error, want to use rowStatus to show the row in error
     // but this clears the dirtyRows
     let dirtyRows: Array<any> = this.sohoDataGridComponent.dirtyRows();
-    alert('dirtyRows().length = ' + dirtyRows.length);
+    console.log('dirtyRows().length = ' + dirtyRows.length);
     for (let i = 0, l = dirtyRows.length; i < l; i++) {
       var dirtyRow = dirtyRows[i];
       if (dirtyRow.rowStatus.icon === 'dirty') {
@@ -283,13 +292,49 @@ export class DataGridEditorsDemoComponent implements OnInit {
       }
     }
     dirtyRows = this.sohoDataGridComponent.dirtyRows();
-    alert('dirtyRows().length = ' + dirtyRows.length);
+    console.log('dirtyRows().length = ' + dirtyRows.length);
+  }
+
+
+  onActionSelected(event: SohoContextMenuEvent) {
+    const action = event.args.attr('data-action');
+
+    if (action === 'export') {
+     this.export();
+    }
+    if (action === 'show-errors') {
+     this.showErrors();
+    }
+    if (action === 'clear-status') {
+     this.clearStatus();
+    }
+    if (action === 'show-row-error') {
+     this.showRowError();
+    }
+    if (action === 'validate-row') {
+     this.validateRow();
+    }
+    if (action === 'validate-all') {
+     this.validateAll();
+    }
+  }
+
+  showRowError () {
+    this.sohoDataGridComponent.showRowError(2, 'This row has a custom error message.', 'error');
+  }
+
+  validateRow() {
+    this.sohoDataGridComponent.validateRow(1);
+  }
+
+  validateAll() {
+    this.sohoDataGridComponent.validateAll();
   }
 
   clearStatus() {
     let dirtyRows: Array<any> = this.sohoDataGridComponent.dirtyRows();
     let allRows: Array<any> = this.sohoDataGridComponent.dataset;
-    alert('dirtyRows().length = ' + dirtyRows.length);
+    console.log('dirtyRows().length = ' + dirtyRows.length);
     for (let i = 0, l = allRows.length; i < l; i++) {
       var row = allRows[i];
       if (row.rowStatus && row.rowStatus.icon === 'dirtyerror') {
@@ -298,9 +343,10 @@ export class DataGridEditorsDemoComponent implements OnInit {
         this.sohoDataGridComponent.rowStatus(row.id, '', '');
       }
     }
+    this.sohoDataGridComponent.clearAllErrors();
   }
 
-  export (e: any) {
+  export () {
     this.sohoDataGridComponent.exportToExcel('', '', null);
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds a few (3) missing or non functional datagrid methods.

**Related github/jira issue (required)**:
Fixes #704

**Steps necessary to review your pull request (required)**:
- pull this and `npm i && npm run build && npm run start`
- go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-editors
- select some test actions out of the menu (added Validate Row 2, Show Row Error and Validate All Rows to test these three added methods from EP