### PR TITLE
811  - Namespace Cap events

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 7.1.0 Fixes
 
+- `[ContextualActionPanel]` The contextual action panel turned off all body events messing up other components attached to body so namespaced these.  `TJM` ([Issue #811](https://github.com/infor-design/enterprise-ng/issues/811))
 - `[Locale]` The types for locale where incorrect so fixed them and added some new ones.  `TJM` ([Issue #756](https://github.com/infor-design/enterprise-ng/issues/756))
 - `[Wizard]` Prevent page refresh on selecting wizard ticks.  `BTHH` ([Pull Request #797](https://github.com/infor-design/enterprise-ng/pull/797))
 

--- a/projects/ids-enterprise-ng/package.json
+++ b/projects/ids-enterprise-ng/package.json
@@ -6,7 +6,7 @@
     "@types/jquery": "3.3.29",
     "@types/d3": "4.13.0",
     "ids-enterprise": "4.29.0-dev.20200503",
-    "jquery": "3.4.1",
+    "jquery": "3.5.0",
     "d3": "4.13.0"
   },
   "peerDependencies": {

--- a/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
@@ -284,10 +284,10 @@ export class SohoContextualActionPanelRef<T> {
     });
 
     // Add listeners to control events
-    this.jQueryElement.on('close', ((event: any, isCancelled: boolean) => { this.onClose(event, isCancelled); }));
-    this.jQueryElement.on('open', ((event: any) => { this.onOpen(event); }));
-    this.contextualactionpanel.panel.on('afterclose', ((event: any) => { this.onAfterClose(event); }));
-    this.contextualactionpanel.panel.on('afteropen', ((event: any) => { this.onAfterOpen(event); }));
+    this.jQueryElement.on('close.contextualactionpanel', ((event: any, isCancelled: boolean) => { this.onClose(event, isCancelled); }));
+    this.jQueryElement.on('open.contextualactionpanel', ((event: any) => { this.onOpen(event); }));
+    this.contextualactionpanel.panel.on('afterclose.contextualactionpanel', ((event: any) => { this.onAfterClose(event); }));
+    this.contextualactionpanel.panel.on('afteropen.contextualactionpanel', ((event: any) => { this.onAfterOpen(event); }));
 
     return this;
   }
@@ -407,7 +407,7 @@ export class SohoContextualActionPanelRef<T> {
     });
 
     if (this.jQueryElement) {
-      this.jQueryElement.off();
+      this.jQueryElement.off('close.contextualactionpanel open.contextualactionpanel');
     }
 
     this.contextualactionpanel.destroy();

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -71,7 +71,19 @@ export class ContextualActionPanelDemoComponent {
       .contextualactionpanel(ContextualActionPanelComponent, this.placeholder)
       .modalSettings({ buttons: buttons, title: this.title })
       .open()
-      .initializeContent(true);
+      .initializeContent(true)
+      .opened(() => {
+        console.log('Open Fires');
+      })
+      .afterOpen(() => {
+        console.log('After Open Fires');
+      })
+      .close(() => {
+        console.log('Close Fires');
+      })
+      .afterClose(() => {
+        console.log('After Close Fires');
+      });
   }
 
   openPanel2() {

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -78,8 +78,8 @@ export class ContextualActionPanelDemoComponent {
       .afterOpen(() => {
         console.log('After Open Fires');
       })
-      .close(() => {
-        console.log('Close Fires');
+      .closed(() => {
+        console.log('Closed Fires');
       })
       .afterClose(() => {
         console.log('After Close Fires');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The CAP component turns off any events attached to body by mistake. As per #811 this can and did turn off event used by other components. To fix this i used namespaces on the events.

**Related github/jira issue (required)**:
Fixes #811

**Steps necessary to review your pull request (required)**:
- http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- click the first button
- watch the console for events firing
