### PR TITLE
3274 - Added support for api on expand and collapse children with soho datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 7.0.0 Features
 
+- `[Datagrid]` Added support for api setting on expand and collapse children. ([#3274](https://github.com/infor-design/enterprise/issues/3274))
 - `[General]` Upgraded @angular/cli (to 9.0.x) and @angular/core (to 9.0.x).  `BTHH` ([Pull Request 578](https://github.com/infor-design/enterprise-ng/pull/578))
     - support for Node 10.13.0+
     - support for TypeScript 3.6.x & 3.7.x

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1926,6 +1926,36 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
     return this._gridOptions.onBeforeSelect;
   }
 
+  @Input() set onExpandChildren(expandChildrenFunction: SohoDataGridExpandChildrenFunction) {
+    this._gridOptions.onExpandChildren = expandChildrenFunction;
+    if (this.datagrid) {
+      this.datagrid.settings.onExpandChildren = expandChildrenFunction;
+      this.markForRefresh('onExpandChildren', RefreshHintFlags.Rebuild);
+    }
+  }
+
+  get onExpandChildren(): SohoDataGridExpandChildrenFunction {
+    if (this.datagrid) {
+      return this.datagrid.settings.onExpandChildren;
+    }
+    return this._gridOptions.onExpandChildren;
+  }
+
+  @Input() set onCollapseChildren(collapseChildrenFunction: SohoDataGridCollapseChildrenFunction) {
+    this._gridOptions.onCollapseChildren = collapseChildrenFunction;
+    if (this.datagrid) {
+      this.datagrid.settings.onCollapseChildren = collapseChildrenFunction;
+      this.markForRefresh('onCollapseChildren', RefreshHintFlags.Rebuild);
+    }
+  }
+
+  get onCollapseChildren(): SohoDataGridCollapseChildrenFunction {
+    if (this.datagrid) {
+      return this.datagrid.settings.onCollapseChildren;
+    }
+    return this._gridOptions.onCollapseChildren;
+  }
+
   /**
    * Event fired after edit mode is activated on an editor.
    * @param args the event arguments

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -261,6 +261,18 @@ interface SohoDataGridOptions {
   onExpandRow?: SohoDataGridExpandRowFunction;
 
   /**
+  * A callback function that fires when expanding children for treegrid.
+  * delay opening to adjust children or false to break it.
+  */
+  onExpandChildren?: SohoDataGridExpandChildrenFunction;
+
+  /**
+  * A callback function that fires when collapseing children for treegrid.
+  * delay opening to adjust children or false to break it.
+  */
+  onCollapseChildren?: SohoDataGridCollapseChildrenFunction;
+
+  /**
    * An empty message will be displayed when there are no rows in the grid.
    * This accepts an object of the form SohoEmptyMessageOptions, set
    * this to null for no message or it will default to 'No Data Found with an icon.'
@@ -410,6 +422,22 @@ interface SohoDataGridBeforeSelectFunction {
 
 type SohoDataGridBeforeSelectEventData = (
   node: JQuery, idx: number
+) => void;
+
+interface SohoDataGridExpandChildrenFunction {
+  eventData: SohoDataGridExpandChildrenEventData;
+}
+
+type SohoDataGridExpandChildrenEventData = (
+  grid: SohoDataGridStatic, row: number, item: JQuery, rowData: object
+) => void;
+
+interface SohoDataGridCollapseChildrenFunction {
+  eventData: SohoDataGridCollapseChildrenEventData;
+}
+
+type SohoDataGridCollapseChildrenEventData = (
+  grid: SohoDataGridStatic, row: number, item: JQuery, rowData: object
 ) => void;
 
 /**

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -103,6 +103,7 @@ import { DataGridTabDemoComponent } from './datagrid/datagrid-tab.demo';
 import { DataGridTestSettingsDemoComponent } from './datagrid/datagrid-test-settings.demo';
 import { DataGridToolbarDemoComponent } from './datagrid/datagrid-toolbar.demo';
 import { DataGridTreeGridDemoComponent } from './datagrid/datagrid-treegrid.demo';
+import { DataGridTreeGridLazyDemoComponent } from './datagrid/datagrid-treegrid-lazy.demo';
 import { DatagridTreegridDynamicfilteringDemoComponent } from './datagrid/datagrid-treegrid-dynamicfiltering.demo';
 import { DatepickerDemoComponent } from './datepicker/datepicker.demo';
 import { DonutDemoComponent } from './donut/donut.demo';
@@ -300,6 +301,7 @@ import { WeekViewDemoComponent } from './week-view/week-view.demo';
     DataGridTestSettingsDemoComponent,
     DataGridToolbarDemoComponent,
     DataGridTreeGridDemoComponent,
+    DataGridTreeGridLazyDemoComponent,
     DataGridTreeGridCubeDemoComponent,
     DatagridTreegridDynamicfilteringDemoComponent,
     DataGridGroupableDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -67,6 +67,7 @@ import { DataGridStandardFormatterDemoComponent } from './datagrid/datagrid-stan
 import { DataGridTabDemoComponent } from './datagrid/datagrid-tab.demo';
 import { DataGridTestSettingsDemoComponent } from './datagrid/datagrid-test-settings.demo';
 import { DataGridTreeGridDemoComponent } from './datagrid/datagrid-treegrid.demo';
+import { DataGridTreeGridLazyDemoComponent } from './datagrid/datagrid-treegrid-lazy.demo';
 import { DatagridTreegridDynamicfilteringDemoComponent } from './datagrid/datagrid-treegrid-dynamicfiltering.demo';
 import { DatepickerDemoComponent } from './datepicker/datepicker.demo';
 import { DonutDemoComponent } from './donut/donut.demo';
@@ -234,6 +235,7 @@ export const routes: Routes = [
   { path: 'datagrid-expandable-row', component: DataGridExpandableRowDemoComponent },
   { path: 'datagrid-standalone-pager', component: DatagridStandalonePagerDemoComponent },
   { path: 'datagrid-treegrid', component: DataGridTreeGridDemoComponent },
+  { path: 'datagrid-treegrid-lazy', component: DataGridTreeGridLazyDemoComponent },
   { path: 'datagrid-treegrid-cube', component: DataGridTreeGridCubeDemoComponent },
   { path: 'datagrid-treegrid-dynamicfilter', component: DatagridTreegridDynamicfilteringDemoComponent },
   { path: 'datagrid-tab', component: DataGridTabDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -85,6 +85,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-breadcrumb']"><span>DataGrid - Toolbar and Breadcrumb</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-treegrid']"><span>DataGrid - TreeGrid</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-treegrid-cube']"><span>DataGrid - TreeGridCube</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['datagrid-treegrid-lazy']"><span>DataGrid - TreeGrid Lazy</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-treegrid-dynamicfilter']"><span>DataGrid - TreeGrid Dynamic Filter</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-settings']"><span>DataGrid - Updatable Settings</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-expandable-row']"><span>DataGrid - Expandable Row</span></a></div>

--- a/src/app/datagrid/datagrid-treegrid-lazy-service.demo.ts
+++ b/src/app/datagrid/datagrid-treegrid-lazy-service.demo.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@angular/core';
+import {Observable} from 'rxjs';
+import {HttpClient} from '@angular/common/http';
+
+@Injectable()
+export class DatagridTreegridLazyServiceDemo {
+
+  private _columns: SohoDataGridColumn[];
+  private _data: Object[];
+
+  constructor(private http: HttpClient) {}
+
+  public getColumns(): SohoDataGridColumn[] {
+    if (!this._columns) {
+      this._columns = [];
+      /* tslint:disable */
+      this._columns.push({id: 'selectionCheckbox', sortable: false, resizable: false, width: 50, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+      this._columns.push({id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Soho.Formatters.Tree, filterType: 'text', width: 250});
+      this._columns.push({id: 'id', name: 'Id', field: 'id', filterType: 'text', width: 25 });
+      this._columns.push({id: 'desc', name: 'Description', field: 'desc', filterType: 'text'});
+      this._columns.push({id: 'comments', name: 'Comments', field: 'comments', formatter: Soho.Formatters.Hyperlink, filterType: 'text', width: 60 });
+      this._columns.push({id: 'time', name: 'Time', field: 'time', filterType: 'time', width: 60 });
+      /* tslint:enable */
+    }
+    return this._columns;
+  }
+
+  public getData(): any[] {
+    if (!this._data) {
+      /* tslint:disable */
+      this._data = [
+        {id: 1, escalated: 2, depth: 1, expanded: false, taskName: 'Follow up action with HMM Global', desc: '', comments: null, time: '', children: [
+            {id: 2, escalated: 1, depth: 2, taskName: 'Quotes due to expire',  desc: 'Update pending quotes and send out again to customers.', comments: 3, time: '7:10 AM'},
+            {id: 3, escalated: 0, depth: 2, taskName: 'Follow up action with Universal Shipping Logistics Customers', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '9:10 AM'},
+            {id: 4, escalated: 0, depth: 2, taskName: 'Follow up action with Acme Trucking', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '14:10 PM'},
+          ]
+        },
+        {id: 5, escalated: 0, depth: 1, taskName: 'Follow up action with Residental Housing', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '18:10 PM'},
+        {id: 6, escalated: 0, depth: 1, taskName: 'Follow up action with HMM Global', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '20:10 PM'},
+        {id: 7, escalated: 0, depth: 1, expanded: true, taskName: 'Follow up action with Residental Housing', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '22:10 PM', children: [
+            {id: 8, escalated: 0, depth: 2, taskName: 'Follow up action with Universal HMM Logistics', desc: 'Contact sales representative.', comments: 2, time: '22:10 PM'},
+            {id: 9, escalated: 0, depth: 2, taskName: 'Follow up action with Acme Shipping', desc: 'Contact sales representative.', comments: 2, time: '22:10 PM'},
+            {id: 10, escalated: 0, depth: 2, expanded: true, taskName: 'Follow up action with Residental Shipping Logistics ', desc: 'Contact sales representative.', comments: 2, time: '7:04 AM', children: [
+                {id: 11, escalated: 0, depth: 3, taskName: 'Follow up action with Universal Shipping Logistics Customers', desc: 'Contact sales representative.', comments: 2, time: '14:10 PM'},
+                {id: 12, escalated: 0, depth: 3, expanded: true, taskName: 'Follow up action with Acme Universal Logistics Customers', desc: 'Contact sales representative.', comments: 2, time: '7:04 AM', children: [
+                    {id: 13, escalated: 0, depth: 4, taskName: 'More Contact', desc: 'Contact sales representative.', comments: 2, time: '14:10 PM'},
+                    {id: 14, escalated: 0, depth: 4, taskName: 'More Follow up', desc: 'Contact sales representative.', comments: 2, time: '7:04 AM'},
+                  ]
+                },
+              ]
+            }
+          ]
+        }
+      ];
+    }
+    return this._data;
+  }
+
+  public getSimpleColumns(): SohoDataGridColumn[] {
+    if (!this._columns) {
+      this._columns = [];
+      this._columns.push({id: 'selectionCheckbox', sortable: false, resizable: false, width: 50, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+      this._columns.push({id: 'id', name: 'Id', field: 'id', width: 100, formatter: Soho.Formatters.Tree });
+      this._columns.push({id: 'alpha', name: 'Alpha', field: 'alpha', width: 250, filterType: 'text' });
+    }
+
+    return this._columns;
+  }
+
+  public getSimpleData(): any[] {
+    return [
+      {id: 1, alpha: 'A'},
+      {id: 2, alpha: 'B'},
+      {id: 3, alpha: 'C', depth: 1, children: [{id: 4, alpha: 'C1', depth: 2}, {id: 5, alpha: 'C2', depth: 2}]},
+      {id: 6, alpha: 'D'},
+      {id: 7, alpha: 'E'},
+      {id: 8, alpha: 'F'},
+      {id: 9, alpha: 'G'},
+      {id: 10, alpha: 'H'},
+      {id: 11, alpha: 'I'},
+      {id: 12, alpha: 'J'},
+      {id: 13, alpha: 'K'},
+      {id: 14, alpha: 'L'},
+      {id: 15, alpha: 'M'},
+      {id: 16, alpha: 'N'},
+      {id: 17, alpha: 'O'}
+    ]
+  }
+
+  public getInitialFilterDemoData(): Observable<any> {
+    return this.http.get('./app/demodata/tree-filtering.demo.json');
+  }
+}

--- a/src/app/datagrid/datagrid-treegrid-lazy.demo.html
+++ b/src/app/datagrid/datagrid-treegrid-lazy.demo.html
@@ -1,0 +1,45 @@
+﻿﻿<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Soho Data Grid - TreeGrid Lazy Loading</h2>
+  </div>
+  <div class="row">
+    <div class="twelve columns demo" role="main">
+      <section class="scrollable contained-scrolling-right-bottom height-100">
+        <div soho-datagrid
+             (selected)="onSelected($event)"
+             (expandrow)="onExpandRow($event)"
+             (collapserow)="onCollapseRow($event)"
+             selectable="multiple"
+             [onExpandChildren]="onExpandChildren"
+             [treeGrid]="true"
+             [columns]="columns"
+             [dataset]="data"
+             [showSelectAllCheckBox]="false"
+             [stretchColumn]="'desc'"
+             [toolbar]="{title: 'Tasks (Hierarchical)', results: true, personalize: true}"
+             [filterable]="true">
+        </div>
+      </section>
+    </div>
+  </div>
+  <br/>
+  <div class="row" style="display:none">
+    <div class="two-thirds column">
+      <div class="card">
+        <div class="card-header">
+          <h2 class="card-title">Control Events</h2>
+        </div>
+        <div class="card-content">
+          <soho-listview style="display:none">
+            <li soho-listview-item *ngFor="let event of events" [disabled]="true">
+              <p soho-listview-header>Event '{{event.name}}'</p>
+              <p soho-listview-subheader>{{event.descr}}</p>
+              <p soho-listview-micro>Fired: {{event.fired}}</p>
+            </li>
+          </soho-listview>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/src/app/datagrid/datagrid-treegrid-lazy.demo.ts
+++ b/src/app/datagrid/datagrid-treegrid-lazy.demo.ts
@@ -1,21 +1,21 @@
 ﻿import { Component, ViewChild, ChangeDetectionStrategy } from '@angular/core';
 import { SohoDataGridComponent, SohoDataGridToggleRowEvent } from 'ids-enterprise-ng';
 import { SohoBusyIndicatorDirective } from 'ids-enterprise-ng';
-import { DatagridTreegridServiceDemo } from './datagrid-treegrid-service.demo';
+import { DatagridTreegridLazyServiceDemo } from './datagrid-treegrid-lazy-service.demo';
 
 @Component({
-  selector: 'app-datagrid-treegrid-demo',
-  templateUrl: 'datagrid-treegrid.demo.html',
+  selector: 'app-datagrid-treegrid-lazy-demo',
+  templateUrl: 'datagrid-treegrid-lazy.demo.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [DatagridTreegridServiceDemo]
+  providers: [DatagridTreegridLazyServiceDemo]
 })
-export class DataGridTreeGridDemoComponent {
+export class DataGridTreeGridLazyDemoComponent {
   @ViewChild(SohoDataGridComponent, { static: true }) dataGrid: SohoDataGridComponent;
   @ViewChild(SohoBusyIndicatorDirective, { static: true }) busyIndicator: SohoBusyIndicatorDirective;
 
   events: any[] = [];
 
-  constructor(private treeService: DatagridTreegridServiceDemo) { }
+  constructor(private treeService: DatagridTreegridLazyServiceDemo) { }
 
   public get columns(): SohoDataGridColumn[] {
     return this.treeService.getColumns();
@@ -25,12 +25,24 @@ export class DataGridTreeGridDemoComponent {
     return this.treeService.getData();
   }
 
-  toggleFilterRow() {
-    this.dataGrid.toggleFilterRow();
-  }
+  onExpandChildren(args: any) {
+    console.log(args);
 
-  clearFilter() {
-    this.dataGrid.clearFilter();
+    const someData: any[] = [{
+      id: 215,
+      escalated: 0,
+      taskName: 'Follow up action with Residental Housing',
+      desc: 'Contact sales representative with the updated purchase order.',
+      comments: 2,
+      time: '22:10 PM'
+    }];
+    const promise = new Promise((resolve, reject) => {
+      setTimeout(() => {
+        args.grid.addChildren(args.row, someData);
+        resolve();
+      }, 1000);
+    });
+    return promise;
   }
 
   onSelected(e: SohoDataGridSelectedEvent) {
@@ -53,16 +65,5 @@ export class DataGridTreeGridDemoComponent {
   onCollapseRow(e: SohoDataGridToggleRowEvent) {
     const descr = e.rowData.taskName;
     this.events.push({ name: 'collapserow', descr, date: new Date() });
-  }
-
-  makeChange() {
-    this.dataGrid.isList = !this.dataGrid.isList;
-    this.dataGrid.alternateRowShading = !this.dataGrid.alternateRowShading;
-    this.dataGrid.cellNavigation = !this.dataGrid.cellNavigation;
-  }
-
-  toggleSelectAll() {
-    this.dataGrid.showSelectAllCheckBox = !this.dataGrid.showSelectAllCheckBox;
-    console.log(`showSelectAllCheckBox=${this.dataGrid.showSelectAllCheckBox}`);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support for api setting on expand and collapse children with Soho Datagrid.

**Related github/jira issue (required)**:
Closes infor-design/enterprise#3274

**Steps necessary to review your pull request (required)**:
- After ([PR 3581](https://github.com/infor-design/enterprise/pull/3581)) merged
- Pull and build this branch
- Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-treegrid-lazy
- Toggle any parent row
- Every time on expand it should some delay add new row with id `215`

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
