### PR TITLE
stand alone pager optimizations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Lookup]` And added an example showing how to use the buttonsetAPI to enable and disable buttons.  `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))
 - `[Lookup]` And added an example showing how to use a dataset as an input to populate the lookup.  `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))
 - `[ModalDialog]` Make the router dependency optional in the Modal Dialog. ([Issue #803](https://github.com/infor-design/enterprise/issues/803))
+- `[StandalonePager]` Optimize enable/show buttons and pageSizeChooser to call methods directly in pager.js avoiding a rerender of the entire pager. ([Issue #843](https://github.com/infor-design/enterprise-ng/issues/843))
 - `[ToolbarSearchField]` And missing change event.  `TJM` ([Issue #839](https://github.com/infor-design/enterprise/issues/839))
 
 ## v7.2.3

--- a/projects/ids-enterprise-ng/src/lib/pager/soho-pager.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/pager/soho-pager.d.ts
@@ -154,6 +154,8 @@ interface SohoPagerStatic {
   updatePagingInfo(pagerInfo: SohoPagerPagingInfo): void;
 }
 
+type PagerButtonType = 'first' | 'last' | 'previous' | 'next';
+
 interface SohoStandalonePagerStatic {
   /** Accessible settings - for updates. */
   settings: SohoStandalonePagerOptions;
@@ -163,6 +165,26 @@ interface SohoStandalonePagerStatic {
 
   /** call updated when options change after the pager has been initialized */
   updated(SohoStandalonePagerOptions): void;
+
+  /**
+   * Shows or hides a specified special control button on the Pager.
+   * @param type the type of button to target.
+   * @param   toggleOption Show vs. Hide
+   */
+  showButton(type: PagerButtonType, toggleOption: boolean);
+
+  /**
+   * Enables or disables a specified special control button on the Pager.
+   * @param type the type of button to target.
+   * @param toggleOption Enable vs. Disable
+   */
+  enableButton(type: PagerButtonType, toggleOption: boolean);
+
+  /**
+   * Show page size selector
+   * @param toggleOption Toggle vs show
+   */
+  showPageSizeSelector(toggleOption: boolean);
 
   /** call from ngOnDestroy to ensure any resources the pager uses are cleaned up */
   destroy();

--- a/projects/ids-enterprise-ng/src/lib/pager/soho-standalone-pager.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/pager/soho-standalone-pager.component.ts
@@ -33,8 +33,6 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
     this.options.showFirstButton = showFirstButton;
     if (this.pager) {
       this.pager.showButton('first', showFirstButton);
-    } else {
-      this.updateRequired = !!this.pager;
     }
   }
 
@@ -42,8 +40,6 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
     this.options.showLastButton = showLastButton;
     if (this.pager) {
       this.pager.showButton('last', showLastButton);
-    } else {
-      this.updateRequired = !!this.pager;
     }
   }
 
@@ -51,8 +47,6 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
     this.options.showNextButton = showNextButton;
     if (this.pager) {
       this.pager.showButton('next', showNextButton);
-    } else {
-      this.updateRequired = !!this.pager;
     }
   }
 
@@ -60,8 +54,6 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
     this.options.showPreviousButton = showPreviousButton;
     if (this.pager) {
       this.pager.showButton('previous', showPreviousButton);
-    } else {
-      this.updateRequired = !!this.pager;
     }
   }
 
@@ -69,8 +61,6 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
     this.options.showPageSizeSelector = showPageSizeSelector;
     if (this.pager) {
       this.pager.showPageSizeSelector(showPageSizeSelector);
-    } else {
-      this.updateRequired = !!this.pager;
     }
   }
 
@@ -78,8 +68,6 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
     this.options.enableFirstButton = enableFirstButton;
     if (this.pager) {
       this.pager.enableButton('first', enableFirstButton);
-    } else {
-      this.updateRequired = !!this.pager;
     }
   }
 
@@ -87,8 +75,6 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
     this.options.enableLastButton = enableLastButton;
     if (this.pager) {
       this.pager.enableButton('last', enableLastButton);
-    } else {
-      this.updateRequired = !!this.pager;
     }
   }
 
@@ -96,8 +82,6 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
     this.options.enablePreviousButton = enablePreviousButton;
     if (this.pager) {
       this.pager.enableButton('previous', enablePreviousButton);
-    } else {
-      this.updateRequired = !!this.pager;
     }
   }
 
@@ -105,8 +89,6 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
     this.options.enableNextButton = enableNextButton;
     if (this.pager) {
       this.pager.enableButton('next', enableNextButton);
-    } else {
-      this.updateRequired = !!this.pager;
     }
   }
 

--- a/projects/ids-enterprise-ng/src/lib/pager/soho-standalone-pager.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/pager/soho-standalone-pager.component.ts
@@ -31,47 +31,83 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
 
   @Input() set showFirstButton(showFirstButton: boolean) {
     this.options.showFirstButton = showFirstButton;
-    this.updateRequired = !!this.pager;
+    if (this.pager) {
+      this.pager.showButton('first', showFirstButton);
+    } else {
+      this.updateRequired = !!this.pager;
+    }
   }
 
   @Input() set showLastButton(showLastButton: boolean) {
     this.options.showLastButton = showLastButton;
-    this.updateRequired = !!this.pager;
+    if (this.pager) {
+      this.pager.showButton('last', showLastButton);
+    } else {
+      this.updateRequired = !!this.pager;
+    }
   }
 
   @Input() set showNextButton(showNextButton: boolean) {
     this.options.showNextButton = showNextButton;
-    this.updateRequired = !!this.pager;
+    if (this.pager) {
+      this.pager.showButton('next', showNextButton);
+    } else {
+      this.updateRequired = !!this.pager;
+    }
   }
 
   @Input() set showPreviousButton(showPreviousButton: boolean) {
     this.options.showPreviousButton = showPreviousButton;
-    this.updateRequired = !!this.pager;
+    if (this.pager) {
+      this.pager.showButton('previous', showPreviousButton);
+    } else {
+      this.updateRequired = !!this.pager;
+    }
   }
 
   @Input() set showPageSizeSelector(showPageSizeSelector: boolean) {
     this.options.showPageSizeSelector = showPageSizeSelector;
-    this.updateRequired = !!this.pager;
+    if (this.pager) {
+      this.pager.showPageSizeSelector(showPageSizeSelector);
+    } else {
+      this.updateRequired = !!this.pager;
+    }
   }
 
   @Input() set enableFirstButton(enableFirstButton: boolean) {
     this.options.enableFirstButton = enableFirstButton;
-    this.updateRequired = !!this.pager;
+    if (this.pager) {
+      this.pager.enableButton('first', enableFirstButton);
+    } else {
+      this.updateRequired = !!this.pager;
+    }
   }
 
   @Input() set enableLastButton(enableLastButton: boolean) {
     this.options.enableLastButton = enableLastButton;
-    this.updateRequired = !!this.pager;
+    if (this.pager) {
+      this.pager.enableButton('last', enableLastButton);
+    } else {
+      this.updateRequired = !!this.pager;
+    }
   }
 
   @Input() set enablePreviousButton(enablePreviousButton: boolean) {
     this.options.enablePreviousButton = enablePreviousButton;
-    this.updateRequired = !!this.pager;
+    if (this.pager) {
+      this.pager.enableButton('previous', enablePreviousButton);
+    } else {
+      this.updateRequired = !!this.pager;
+    }
   }
 
   @Input() set enableNextButton(enableNextButton: boolean) {
     this.options.enableNextButton = enableNextButton;
-    this.updateRequired = !!this.pager;
+    if (this.pager) {
+      this.pager.enableButton('next', enableNextButton);
+    } else {
+      this.updateRequired = !!this.pager;
+    }
   }
 
   @Input() set previousPageTooltip(previousPageTooltip: string) {


### PR DESCRIPTION
The standalone-pager was causing the EP pager component to rebuild on each enable/show of a pager button. 

**Related github/jira issue (required)**:
Closes #843 

**Steps necessary to review your pull request (required)**:
- open stand alone pager example http://localhost:4200/ids-enterprise-ng-demo/pager-standalone
- set a breakpoint in sohoxi.js pager renderButton
- click each show/hide pager button on example page
- renderButton should not be called anymore on these operations.
