### PR TITLE
[soho-field-filter] field filter reset

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
@@ -118,8 +118,9 @@ export class SohoFieldFilterDirective implements AfterViewChecked, AfterViewInit
    * returns {void}
    */
   public setFilterType(value: SohoFieldFilterOperator | number) {
+    // set 1st option as default in order to achieve filter reset
     if (!value) {
-      return;
+      value = 0;
     }
     // Do this if jQueryElement has been built already
     if (this.fieldFilter) {

--- a/src/app/field-filter/field-filter.demo.html
+++ b/src/app/field-filter/field-filter.demo.html
@@ -9,6 +9,7 @@
         <option value="does-not-equal">does-not-equal</option>
         <option value="less-than">less-than</option>
       </select>
+      <p>filterOperator: {{filterOperator}}</p>
     </div>
 
     <div class="field">
@@ -19,6 +20,7 @@
         (filtered)="onFiltered($event)"
         [(ngModel)]="model.text.value" >
       <p>Value: {{model.text.value}} <br> FilterType: {{model.text.filterType}}</p>
+      <button soho-button icon="reset" (click)="resetTextFilter()">Reset Filter</button>
     </div>
 
     <div class="field">

--- a/src/app/field-filter/field-filter.demo.ts
+++ b/src/app/field-filter/field-filter.demo.ts
@@ -70,7 +70,10 @@ export class FieldFilterDemoComponent {
 
   public dateMode = 'standard';
 
-  constructor() { }
+  resetTextFilter() {
+    this.model.text.value = '';
+    this.filterOperator = null;
+  }
 
   onFiltered(event: SohoFieldFilteredEvent) {
     const targetElement = event.target as Element;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Forgot to consider reset in #820. You may set selectedFilterType to any default value that you want you perform the reset, but normally you would expect just set operator and value to null and let the directive do its job to reset to the default.

**Related github/jira issue (required)**:
improvement from #820

**Steps necessary to review your pull request (required)**:
1. checkout this branch
2. go to http://localhost:4200/ids-enterprise-ng-demo/field-filter
3. change "Text Field" operator / value
4. hit the reset button
5. value and operator must reset 

![field-filter-reset](https://user-images.githubusercontent.com/11013464/82393074-05a9f980-9a78-11ea-85ae-02d7210a8c9a.gif)

