### PR TITLE
app menu test performance

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -226,6 +226,7 @@ import { WizardDemoTargetFolderPageComponent } from './wizard/wizard-target-fold
 import { WizardDemoValidationRulesPageComponent } from './wizard/wizard-validation-rules-page.demo';
 import { LocaleInitializerModule } from './locale-initializer/locale-initializer.module';
 import { ApplicationMenuRoleSwitcherDemoComponent } from './application-menu/application-menu-roleswitcher.demo';
+import { ApplicationMenuTestPerfDemoComponent } from './application-menu/application-menu-test-performance.demo';
 import { DataGridTreeGridCubeDemoComponent } from './datagrid/datagrid-treegrid-cube.demo';
 import { WeekViewDemoComponent } from './week-view/week-view.demo';
 import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
@@ -239,6 +240,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     ApplicationMenuLazyDemoComponent,
     ApplicationMenuLazyMenuDemoComponent,
     ApplicationMenuRoleSwitcherDemoComponent,
+    ApplicationMenuTestPerfDemoComponent,
     AreaDemoComponent,
     AutocompleteDemoComponent,
     BarDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -176,6 +176,7 @@ import { ValidationFormGroupDemoComponent } from './validation/validation-form-g
 import { ExpandableAreaFooterDemoComponent } from './expandablearea/expandablearea-footer.demo';
 import { WizardDemoComponent } from './wizard/wizard.demo';
 import { ApplicationMenuRoleSwitcherDemoComponent } from './application-menu/application-menu-roleswitcher.demo';
+import { ApplicationMenuTestPerfDemoComponent } from './application-menu/application-menu-test-performance.demo';
 import { DataGridTreeGridCubeDemoComponent } from './datagrid/datagrid-treegrid-cube.demo';
 import { WeekViewDemoComponent } from './week-view/week-view.demo';
 import { DataGridExpandableRowNestedDemoComponent } from './datagrid/datagrid-expandable-row-nested.demo';
@@ -188,6 +189,7 @@ export const routes: Routes = [
   { path: 'alert', component: AlertDemoComponent },
   { path: 'application-lazy-menu', component: ApplicationMenuLazyDemoComponent },
   { path: 'application-menu-roleswitcher', component: ApplicationMenuRoleSwitcherDemoComponent },
+  { path: 'application-menu-test-performance', component: ApplicationMenuTestPerfDemoComponent },
   { path: 'area', component: AreaDemoComponent },
   { path: 'autocomplete', component: AutocompleteDemoComponent },
   { path: 'bar', component: BarDemoComponent },

--- a/src/app/application-menu/application-menu-test-performance.demo.html
+++ b/src/app/application-menu/application-menu-test-performance.demo.html
@@ -1,0 +1,52 @@
+
+<div class="twelve columns">
+  <!-- BEGIN Toolbar with All Buttons (Title Favoring) -->
+  <soho-toolbar-flex>
+    <soho-toolbar-flex-section [isTitle]="true" [isTitleFavor]="true">
+      <h2>Incredibly Long Toolbar (Favor's Title)</h2>
+    </soho-toolbar-flex-section>
+
+    <soho-toolbar-flex-section [isButtonSet]="true">
+      <button soho-button="btn">
+        <span>Text Button</span>
+      </button>
+
+      <button soho-menu-button>
+        <span>Menu Button</span>
+      </button>
+      <ul class="popupmenu">
+        <li><a href="#">Item One</a></li>
+        <li><a href="#">Item Two</a></li>
+        <li class="submenu">
+          <a href="#">Item Three</a>
+          <ul class="popupmenu">
+            <li><a href="#">Sub-Item One</a></li>
+            <li><a href="#">Sub-Item Two</a></li>
+          </ul>
+        </li>
+        <li><a href="#">Item Four</a></li>
+      </ul>
+
+      <button soho-button="icon" icon="settings"> Settings </button>
+
+      <button soho-button="icon" icon="delete"> Trash </button>
+    </soho-toolbar-flex-section>
+
+    <soho-toolbar-flex-section [isSearch]="true">
+      <input soho-toolbar-flex-searchfield placeholder="Search..." [clearable]="true" [collapsible]="true"/>
+    </soho-toolbar-flex-section>
+
+    <soho-toolbar-flex-more-button>
+      <ul class="popupmenu">
+        <li><a href="#">Pre-defined Item #1</a></li>
+        <li><a href="#">Pre-defined Item #2</a></li>
+        <li><a href="#">Pre-defined Item #3</a></li>
+      </ul>
+    </soho-toolbar-flex-more-button>
+  </soho-toolbar-flex>
+
+  <div class="field">
+    <input soho-checkbox type="checkbox" id="id1" name="checkbox1" [(ngModel)]="checkBox1Value" (change)="checkChanged()">
+    <label soho-label for="id1" [forCheckBox]="true">Checkbox test updating the toolbar</label>
+  </div>
+</div>

--- a/src/app/application-menu/application-menu-test-performance.demo.ts
+++ b/src/app/application-menu/application-menu-test-performance.demo.ts
@@ -1,0 +1,34 @@
+import {
+  AfterViewChecked,
+  Component,
+  ViewChild,
+  ChangeDetectionStrategy
+} from '@angular/core';
+
+import { SohoToolbarFlexComponent } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'application-menu-test-performance-demo',
+  templateUrl: 'application-menu-test-performance.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ApplicationMenuTestPerfDemoComponent implements AfterViewChecked {
+
+  @ViewChild(SohoToolbarFlexComponent) sohoFlexToolbar: SohoToolbarFlexComponent;
+
+  public checkBox1Value = false;
+  public updateToolbar = false;
+
+  constructor() {}
+
+  ngAfterViewChecked() {
+    if (this.updateToolbar) {
+      this.sohoFlexToolbar.updated();
+      this.updateToolbar = false;
+    }
+  }
+
+  public checkChanged() {
+    this.updateToolbar = this.checkBox1Value;
+  }
+}

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -9,6 +9,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['alert']"><span>Alert</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['application-lazy-menu']"><span>Application Lazy Menu</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['application-menu-roleswitcher']"><span>Application Menu Role Switcher</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['application-menu-test-performance']"><span>Application Menu Test Performance</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['area']"><span>Area Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['autocomplete']"><span>Autocomplete</span></a></div>
   </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adding a  new test for app menu affecting performance of other components in the page.

**Steps necessary to review your pull request (required)**:
1. checkout branch
2. go to http://localhost:4200/ids-enterprise-ng-demo/application-menu-test-performance
3. start recording from devtools' performance tab
4. tick the checkbox (notice some delay in animation when it's not performant)
5. stop recording

### There are 3 difference scenarios that can be observed here:
1. The application menu is **OPEN** and **WITHOUT** the `display:none` fix in [#4052](https://github.com/infor-design/enterprise/pull/4052) originally from [#4040](https://github.com/infor-design/enterprise/pull/4040) - You'll noticed that ticking the checkbox shows a bit of delay in animation. Performance below shows two recalcs from the toolbar call stack takes around 100ms (this also increases exponentially as menu gets bigger, e.g. 2x more menu yields 300+ms)
![image](https://user-images.githubusercontent.com/11013464/85126863-e366ef80-b260-11ea-9f87-fb9a41630c9a.png)

2. The application menu is **CLOSE** and **WITHOUT** the `display:none` fix in [#4052](https://github.com/infor-design/enterprise/pull/4052) originally from [#4040](https://github.com/infor-design/enterprise/pull/4040) - You'll noticed that ticking the checkbox shows no delay in animation. Performance below shows the recalcs from the toolbar call stack just takes just 9ms (more than 10x or more faster because this stays constant even with bigger menu)
![image](https://user-images.githubusercontent.com/11013464/85127090-5bcdb080-b261-11ea-8c84-470c13e03c6d.png)

3. The application menu is **OPEN** and **WITH** the `display:none` fix in [#4052](https://github.com/infor-design/enterprise/pull/4052) originally from [#4040](https://github.com/infor-design/enterprise/pull/4040) - You'll noticed that ticking the checkbox shows unnoticeable delay in animation. Performance below shows the recalcs from the toolbar call stack just takes around 25ms (4-10x faster depending on the size of the menu)
![image](https://user-images.githubusercontent.com/11013464/85127255-afd89500-b261-11ea-87f4-b21f8927dd55.png)

