### PR TITLE
Fixed page refresh on selecting wizard tick

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 7.1.0 Fixes
 
+- `[Wizard]` Prevent page refresh on selecting wizard ticks.  `BTHH` ([Pull Request #797](https://github.com/infor-design/enterprise-ng/pull/797))
+
 ## v7.0.1
 
 ### 7.0.1 Fixes

--- a/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-page.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-page.component.ts
@@ -70,7 +70,7 @@ export class SohoWizardPageComponent implements AfterViewInit {
    * I'd have rather done this with an event, but we end up
    * with a circular dependency.
    *
-   * @param e - the soho wizaerd event.
+   * @param e - the soho wizard event.
    *
    */
   fireActivated(e: SohoWizardEvent) {

--- a/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-tick.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-tick.component.ts
@@ -6,7 +6,8 @@ import {
   ChangeDetectionStrategy,
   AfterViewInit,
   HostBinding,
-  Input
+  Input,
+  HostListener
 } from '@angular/core';
 
 /**
@@ -43,6 +44,9 @@ export class SohoWizardTickComponent implements AfterViewInit {
    */
   @Input() public tickId: string;
 
+  /**
+   *
+   */
   @HostBinding('class.current')
   @Input() public current = false;
 
@@ -52,7 +56,18 @@ export class SohoWizardTickComponent implements AfterViewInit {
   @HostBinding('class.is-disabled')
   @Input() public disabled = false;
 
+  /**
+   * JQuery Element.
+   */
   public jQueryElement: JQuery;
+
+  /**
+   * Disable the click handler.
+   */
+  @HostListener('click', ['$event']) onClick(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
 
   public isCurrentTick(): boolean {
     // A step is selected if the element has the current class.

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -364,4 +364,4 @@ export const routes: Routes = [
 /**
  * To test the application using the hashing routing strategy, swap the two lines below.
  */
-export const AppRoutingModule: ModuleWithProviders = RouterModule.forRoot(routes, { useHash: true });
+export const AppRoutingModule: ModuleWithProviders = RouterModule.forRoot(routes, { useHash: false });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When clicking on the tick of the wizard component, the page is refreshed and in the case of the hash router an error is displayed because the target route does not eixst.

This is because the anchor element used by the wizard tick has an href associated with it which is automatically be routed.  This is disabled by adding a host listener to the wizard tick and prevent event propagation.

I have also remove the hash routing as the default in the demo, as standard routing is prefereable.

**Related github/jira issue (required)**:

N/A

**Steps necessary to review your pull request (required)**:

```sh
npm i
npm run build
npm run lint
npm run test
npm run start
```

Navigate to http://localhost:4200/ids-enterprise-ng-demo/wizard and click on the ticks, e.g. 'Select Files'.  The wizard should change page but the page should not be redrawn,
