### PR TITLE
add data arg to DataGrid.setDirtyIndicator function

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Datagrid]` Fixed updatePagingInfo function which was wired on pager now and not working. To fix it i kept it flat on the datagrid object  `TJM` ([Issue #781](https://github.com/infor-design/enterprise-ng/issues/781))
 - `[Datagrid]` Added target property for hyperlink formatter column. ([#3731](https://github.com/infor-design/enterprise/issues/3731))
 - `[Datagrid]` Build expanded datagrid row with dynamic component. Special case: nested datagrid.  `AF` ([Issue #206](https://github.com/infor-design/enterprise-ng/issues/206))
+- `[DataGrid]` Added optional data object param to setDirtyIndicator to match soho datagrid setDirtyIndicator. `PWP` ([Issue #829](https://github.com/infor-design/enterprise-ng/issues/829))
 - `[Lookup]` Resynced the lookup api settings, methods and events with the core component. Also made sure everything is using ngZone. `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))
 - `[Lookup]` And added an example showing how to use the buttonsetAPI to enable and disable buttons.  `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))
 - `[Lookup]` And added an example showing how to use a dataset as an input to populate the lookup.  `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1574,10 +1574,11 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
    * @param row The row index
    * @param cell The cell index
    * @param toggle True to set it and false to remove it
+   * @param data Adds dirty data to the internal tracker
    */
-  setDirtyIndicator(row: number, cell: number, toggle: boolean): void {
+  setDirtyIndicator(row: number, cell: number, toggle: boolean, data?: object): void {
     this.ngZone.runOutsideAngular(() => {
-      this.datagrid.setDirtyIndicator(row, cell, toggle);
+      this.datagrid.setDirtyIndicator(row, cell, toggle, data);
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -1180,7 +1180,7 @@ interface SohoDataGridStatic {
    * @param cell The cell index
    * @param toggle True to set it and false to remove it
    */
-  setDirtyIndicator(row: number, cell: number, toggle: boolean): void;
+  setDirtyIndicator(row: number, cell: number, toggle: boolean, data?: object): void;
 
   /**
    * Returns the row dom jQuery node.


### PR DESCRIPTION
Need to be able to programatically set data on the busy indicator

**Related github/jira issue (required)**:
closes #829 

**Steps necessary to review your pull request (required)**:
Note both soho-datagrid.d.ts and soho-datagrid.component.ts setBusyIndicator functions have new options data param added to the end of the argument list.
