### PR TITLE
3731 - Add target property for hyperlink with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 7.3.0 Fixes
 
+- `[Datagrid]` Added target property for hyperlink formatter column. ([#3731](https://github.com/infor-design/enterprise/issues/3731))
+
 ## v7.2.0
 
 ### 7.2.0 Notes

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -807,6 +807,9 @@ interface SohoDataGridColumn {
   /** href for hyperlink */
   href?: SohoDataGridColumnHref;
 
+  /** href target for hyperlink */
+  target?: string;
+
   /** Column function to dynamically set the readonly property on cells based on row data. */
   isEditable?: SohoDataGridColumnIsEditableFunction;
 

--- a/src/app/datagrid/datagrid-custom-formatter-service.demo.ts
+++ b/src/app/datagrid/datagrid-custom-formatter-service.demo.ts
@@ -38,6 +38,14 @@ export class DataGridCustomFormatterServiceDemoComponent implements OnInit {
 
     PAGING_COLUMNS.forEach(element => columns.push(element));
 
+    /**
+     * Add a href to hyperlink column, `Product Name`
+     */
+    if (columns.length > 2) {
+      columns[2].href = 'http://www.google.com';
+      columns[2].target = '_blank';
+    }
+
     columns.push({
       id: 'custom-formatter',
       name: 'Custom Formatter',
@@ -51,6 +59,7 @@ export class DataGridCustomFormatterServiceDemoComponent implements OnInit {
       selectable: 'single',
       paging: true,
       pagesize: 10,
+      toolbar: { title: 'Data Grid Header Title', collapsibleFilter: true, keywordFilter: true, actions: true, rowHeight: true }
     };
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added target property for hyperlink formatter column with Datagrid.

**Related github/jira issue (required)**:
Closes infor-design/enterprise#3731

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/datagrid-custom-formatter-service
- Click on any cell in column `Product Name`
- Link should open in next tab

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
