### PR TITLE
Added back ability to run with IE compatibility

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -74,6 +74,9 @@
                     "maximumError": "10kb"
                   }
                 ]
+              },
+              "es5": {
+                "tsConfig": "tsconfig.es5.json"
               }
             }
           },

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -19,20 +19,20 @@
  */
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. */
-// import 'core-js/es/symbol';
-// import 'core-js/es/object';
-// import 'core-js/es/function';
-// import 'core-js/es/parse-int';
-// import 'core-js/es/parse-float';
-// import 'core-js/es/number';
-// import 'core-js/es/math';
-// import 'core-js/es/string';
-// import 'core-js/es/date';
-// import 'core-js/es/array';
-// import 'core-js/es/regexp';
-// import 'core-js/es/map';
-// import 'core-js/es/weak-map';
-// import 'core-js/es/set';
+import 'core-js/es/symbol';
+import 'core-js/es/object';
+import 'core-js/es/function';
+import 'core-js/es/parse-int';
+import 'core-js/es/parse-float';
+import 'core-js/es/number';
+import 'core-js/es/math';
+import 'core-js/es/string';
+import 'core-js/es/date';
+import 'core-js/es/array';
+import 'core-js/es/regexp';
+import 'core-js/es/map';
+import 'core-js/es/weak-map';
+import 'core-js/es/set';
 
 /**
  * If the application will be indexed by Google Search, the following is required.
@@ -41,10 +41,10 @@
  **/
 // import 'core-js/es/array';
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
-// import 'classlist.js';  // Run `npm install --save classlist.js`.
+import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /** IE10 and IE11 requires the following for the Reflect API. */
-// import 'core-js/es/reflect';
+import 'core-js/es/reflect';
 
 /**
  * Web Animations `@angular/platform-browser/animations`


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Add missing configuration for IE (es5) showing how to run example in IE.

**Related github/jira issue (required)**:

Closes #668 (again)

**Steps necessary to review your pull request (required)**:

```sh
git clone 
npm i
npm run build:lib
npm start:ie
```

Navigate to http://localhost:4200/ids-enterprise-ng-demo
