### PR TITLE
#770 Homepage edit events should trigger on widgets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datagrid]` Update the dynamic datagrid example to not show the browser contextmenu.  `TJM` ([#817](https://github.com/infor-design/enterprise/issues/817))
 - `[Modal]` The modal dialog had a second wrapper added (SohoModal vs SohoModalDialog), it was decided to stick with one, the existing SohoModalDialog.  `TJM` ([Issue #776](https://github.com/infor-design/enterprise-ng/issues/776))
+- `[Homepage]` Homepage edit events (resize, reorder, remove widgets) now fire on widget elements too ([#770](https://github.com/infor-design/enterprise-ng/issues/770))
 
 ## v7.1.0
 

--- a/projects/ids-enterprise-ng/src/lib/homepage/soho-homepage.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/homepage/soho-homepage.component.ts
@@ -219,9 +219,7 @@ export class SohoHomePageComponent implements AfterViewInit, OnDestroy {
   }
 
   onResizeCard(card: JQuery, metadata: object) {
-    const event: SohoHomePageEditEvent = { card: null, metadata: null };
-    event.card = card;
-    event.metadata = metadata;
+    const event: SohoHomePageEditEvent = { homepage: this, card: card, metadata: null };
 
     this.ngZone.run(() => {
       this.resizecard.emit(event);
@@ -229,9 +227,7 @@ export class SohoHomePageComponent implements AfterViewInit, OnDestroy {
   }
 
   onReorderCard(card: JQuery, metadata: object) {
-    const event: SohoHomePageEditEvent = { card: null, metadata: null };
-    event.card = card;
-    event.metadata = metadata;
+    const event: SohoHomePageEditEvent = { homepage: this, card: card, metadata: null };
 
     this.ngZone.run(() => {
       this.reordercard.emit(event);
@@ -239,9 +235,7 @@ export class SohoHomePageComponent implements AfterViewInit, OnDestroy {
   }
 
   onRemoveCard(card: JQuery, metadata: object) {
-    const event: SohoHomePageEditEvent = { card: null, metadata: null };
-    event.card = card;
-    event.metadata = metadata;
+    const event: SohoHomePageEditEvent = { homepage: this, card: card, metadata: null };
 
     this.ngZone.run(() => {
       this.removecard.emit(event);

--- a/projects/ids-enterprise-ng/src/lib/homepage/soho-homepage.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/homepage/soho-homepage.component.ts
@@ -219,7 +219,7 @@ export class SohoHomePageComponent implements AfterViewInit, OnDestroy {
   }
 
   onResizeCard(card: JQuery, metadata: object) {
-    const event: SohoHomePageEditEvent = { homepage: this, card: card, metadata: null };
+    const event: SohoHomePageEditEvent = { homepage: this, card: card, metadata: metadata };
 
     this.ngZone.run(() => {
       this.resizecard.emit(event);
@@ -227,7 +227,7 @@ export class SohoHomePageComponent implements AfterViewInit, OnDestroy {
   }
 
   onReorderCard(card: JQuery, metadata: object) {
-    const event: SohoHomePageEditEvent = { homepage: this, card: card, metadata: null };
+    const event: SohoHomePageEditEvent = { homepage: this, card: card, metadata: metadata };
 
     this.ngZone.run(() => {
       this.reordercard.emit(event);
@@ -235,7 +235,7 @@ export class SohoHomePageComponent implements AfterViewInit, OnDestroy {
   }
 
   onRemoveCard(card: JQuery, metadata: object) {
-    const event: SohoHomePageEditEvent = { homepage: this, card: card, metadata: null };
+    const event: SohoHomePageEditEvent = { homepage: this, card: card, metadata: metadata };
 
     this.ngZone.run(() => {
       this.removecard.emit(event);

--- a/projects/ids-enterprise-ng/src/lib/homepage/soho-homepage.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/homepage/soho-homepage.d.ts
@@ -86,6 +86,16 @@ interface SohoHomePageEvent {
  * Soho Homepage Edit Event
  */
 interface SohoHomePageEditEvent {
+  homepage?: import("./soho-homepage.component").SohoHomePageComponent;
+  card?: JQuery;
+  metadata?: object;
+}
+
+/**
+ * Soho Homepage Edit Event on Widget
+ */
+interface SohoHomePageWidgetEditEvent {
+  widget?: import("./soho-widget.component").SohoWidgetComponent;
   card?: JQuery;
   metadata?: object;
 }

--- a/projects/ids-enterprise-ng/src/lib/homepage/soho-widget.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/homepage/soho-widget.component.ts
@@ -1,8 +1,14 @@
 import {
   Component,
   HostBinding,
-  Input
+  Input,
+  Output,
+  EventEmitter,
+  NgZone,
+  ElementRef,
+  AfterViewInit,
 } from '@angular/core';
+import { eventNames } from 'process';
 
 export type WidgetSize = 'single' | 'double' | 'triple' | 'quad';
 
@@ -10,7 +16,7 @@ export type WidgetSize = 'single' | 'double' | 'triple' | 'quad';
   selector: 'div[soho-widget]', // tslint:disable-line
   template: `<ng-content></ng-content>`,
 })
-export class SohoWidgetComponent {
+export class SohoWidgetComponent implements AfterViewInit {
   @HostBinding('class') get classList(): string {
     let tmp = '';
 
@@ -36,4 +42,51 @@ export class SohoWidgetComponent {
   @Input() widgetWidth: WidgetSize;
   @Input() widgetHeight: WidgetSize | 'auto';
   @Input() removable: boolean;
+
+  @Output() resizecard = new EventEmitter<any>();
+  @Output() reordercard = new EventEmitter<any>();
+  @Output() removecard = new EventEmitter<any>();
+
+  constructor(
+    private elementRef: ElementRef,
+    private ngZone: NgZone,
+  ) { }
+
+  // Reference to the jQuery element.
+  private jQueryElement: JQuery;
+
+  ngAfterViewInit() {
+    this.ngZone.runOutsideAngular(() => {
+      this.jQueryElement = jQuery(this.elementRef.nativeElement);
+
+      this.jQueryElement
+        .on('resizecard', (e: JQuery.TriggeredEvent, card: JQuery, metadata: object) => { this.onResizeCard(card, metadata) })
+        .on('reordercard', (e: JQuery.TriggeredEvent, card: JQuery, metadata: object) => { this.onReorderCard(card, metadata) })
+        .on('removecard', (e: JQuery.TriggeredEvent, card: JQuery, metadata: object) => { this.onRemoveCard(card, metadata) })
+    });
+  }
+
+  onResizeCard(card: JQuery<HTMLElement>, metadata: object) {
+    const event: SohoHomePageWidgetEditEvent = { widget: this, card: card, metadata: metadata };
+
+    this.ngZone.run(() => {
+      this.resizecard.emit(event);
+    });
+  }
+
+  onReorderCard(card: JQuery<HTMLElement>, metadata: object) {
+    const event: SohoHomePageWidgetEditEvent = { widget: this, card: card, metadata: metadata };
+
+    this.ngZone.run(() => {
+      this.reordercard.emit(event);
+    });
+  }
+
+  onRemoveCard(card: JQuery<HTMLElement>, metadata: object) {
+    const event: SohoHomePageWidgetEditEvent = { widget: this, card: card, metadata: metadata };
+
+    this.ngZone.run(() => {
+      this.removecard.emit(event);
+    });
+  }
 }

--- a/projects/ids-enterprise-ng/src/lib/homepage/soho-widget.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/homepage/soho-widget.component.ts
@@ -60,9 +60,9 @@ export class SohoWidgetComponent implements AfterViewInit {
       this.jQueryElement = jQuery(this.elementRef.nativeElement);
 
       this.jQueryElement
-        .on('resizecard', (e: JQuery.TriggeredEvent, card: JQuery, metadata: object) => { this.onResizeCard(card, metadata) })
-        .on('reordercard', (e: JQuery.TriggeredEvent, card: JQuery, metadata: object) => { this.onReorderCard(card, metadata) })
-        .on('removecard', (e: JQuery.TriggeredEvent, card: JQuery, metadata: object) => { this.onRemoveCard(card, metadata) })
+        .on('resizecard', (e: JQuery.TriggeredEvent, card: JQuery, metadata: object) => { this.onResizeCard(card, metadata); })
+        .on('reordercard', (e: JQuery.TriggeredEvent, card: JQuery, metadata: object) => { this.onReorderCard(card, metadata); })
+        .on('removecard', (e: JQuery.TriggeredEvent, card: JQuery, metadata: object) => { this.onRemoveCard(card, metadata); });
     });
   }
 

--- a/src/app/homepage/homepage-editable.demo.html
+++ b/src/app/homepage/homepage-editable.demo.html
@@ -4,19 +4,19 @@
 <div soho-homepage soho-homepage-sizer [columns]="3" [editing]="isEditingMode" [onBeforeRemoveCard]="onBeforeRemoveCard"
   (resizecard)="onResizeCard($event)" (reordercard)="onReorderCard($event)" (removecard)="onRemoveCard($event)">
 
-  <div soho-widget>
+  <div soho-widget (resizecard)="onResizeCard($event)" (reordercard)="onReorderCard($event)" (removecard)="onRemoveCard($event)">
     <div soho-widget-header>
       <h2 soho-widget-title [tabIndex]="0">Widget 1x1 (Dom Order 1)</h2>
     </div>
   </div>
 
-  <div soho-widget removable="false" widgetWidth="double">
+  <div soho-widget removable="false" widgetWidth="double" (resizecard)="onResizeCard($event)" (reordercard)="onReorderCard($event)">
     <div soho-widget-header>
       <h2 soho-widget-title [tabIndex]="1">Widget 2x1 (Dom Order 2)</h2>
     </div>
   </div>
 
-  <div soho-widget>
+  <div soho-widget (resizecard)="onResizeCard($event)" (reordercard)="onReorderCard($event)" (removecard)="onRemoveCard($event)">
     <div soho-widget-header>
       <h2 soho-widget-title [tabIndex]="2">Widget 1x1 (Dom Order 3)</h2>
     </div>

--- a/src/app/homepage/homepage-editable.demo.ts
+++ b/src/app/homepage/homepage-editable.demo.ts
@@ -15,13 +15,13 @@ export class HomePageEditableDemoComponent {
     this.isEditingMode = !this.isEditingMode;
   }
 
-  onResizeCard(event) {
-    this.toastService.show({ draggable: true, title: 'Widget Resized', message: 'A widget has been resized' });
+  onResizeCard(event: SohoHomePageEditEvent & SohoHomePageWidgetEditEvent) {
+    this.toastService.show({ draggable: true, title: `${event.widget ? 'Widget' : 'Homepage'}`, message: `A widget has been resized` });
     console.log(event);
   }
 
-  onReorderCard(event) {
-    this.toastService.show({ draggable: true, title: 'Widget Reordered', message: 'A widget has been moved' });
+  onReorderCard(event: SohoHomePageEditEvent & SohoHomePageWidgetEditEvent) {
+    this.toastService.show({ draggable: true, title: `${event.widget ? 'Widget' : 'Homepage'}`, message: `A widget has been reordered` });
     console.log(event);
   }
 
@@ -55,8 +55,8 @@ export class HomePageEditableDemoComponent {
     return result;
   }
 
-  onRemoveCard(event) {
-    this.toastService.show({ draggable: true, title: 'Widget Removed', message: 'A widget has been removed' });
+  onRemoveCard(event: SohoHomePageEditEvent & SohoHomePageWidgetEditEvent) {
+    this.toastService.show({ draggable: true, title: `${event.widget ? 'Widget' : 'Homepage'}`, message: `A widget has been removed` });
     console.log(event);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Need to allow handling of events in different ways. It can be more useful for the event to fire on the widget sometimes.

**Related github/jira issue (required)**:
Closes #770

**Steps necessary to review your pull request (required)**:
Run the demo app and go to http://localhost:4200/ids-enterprise-ng-demo/homepage-editable
Resize, reorder, remove widgets.
Expect to see two event toast messages. One will fire on the homepage element, and the other on the widget element.

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
