### PR TITLE
794 - Add new contextmenu event and dynamic tree example

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,8 @@
 - `[ModalDialog]` Added support the new buttonsetAPI on modal.  `BTHH` ([Issue #781](https://github.com/infor-design/enterprise-ng/issues/781))
 - `[Mask]` Removed the old and deprecated MaskLegacyDemoComponent from the examples.  `TJM` ([Issue #781](https://github.com/infor-design/enterprise-ng/issues/781))
 - `[Popupmenu]` Added new shortcut text option.  `TJM` ([Issue #3849](https://github.com/infor-design/enterprise/issues/3849))
-- `[Slider]` Added missing options tooltipPosition, sliding, slidestart, slidestop.  `TJM` ([Issue #3849](https://github.com/infor-design/enterprise-ng/issues/787 ))
+- `[Slider]` Added missing options tooltipPosition, sliding, slidestart, slidestop.  `TJM` ([Issue #787](https://github.com/infor-design/enterprise-ng/issues/787))
+- `[Tree]` Added a new contextmenu method, and show a dynamic menu example.  `TJM` ([Issue #794](https://github.com/infor-design/enterprise-ng/issues/79))
 
 ### 7.2.0 Fixes
 

--- a/projects/ids-enterprise-ng/src/lib/tree/soho-tree.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tree/soho-tree.component.ts
@@ -175,6 +175,11 @@ export class SohoTreeComponent implements AfterViewInit, OnInit, OnDestroy {
   @Output() selected = new EventEmitter<SohoTreeEvent>();
 
   /**
+   * This event is fired when right clicking a node.
+   * */
+  @Output() contextmenu = new EventEmitter<SohoTreeEvent>();
+
+  /**
    * This event is fired when a node is unselected, the SohoTreeNode
    * unselected is passed in the argument passed to the handler.
    * */
@@ -482,6 +487,7 @@ export class SohoTreeComponent implements AfterViewInit, OnInit, OnDestroy {
 
     // Initialize any event handlers.
     this.jQueryElement
+      .on('contextmenu', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.contextmenu.next(args))
       .on('selected', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.selected.next(args))
       .on('unselected', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.unselected.next(args))
       .on('expand', (e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.expand.next(args))

--- a/src/app/tree/tree-content.demo.html
+++ b/src/app/tree/tree-content.demo.html
@@ -14,35 +14,55 @@
 <br>
 <div class="row top-padding">
   <div class="twelve columns demo" role="main">
-      <ul soho-busyindicator [soho-tree]="'content-only'" menuId="tree-popupmenu" (menuselect)="onMenuSelected($event)" (selected)="onSelected($event)">
-        <li>
-          <a href="#" id="home">Home</a>
-        </li>
-        <li><a href="#" id="about">About Us</a></li>
-        <li class="is-open">
-          <a href="#" id="public">Public Folders</a>
-          <ul class="is-open root">
-            <li class="is-open">
-              <a href="#" id="leadership">Leadership</a>
-              <ul class="is-open">
-                <li class="is-selected">
-                  <a href="#" id="managers" class="icon-tree-image">Managers</a>
-                </li>
-                <li>
-                  <a href="#" id="history">History</a>
-                </li>
-                <li>
-                  <a href="#" id="careers" class="is-disabled">Careers</a>
-                </li>
-              </ul>
-            </li>
-          </ul>
-        </li>
-      </ul>
+    <ul soho-busyindicator [soho-tree]="'content-only'" (menuopen)="onMenuOpen($event)"
+      (menuselect)="onMenuSelected($event)" (selected)="onSelected($event)" (contextmenu)="onContextMenu($event)">
+      <li>
+        <a href="#" id="home">Home</a>
+      </li>
+      <li><a href="#" id="about">About Us</a></li>
+      <li class="is-open">
+        <a href="#" id="public">Public Folders</a>
+        <ul class="is-open root">
+          <li class="is-open">
+            <a href="#" id="leadership">Leadership</a>
+            <ul class="is-open">
+              <li class="is-selected">
+                <a href="#" id="managers">Managers</a>
+              </li>
+              <li>
+                <a href="#" id="history">History</a>
+              </li>
+              <li>
+                <a href="#" id="careers">Careers</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li class="is-open">
+        <a href="#" id="priv">Private Folders</a>
+        <ul class="is-open root">
+          <li class="is-open">
+            <a href="#" id="departments">Departments</a>
+            <ul class="is-open">
+              <li>
+                <a href="#" id="hr">HR</a>
+              </li>
+              <li>
+                <a href="#" id="fin">Finance</a>
+              </li>
+              <li>
+                <a href="#" id="mkt">Mkt</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
   </div>
 </div>
-
-<ul id="tree-popupmenu" class="popupmenu">
- <li><a id="add" href="#" data-cmd="add">Add</a></li>
- <li><a id="delete" href="#" data-cmd="delete">Delete</a></li>
- </ul>
+<ul #treeContextMenu id="treeContextPopupMenu" class="popupmenu">
+  <li *ngFor="let childOption of contextMenuOptions">
+    <a id="{{childOption.id}}" href="#">{{childOption.name}}</a>
+  </li>
+</ul>

--- a/src/app/tree/tree-content.demo.ts
+++ b/src/app/tree/tree-content.demo.ts
@@ -2,8 +2,11 @@ import {
   Component,
   ElementRef,
   ViewChild,
+  NgZone,
+  ChangeDetectionStrategy,
+  ViewChildren,
   OnInit,
-  ChangeDetectionStrategy
+  QueryList
 } from '@angular/core';
 
 import { SohoTreeComponent } from 'ids-enterprise-ng';
@@ -14,17 +17,196 @@ import { SohoTreeComponent } from 'ids-enterprise-ng';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TreeContentDemoComponent implements OnInit {
-
   @ViewChild(SohoTreeComponent, { static: true }) tree: SohoTreeComponent;
+  @ViewChildren('treeContextMenu') treeContextMenu: QueryList<any>;
+
+  treeOptions: SohoTreeOptions = {
+    folderIconOpen: 'plusminus-folder-open',
+    folderIconClosed: 'plusminus-folder-closed',
+    menuId: 'treeContextPopupMenu',
+    hideCheckboxes: true
+  };
   enabled = true;
   selected: SohoTreeNode;
+  contextMenuOptions = [];
+  options1 = [
+    {
+      'id': 'PISumOfMathFunctionBtn',
+      'name': 'sum_of',
+      'functionname': 'sum',
+      'action': 'AddMathFuntion'
+    },
+    {
+      'id': 'PIAverageOfMathFunctionBtn',
+      'name': 'avg_of',
+      'functionname': 'avg',
+      'action': 'AddMathFuntion'
 
-  ngOnInit(): void {
-    // Can also set options here as well as in the inputs
-    // this.tree.options.menuId = 'tree-popupmenu';
+    },
+    {
+      'id': 'PIMaximumOfMathFunctionBtn',
+      'name': 'max_of',
+      'functionname': 'max',
+      'action': 'AddMathFuntion'
+    },
+    {
+      'id': 'PICountOfMathFunctionBtn',
+      'name': 'count_of',
+      'functionname': 'count',
+      'action': 'AddMathFuntion'
+    },
+    {
+      'id': 'PIMinimumOfMathFunctionBtn',
+      'name': 'min_of',
+      'functionname': 'min',
+      'action': 'AddMathFuntion'
+    },
+    {
+      'id': 'PIAbsoluteOfMathFunctionBtn',
+      'name': 'abs_of',
+      'functionname': 'abs',
+      'action': 'AddMathFuntion'
+    },
+    {
+      'id': 'PIVarianceOfMathFunctionBtn',
+      'name': 'var_of',
+      'functionname': 'var',
+      'action': 'AddMathFuntion'
+    },
+    {
+      'id': 'PIDateDifferenceOfMathFunctionBtn',
+      'name': 'datediff_of',
+      'functionname': 'datediff',
+      'action': 'AddDateDiffMathFuntion'
+    },
+    {
+      'id': 'PIAdditionOperBtn',
+      'name': 'addition_operator',
+      'functionname': 'plus',
+      'action': 'AddMathOperator'
+    },
+    {
+      'id': 'PISubtractionOperBtn',
+      'name': 'subtraction_operator',
+      'functionname': 'minus',
+      'action': 'AddMathOperator'
+    },
+    {
+      'id': 'PIMultiplicationOperBtn',
+      'name': 'multiplication_operator',
+      'functionname': 'multiply',
+      'action': 'AddMathOperator'
+    },
+    {
+      'id': 'PIDivisionOperBtn',
+      'name': 'division_operator',
+      'functionname': 'divide',
+      'action': 'AddMathOperator'
+    },
+    {
+      'id': 'PIModuloOperBtn',
+      'name': 'modulo_operator',
+      'functionname': 'modulo',
+      'action': 'AddMathOperator'
+    },
+    {
+      'id': 'PIBracketsBtn',
+      'name': 'add brackets',
+      'functionname': 'brackets',
+      'action': 'AddBrackets'
+    },
+    {
+      'id': 'PIOpenBracketBtn',
+      'name': 'open_bracket',
+      'functionname': 'open brackets',
+      'action': 'AddOpenBracket'
+    },
+    {
+      'id': 'PICloseBracketBtn',
+      'name': 'close_bracket',
+      'functionname': 'Close brackets',
+      'action': 'AddCloseBracket'
+    },
+    {
+      'id': 'PIValueMoveUpBtn',
+      'name': 'move_up',
+      'functionname': 'Move Up',
+      'action': 'MoveNodeUp'
+    },
+    {
+      'id': 'PIValueMoveDownBtn',
+      'name': 'move_down',
+      'functionname': 'Move down',
+      'action': 'MoveNodeDown'
+    },
+    {
+      'id': 'PIRemoveValueBtn',
+      'name': 'remove_this_condition',
+      'functionname': 'Remove Condition',
+      'action': 'RemoveNode'
+    },
+    {
+      'id': 'PISumOfMathFunctionBtn',
+      'name': 'sum_of',
+      'functionname': 'sum',
+      'action': 'ReplaceMathFuntion'
+    },
+    {
+      'id': 'PIAverageOfMathFunctionBtn',
+      'name': 'avg_of',
+      'functionname': 'avg',
+      'action': 'ReplaceMathFuntion'
+    },
+    {
+      'id': 'PIMaximumOfMathFunctionBtn',
+      'name': 'max_of',
+      'functionname': 'max',
+      'action': 'ReplaceMathFuntion'
+    },
+    {
+      'id': 'PICountOfMathFunctionBtn',
+      'name': 'count_of',
+      'functionname': 'count',
+      'action': 'ReplaceMathFuntion'
+    },
+    {
+      'id': 'PIMinimumOfMathFunctionBtn',
+      'name': 'min_of',
+      'functionname': 'min',
+      'action': 'ReplaceMathFuntion'
+    },
+    {
+      'id': 'PIAbsoluteOfMathFunctionBtn',
+      'name': 'abs_of',
+      'functionname': 'abs',
+      'action': 'ReplaceMathFuntion'
+    },
+    {
+      'id': 'PIVarianceOfMathFunctionBtn',
+      'name': 'var_of',
+      'functionname': 'var',
+      'action': 'ReplaceMathFuntion'
+    },
+    {
+      'id': 'PIDateDifferenceOfMathFunctionBtn',
+      'name': 'datediff_of',
+      'functionname': 'datediff',
+      'action': 'AddDateDiffMathFuntion'
+    }
+  ];
+  options2 = [
+    {
+      'id': 'id_NoOperation',
+      'name': 'No Operations available',
+      'action': 'Nothing'
+    }
+  ];
+
+  constructor(private element: ElementRef, private ngZone: NgZone) {
   }
 
-  constructor(private el: ElementRef) {
+  ngOnInit() {
+    this.tree.options = this.treeOptions;
   }
 
   expandAll() {
@@ -33,6 +215,26 @@ export class TreeContentDemoComponent implements OnInit {
 
   collapseAll() {
     this.tree.collapseAll();
+  }
+
+  onMenuOpen(e) {
+    console.log('menu-open', e);
+  }
+
+  onContextMenu(e) {
+    console.log('contextmenu', e);
+    this.ngZone.runOutsideAngular(() => {
+      if (this.contextMenuOptions.length === this.options1.length) {
+        this.contextMenuOptions = this.options2;
+      } else {
+        this.contextMenuOptions = this.options1;
+      }
+    });
+  }
+
+  onMenuSelected(treeEvent: SohoTreeEvent) {
+    const cmd = (treeEvent as any).item[0].getAttribute('data-cmd');
+    console.log(`You selected command: ${cmd}`);
   }
 
   toggleEnabled(event: any) {
@@ -57,7 +259,7 @@ export class TreeContentDemoComponent implements OnInit {
   }
 
   addNode() {
-    const tn: SohoTreeNode = {text: 'New Item 1.2', disabled: true};
+    const tn: SohoTreeNode = { text: 'New Item 1.2', disabled: false };
     this.tree.addNode(tn, this.selected);
   }
 
@@ -66,8 +268,4 @@ export class TreeContentDemoComponent implements OnInit {
     console.log('Tree Event: ${this.selected}');
   }
 
-  onMenuSelected(treeEvent: SohoTreeEvent) {
-    const cmd = (treeEvent as any).item[0].getAttribute('data-cmd');
-    console.log(`You selected command: ${cmd}`);
-  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The use case on #794 was tricky. It required doing this a bit differently with timing. To facilitate this..

a) needed a new context menu event
b) need to run the menu change outside of zone or this all fires at the wrong time after the component runs position logic.

**Related github/jira issue (required)**:
Fixes #794

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4200/ids-enterprise-ng-demo/tree-content
- right click the tree
- each time you do it will toggle between a short and long menu.
- the menu should position OK each time

