### PR TITLE
[soho-field-filter] A more convenient way to set the filter operator

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.d.ts
@@ -44,18 +44,21 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
   fieldfilter(settings?: SohoFieldFilterSettings): JQuery;
 }
 
+type SohoFieldFilterOperator =
+  'end-with' | 'does-not-end-with' |
+ 'start-with' | 'does-not-start-with' |
+ 'equals' | 'does-not-equal' |
+ 'contains' | 'does-not-contain' |
+ 'calendar' | 'in-range' |
+ 'is-empty' | 'is-not-empty' |
+ 'less-equals' | 'less-than' |
+ 'greater-equals' | 'greater-than' |
+ 'between' | 'selected-notselected' |
+ 'selected' | 'not-selected' |
+ 'sort-a-to-z' | 'sort-z-to-a';
+
 interface SohoFieldFilterOption {
-  value: 'end-with' | 'does-not-end-with' |
-         'start-with' | 'does-not-start-with' |
-         'equals' | 'does-not-equal' |
-         'contains' | 'does-not-contain' |
-         'calendar' | 'in-range' |
-         'is-empty' | 'is-not-empty' |
-         'less-equals' | 'less-than' |
-         'greater-equals' | 'greater-than' |
-         'between' | 'selected-notselected' |
-         'selected' | 'not-selected' |
-         'sort-a-to-z' | 'sort-z-to-a';
+  value: SohoFieldFilterOperator;
   text: string;
   icon: string;
   selected ?: boolean;

--- a/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
@@ -46,9 +46,7 @@ export class SohoFieldFilterDirective implements AfterViewChecked, AfterViewInit
   }
 
   @Input() set selectedFilterType(type: SohoFieldFilterOperator) {
-    if (this.fieldFilter) {
-      this.setFilterType(type);
-    }
+    this.setFilterType(type);
   }
 
   @Output() filtered: EventEmitter<SohoFieldFilteredEvent> = new EventEmitter<SohoFieldFilteredEvent>();
@@ -66,6 +64,7 @@ export class SohoFieldFilterDirective implements AfterViewChecked, AfterViewInit
   private jQueryElement: JQuery;
   private fieldFilter: SohoFieldFilterStatic;
   private runUpdatedOnCheck: boolean;
+  private filterType: SohoFieldFilterOperator;
 
   constructor(
     private ref: ChangeDetectorRef,
@@ -119,7 +118,20 @@ export class SohoFieldFilterDirective implements AfterViewChecked, AfterViewInit
    * returns {void}
    */
   public setFilterType(value: SohoFieldFilterOperator | number) {
-    this.ngZone.runOutsideAngular(() => this.fieldFilter.setFilterType(value));
+    if (!value) {
+      return;
+    }
+    // Do this if jQueryElement has been built already
+    if (this.fieldFilter) {
+      this.ngZone.runOutsideAngular(() => this.fieldFilter.setFilterType(value));
+      return;
+    }
+    // Otherwise, as long as type is SohoFieldFilterOperator, set the selected attribute
+    if (typeof value !== 'number') {
+      this._settings.dataset.forEach((filterOption: SohoFieldFilterOption) => {
+        filterOption.selected = (filterOption.value === value);
+      });
+    }
   }
 
   /** Destructor. */

--- a/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
@@ -45,6 +45,12 @@ export class SohoFieldFilterDirective implements AfterViewChecked, AfterViewInit
     }
   }
 
+  @Input() set selectedFilterType(type: SohoFieldFilterOperator) {
+    if (this.fieldFilter) {
+      this.setFilterType(type);
+    }
+  }
+
   @Output() filtered: EventEmitter<SohoFieldFilteredEvent> = new EventEmitter<SohoFieldFilteredEvent>();
 
   // default to only equals
@@ -112,7 +118,7 @@ export class SohoFieldFilterDirective implements AfterViewChecked, AfterViewInit
    * param {number|string} value to be set, index or value.
    * returns {void}
    */
-  public setFilterType(value: any) {
+  public setFilterType(value: SohoFieldFilterOperator | number) {
     this.ngZone.runOutsideAngular(() => this.fieldFilter.setFilterType(value));
   }
 

--- a/src/app/field-filter/field-filter.demo.html
+++ b/src/app/field-filter/field-filter.demo.html
@@ -3,8 +3,21 @@
   <div class="one-half column">
 
     <div class="field">
+      <label soho-label for="example-dropdown">Filter Operator for Text Field</label>
+      <select soho-dropdown name="example-dropdown" class="input-mm" [(ngModel)]="filterOperator">
+        <option value="equals">equals</option>
+        <option value="does-not-equal">does-not-equal</option>
+        <option value="less-than">less-than</option>
+      </select>
+    </div>
+
+    <div class="field">
       <label soho-label for="filter-text">Text Field</label>
-      <input soho-field-filter [fieldSettings]="filterSettings" type="text" id="filter-text" name="filter-text" class="input-sm" [(ngModel)]="model.text.value" (filtered)="onFiltered($event)">
+      <input soho-field-filter type="text" id="filter-text" name="filter-text" class="input-sm"
+        [fieldDropdownDataSet]="fieldDropdownDataSet"
+        [selectedFilterType]="filterOperator"
+        (filtered)="onFiltered($event)"
+        [(ngModel)]="model.text.value" >
       <p>Value: {{model.text.value}} <br> FilterType: {{model.text.filterType}}</p>
     </div>
 

--- a/src/app/field-filter/field-filter.demo.ts
+++ b/src/app/field-filter/field-filter.demo.ts
@@ -46,6 +46,17 @@ export class FieldFilterDemoComponent {
     { value: 'greater-equals', text: 'Greater Or Equals', icon: 'filter-greater-equals' }]
   };
 
+  public fieldDropdownDataSet = [
+    { value: 'equals', text: 'Equals', icon: 'filter-equals' },
+    { value: 'does-not-equal', text: 'Does Not Equal', icon: 'filter-does-not-equal' },
+    { value: 'less-than', text: 'Less Than', icon: 'filter-less-than' },
+    { value: 'less-equals', text: 'Less Or Equals', icon: 'filter-less-equals', selected: true },
+    { value: 'greater-than', text: 'Greater Than', icon: 'filter-greater-than' },
+    { value: 'greater-equals', text: 'Greater Or Equals', icon: 'filter-greater-equals' }
+  ];
+
+  public filterOperator = 'equals';
+
   public filterSettingsWithRange: SohoFieldFilterSettings = {
     dataset: [
     { value: 'equals', text: 'Equals', icon: 'filter-equals' },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Currently it is not very convenient to programmatically change the selected operator in the filter field. Either you update fieldSettings or fieldDropdownDataSet Input which would consist of the whole array of SohoFieldFilterOption. Never had luck in using setFilterType via ViewChild in the parent component, this is very also inconvenient esp. if you have a lot of soho-field-filter in the template.

This new change adds a new Input named **selectedFilterType** which allows for a more convenient way to set the filter field operator. Also added a new type named **SohoFieldFilterOperator** to have stricter type checking for the input.

**Related github/jira issue (required)**:
NA

**Steps necessary to review your pull request (required)**:
1. checkout this branch
2. go to http://localhost:4200/ids-enterprise-ng-demo/field-filter
3. switch values from the "Filter Operator for Text Field" dropdown
4. see realtime changes in the "Text Field" operator

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
