### PR TITLE
803 - Make router dependency optional in modal dialog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Lookup]` Resynced the lookup api settings, methods and events with the core component. Also made sure everything is using ngZone. `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))
 - `[Lookup]` And added an example showing how to use the buttonsetAPI to enable and disable buttons.  `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))
 - `[Lookup]` And added an example showing how to use a dataset as an input to populate the lookup.  `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))
+- `[ModalDialog]` Make the router dependency optional in the Modal Dialog. ([Issue #803](https://github.com/infor-design/enterprise/issues/803))
 
 ## v7.2.0
 

--- a/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
@@ -405,20 +405,22 @@ export class SohoModalDialogRef<T> {
 
     // Add a subscription to the router to remove
     // the dialog when the user navigates.
-    router.events
-      .pipe(takeUntil(this.destroyed$))
-      .subscribe(e => {
-        if (this._closeOnNavigation && e instanceof NavigationEnd) {
-          // Disable the beforeClose veto capability when navigating.
-          this.eventGuard.beforeClose = null;
-          if (this.modal) {
-            this.modal.close(true);
+    if (router) {
+      router.events
+        .pipe(takeUntil(this.destroyed$))
+        .subscribe(e => {
+          if (this._closeOnNavigation && e instanceof NavigationEnd) {
+            // Disable the beforeClose veto capability when navigating.
+            this.eventGuard.beforeClose = null;
+            if (this.modal) {
+              this.modal.close(true);
+            }
+            if (this.componentRef) {
+              this.componentRef.destroy();
+            }
           }
-          if (this.componentRef) {
-            this.componentRef.destroy();
-          }
-        }
-      });
+        });
+    }
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.service.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.service.ts
@@ -7,6 +7,7 @@ import {
   NgZone,
   ViewContainerRef,
   ApplicationRef,
+  Optional
 } from '@angular/core';
 
 import { ArgumentHelper } from '../utils/argument.helper';
@@ -33,7 +34,7 @@ export class SohoModalDialogService {
     private readonly componentFactoryResolver: ComponentFactoryResolver,
     private readonly injector: Injector,
     private readonly ngZone: NgZone,
-    private readonly router: Router) {
+    @Optional() private readonly router: Router) {
   }
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds the Optional flag to the router dependency in modal dialog

**Related github/jira issue (required)**:
closes #803 

**Steps necessary to review your pull request (required)**:
- Pull Branch
- `npm run build:lib && npm run start`
- Go to http://localhost:4200/ids-enterprise-ng-demo/modal-dialog and make sure all the Modals still work

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
