### PR TITLE
588 - Updated example page for async multiselect with soho lookup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `[DataGrid]` Added `showSelectAllCheckBox` option.  `BTHH` ([Pull Request 740](https://github.com/infor-design/enterprise-ng/pull/740))
 - `[Icon]` Changed to remove `Renderer2` and use `href` instead of `xlink:href`.  `BTHH` ([Issue #3611](https://github.com/infor-design/enterprise/issues/3611))
 - `[FlexToobar]` Stopped 'more' button being activated on form submit.   `BTHH` ([Pull Request 743](https://github.com/infor-design/enterprise-ng/pull/743))
-- `[Lookup]` Updated example page for async multiselect. ([#588](https://github.com/infor-design/enterprise-ng/issues/588))
+- `[Lookup]` Updated example page to add async multiselect. ([#588](https://github.com/infor-design/enterprise-ng/issues/588))
 - `[Personalize]` Fixed errors and updated the theme and variant switcher to have several submenus.   `TJM/BTHH` ([Pull Request 745](https://github.com/infor-design/enterprise-ng/pull/745))
 - `[Personalize]` Fixed a problem reseting the color to default and reloading the page.   `TJMH` ([Pull Request 751](https://github.com/infor-design/enterprise-ng/pull/751))
 - `[FileUploadAdvanced]` - Added `errorMaxFilesInProcess` and `errorMaxFileSize` inputs to component, and added zone compatibility.  `BTHH` ([Pull Request XXX](https://github.com/infor-design/enterprise-ng/pull/XXX))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[DataGrid]` Added `showSelectAllCheckBox` option.  `BTHH` ([Pull Request 740](https://github.com/infor-design/enterprise-ng/pull/740))
 - `[Icon]` Changed to remove `Renderer2` and use `href` instead of `xlink:href`.  `BTHH` ([Issue #3611](https://github.com/infor-design/enterprise/issues/3611))
 - `[FlexToobar]` Stopped 'more' button being activated on form submit.   `BTHH` ([Pull Request 743](https://github.com/infor-design/enterprise-ng/pull/743))
+- `[Lookup]` Updated example page for async multiselect. ([#588](https://github.com/infor-design/enterprise-ng/issues/588))
 - `[Personalize]` Fixed errors and updated the theme and variant switcher to have several submenus.   `TJM/BTHH` ([Pull Request 745](https://github.com/infor-design/enterprise-ng/pull/745))
 - `[Personalize]` Fixed a problem reseting the color to default and reloading the page.   `TJMH` ([Pull Request 751](https://github.com/infor-design/enterprise-ng/pull/751))
 - `[FileUploadAdvanced]` - Added `errorMaxFilesInProcess` and `errorMaxFileSize` inputs to component, and added zone compatibility.  `BTHH` ([Pull Request XXX](https://github.com/infor-design/enterprise-ng/pull/XXX))

--- a/src/app/lookup/lookup.demo.html
+++ b/src/app/lookup/lookup.demo.html
@@ -264,8 +264,37 @@
             [dataset]="data_product"
             field="productId"
             name="product_custom_match" />
-
         </div>
+
+        <div class="field">
+          <label soho-label for="product_async">Products (Async Results) Multi Select</label>
+          <input soho-lookup
+            soho-trackdirty (pristine)="onPristine($event)" (dirty)="onDirty($event)"
+            [(ngModel)]="model.async"
+            [columns]="columns_product"
+            multiselect
+            [options]="{
+              allowSelectAcrossPages: true,
+              paging: true,
+              pagesize: 5,
+              pagesizes: [3, 5, 10, 15]
+            }"
+            [source]="source.bind(context)"
+            [toolbar]="{
+              results: true,
+              dateFilter: false,
+              keywordFilter: true,
+              advancedFilter: true,
+              actions: true,
+              views: true,
+              rowHeight: false,
+              collapsibleFilter: false,
+              fullWidth: true
+            }"
+            field="productId"
+            name="product_async_multi"/>
+        </div>
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Updated example page to add async multiselect with Soho Lookup

**Related github/jira issue (required)**:
Closes #588

**Steps necessary to review your pull request (required)**:
- After ([PR 3624](https://github.com/infor-design/enterprise/pull/3624)) merged
- Pull and build this branch
- Go to http://localhost:4200/ids-enterprise-ng-demo/lookup
- Open lookup `Products (Async Results) Multi Select` (last one on the page)
- Select the first value (or any value)
- Click Apply
- Re-open lookup and click Apply without changing anything
- Previously selected value should not lost on 2nd `Apply`
- Try some other combinations as select/deselect or paging etc

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
