### PR TITLE
3847 - Add separate icon to toggle and children count with soho tree

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v7.3.0
 
+### 7.3.0 Features
+
+- `[Tree]` Added the ability to have separate icon button for expand/collapse and children count. ([#3847](https://github.com/infor-design/enterprise/issues/3847))
+
 ### 7.3.0 Fixes
 
 - `[Datagrid]` Fixed updatePagingInfo function which was wired on pager now and not working. To fix it i kept it flat on the datagrid object  `TJM` ([Issue #781](https://github.com/infor-design/enterprise-ng/issues/781))

--- a/projects/ids-enterprise-ng/src/lib/tree/soho-tree.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/tree/soho-tree.d.ts
@@ -11,6 +11,13 @@
 type SohoTreeSelectable = 'single' | 'multiple';
 
 /**
+ * The available options for expand target.
+ * `node` can toggle by clicking on icon or node text.
+ * `icon` allows to toggle when clicking only the icon portion of the tree node.
+ */
+type SohoExpandTarget = 'node' | 'icon';
+
+/**
  * Tree options.
  */
 interface SohoTreeOptions {
@@ -46,6 +53,27 @@ interface SohoTreeOptions {
 
   /** Function used to provide the source of the tree data. */
   source?: SohoTreeSourceFunction;
+
+  /** If set to `icon` will allows to toggle when clicking only the icon portion of node. */
+  expandTarget?: SohoExpandTarget;
+
+  /** If `true`, allows separate icon button for expand/collapse. */
+  useExpandTarget?: boolean;
+
+  /** The icon used for expand target button when a tree folder node is open. */
+  expandIconOpen?: string;
+
+  /** The icon used for expand target button when a tree folder node is closed. */
+  expandIconClosed?: string;
+
+  /** If `true`, will rotate expand target plus-minus icon. */
+  expandPlusminusRotate?: boolean;
+
+  /** If `true`, allows show children count beside the node name text. */
+  showChildrenCount?: boolean;
+
+  /** If `true`, allows to auto count the children. */
+  childrenAutoCount?: boolean;
 }
 
 type SohoTreeSourceFunction = (
@@ -98,7 +126,10 @@ interface SohoTreeNode {
   hideCheckbox?: boolean;
 
   // specify type of control to render for node
-  type?: string;  //supported type- dropdown, anchor
+  type?: string;  // supported type- dropdown, anchor
+
+  // parent node or parent node Id
+  parent?: any;
 }
 
 /**

--- a/projects/ids-enterprise-ng/src/lib/tree/soho-tree.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/tree/soho-tree.d.ts
@@ -37,7 +37,7 @@ interface SohoTreeOptions {
   folderIconClosed?: string;
 
   /** If `true`, allows nodes to become sortable (reorderable) */
-  sortable?: string;
+  sortable?: boolean | string;
 
   /** If defined as a function, fires that function as a callback before the selection on a node occurs. */
   onBeforeSelect?: Function;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -211,6 +211,7 @@ import { TooltipDemoComponent } from './tooltip/tooltip.demo';
 import { TrackDirtyDemoComponent } from './trackdirty/trackdirty.demo';
 import { TreeContentDemoComponent } from './tree/tree-content.demo';
 import { TreeDynamicDemoComponent } from './tree/tree-dynamic.demo';
+import { TreeExpandTargetDemoComponent } from './tree/tree-expand-target.demo';
 import { TreemapDemoComponent } from './treemap/treemap.demo';
 import { TreeServiceDemoComponent } from './tree/tree-service.demo';
 import { TreeSourceDemoComponent } from './tree/tree-source.demo';
@@ -420,6 +421,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     TrackDirtyDemoComponent,
     TreeContentDemoComponent,
     TreeDynamicDemoComponent,
+    TreeExpandTargetDemoComponent,
     TreemapDemoComponent,
     TreeServiceDemoComponent,
     TreeSourceDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -167,6 +167,7 @@ import { TooltipDemoComponent } from './tooltip/tooltip.demo';
 import { TrackDirtyDemoComponent } from './trackdirty/trackdirty.demo';
 import { TreeContentDemoComponent } from './tree/tree-content.demo';
 import { TreeDynamicDemoComponent } from './tree/tree-dynamic.demo';
+import { TreeExpandTargetDemoComponent } from './tree/tree-expand-target.demo';
 import { TreemapDemoComponent } from './treemap/treemap.demo';
 import { TreeServiceDemoComponent } from './tree/tree-service.demo';
 import { TreeSourceDemoComponent } from './tree/tree-source.demo';
@@ -355,6 +356,7 @@ export const routes: Routes = [
   { path: 'trackdirty', component: TrackDirtyDemoComponent },
   { path: 'tree-content', component: TreeContentDemoComponent },
   { path: 'tree-dynamic', component: TreeDynamicDemoComponent },
+  { path: 'tree-expand-target', component: TreeExpandTargetDemoComponent },
   { path: 'treemap', component: TreemapDemoComponent },
   { path: 'tree-service', component: TreeServiceDemoComponent },
   { path: 'tree-source', component: TreeSourceDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -245,6 +245,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['trackdirty']"><span>Track Dirty</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tree-content']"><span>Tree - Content</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tree-dynamic']"><span>Tree - Dynamic</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['tree-expand-target']"><span>Tree - Expand Target</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tree-service']"><span>Tree - Service</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tree-source']"><span>Tree - Source</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['treemap']"><span>Tree Map</span></a></div>

--- a/src/app/tree/tree-expand-target.demo.html
+++ b/src/app/tree/tree-expand-target.demo.html
@@ -1,0 +1,24 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">SoHo Tree - Expand Target</h2>
+    <p>
+      1) Toggle node when clicking only the icon portion.<br>
+      2) Select node when clicking the text portion.<br>
+      3) Select any tree node and click button below to see in action.<br>
+      4) Use Drag/Drop nodes and see children count calculated.
+    </p>
+    <div class="field">
+      <button soho-button (click)="addNode()">Add Node</button>
+      <button soho-button (click)="removeNode()">Remove Node</button>
+      <button soho-button (click)="updateNode()">Update Node</button>
+    </div>
+  </div>
+</div>
+<br>
+<div class="row">
+  <div class="twelve columns demo" role="main">
+    <section soho-busyindicator style="height: 100%">
+      <ul soho-tree (selected)="onSelected($event)"></ul>
+    </section>
+  </div>
+</div>

--- a/src/app/tree/tree-expand-target.demo.ts
+++ b/src/app/tree/tree-expand-target.demo.ts
@@ -271,7 +271,7 @@ export class TreeExpandTargetDemoComponent implements OnInit {
 
   private treeOptions: SohoTreeOptions = {
     dataset: this.DATA,
-    sortable: 'true',
+    sortable: true,
     useExpandTarget: true,
     showChildrenCount: true
   };

--- a/src/app/tree/tree-expand-target.demo.ts
+++ b/src/app/tree/tree-expand-target.demo.ts
@@ -1,0 +1,314 @@
+import {
+  Component,
+  ElementRef,
+  ViewChild,
+  NgZone,
+  ChangeDetectionStrategy,
+  OnInit
+} from '@angular/core';
+
+import { SohoTreeComponent } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-tree-expand-target-demo',
+  templateUrl: 'tree-expand-target.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TreeExpandTargetDemoComponent implements OnInit {
+  @ViewChild(SohoTreeComponent, { static: true }) tree: SohoTreeComponent;
+
+  private DATA: SohoTreeNode[] = [{
+    id: 'node1',
+    text: 'Documents',
+    icon: 'icon-tree-doc'
+  }, {
+    id: 'node2',
+    text: 'Products',
+    open: true,
+    icon: 'icon-cloud',
+    children: [{
+      id: 'node2a',
+      text: 'Accessories',
+      open: false,
+      icon: 'icon-cloud',
+      children: [{
+        id: 'node2a1',
+        text: 'Accessorie1'
+      }, {
+        id: 'node2a2',
+        text: 'Accessorie2'
+      }, {
+        id: 'node2a3',
+        text: 'Accessorie3'
+      }, {
+        id: 'node2a4',
+        text: 'Accessorie4'
+      }, {
+        id: 'node2a5',
+        text: 'Accessorie5'
+      }]
+    }, {
+      id: 'node2b',
+      text: 'Bike',
+      open: true,
+      icon: 'icon-cloud',
+      children: [{
+        id: 'node2b1',
+        text: 'BMX',
+        open: false,
+        icon: 'icon-cloud',
+        children: [{
+          id: 'node2b1a',
+          text: 'BMX-1'
+        }, {
+          id: 'node2b1b',
+          text: 'BMX-2'
+        }]
+      }, {
+        id: 'node2b2',
+        text: 'Foldable',
+        open: false,
+        icon: 'icon-cloud',
+        children: [{
+          id: 'node2b2a',
+          text: 'Foldable-1'
+        }]
+      }, {
+        id: 'node2b3',
+        text: 'Mountain',
+        open: false,
+        icon: 'icon-cloud',
+        children: [{
+          id: 'node2b3a',
+          text: 'Mountain-1'
+        }, {
+          id: 'node2b3b',
+          text: 'Mountain-2'
+        }, {
+          id: 'node2b3c',
+          text: 'Mountain-3'
+        }, {
+          id: 'node2b3d',
+          text: 'Mountain-4'
+        }, {
+          id: 'node2b3e',
+          text: 'Mountain-5'
+        }, {
+          id: 'node2b3f',
+          text: 'Mountain-6'
+        }]
+      }, {
+        id: 'node2b4',
+        text: 'Road',
+        open: false,
+        children: []
+      }]
+    }, {
+      id: 'node2c',
+      text: 'Parts',
+      open: false,
+      icon: 'icon-cloud',
+      children: [{
+        id: 'node2c1',
+        text: 'Parts-1'
+      }, {
+        id: 'node2c2',
+        text: 'Parts-2'
+      }, {
+        id: 'node2c3',
+        text: 'Parts-3'
+      }, {
+        id: 'node2c4',
+        text: 'Parts-4'
+      }, {
+        id: 'node2c5',
+        text: 'Parts-5'
+      }, {
+        id: 'node2c6',
+        text: 'Parts-6'
+      }, {
+        id: 'node2c7',
+        text: 'Parts-7'
+      }, {
+        id: 'node2c8',
+        text: 'Parts-8'
+      }, {
+        id: 'node2c9',
+        text: 'Parts-9'
+      }, {
+        id: 'node2c10',
+        text: 'Parts-10'
+      }, {
+        id: 'node2c11',
+        text: 'Parts-11'
+      }, {
+        id: 'node2c12',
+        text: 'Parts-12'
+      }, {
+        id: 'node2c13',
+        text: 'Parts-13'
+      }, {
+        id: 'node2c14',
+        text: 'Parts-14'
+      }, {
+        id: 'node2c15',
+        text: 'Parts-15'
+      }, {
+        id: 'node2c16',
+        text: 'Parts-16'
+      }, {
+        id: 'node2c17',
+        text: 'Parts-17'
+      }, {
+        id: 'node2c18',
+        text: 'Parts-18'
+      }, {
+        id: 'node2c19',
+        text: 'Parts-19'
+      }, {
+        id: 'node2c20',
+        text: 'Parts-20'
+      }, {
+        id: 'node2c21',
+        text: 'Parts-21'
+      }, {
+        id: 'node2c22',
+        text: 'Parts-22'
+      }, {
+        id: 'node2c23',
+        text: 'Parts-23'
+      }, {
+        id: 'node2c24',
+        text: 'Parts-24'
+      }, {
+        id: 'node2c25',
+        text: 'Parts-25'
+      }, {
+        id: 'node2c26',
+        text: 'Parts-26'
+      }, {
+        id: 'node2c27',
+        text: 'Parts-27'
+      }, {
+        id: 'node2c28',
+        text: 'Parts-28'
+      }, {
+        id: 'node2c29',
+        text: 'Parts-29'
+      }, {
+        id: 'node2c30',
+        text: 'Parts-30'
+      }, {
+        id: 'node2c31',
+        text: 'Parts-31'
+      }, {
+        id: 'node2c32',
+        text: 'Parts-32'
+      }, {
+        id: 'node2c33',
+        text: 'Parts-33'
+      }, {
+        id: 'node2c34',
+        text: 'Parts-34'
+      }, {
+        id: 'node2c35',
+        text: 'Parts-35'
+      }, {
+        id: 'node2c36',
+        text: 'Parts-36'
+      }, {
+        id: 'node2c37',
+        text: 'Parts-37'
+      }, {
+        id: 'node2c38',
+        text: 'Parts-38'
+      }, {
+        id: 'node2c39',
+        text: 'Parts-39'
+      }]
+    }]
+  }, {
+    id: 'node3',
+    text: 'Location',
+    open: false,
+    icon: 'icon-map-pin',
+    children: [{
+      id: 'node3a',
+      text: 'Location-1'
+    }, {
+      id: 'node3b',
+      text: 'Location-2'
+    }, {
+      id: 'node3c',
+      text: 'Location-3'
+    }, {
+      id: 'node3d',
+      text: 'Location-4'
+    }, {
+      id: 'node3e',
+      text: 'Location-5'
+    }, {
+      id: 'node3f',
+      text: 'Location-6'
+    }, {
+      id: 'node3g',
+      text: 'Location-7'
+    }, {
+      id: 'node3h',
+      text: 'Location-8'
+    }, {
+      id: 'node3i',
+      text: 'Location-9'
+    }, {
+      id: 'node3j',
+      text: 'Location-10'
+    }]
+  }, {
+    id: 'node4',
+    text: 'Media',
+    icon: 'icon-tree-image'
+  }];
+
+  private treeOptions: SohoTreeOptions = {
+    dataset: this.DATA,
+    sortable: 'true',
+    useExpandTarget: true,
+    showChildrenCount: true
+  };
+  private selected: SohoTreeNode;
+  private id = 0;
+
+  constructor(private element: ElementRef, private ngZone: NgZone) {
+  }
+
+  ngOnInit() {
+    this.tree.options = this.treeOptions;
+  }
+
+  addNode() {
+    this.id++;
+    this.tree.addNode({
+      id: `new-item-${this.id}`,
+      text: `New Item ${this.id}`,
+      parent: this.selected ? this.selected.node : null
+    });
+  }
+
+  removeNode() {
+    if (this.selected) {
+      this.tree.removeNode(this.selected.node);
+      this.selected = null;
+    }
+  }
+
+  updateNode() {
+    if (this.selected) {
+      this.tree.updateNode({ node: this.selected.node, text: 'Node Updated Text' });
+    }
+  }
+
+  onSelected(selectedEvt: SohoTreeEvent) {
+    this.selected = selectedEvt.data;
+    // console.log('Selected Data: ', this.selected);
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added separate icon to toggle and children count with Soho Tree.

**Related github/jira issue (required)**:
Closes infor-design/enterprise#3847

**Steps necessary to review your pull request (required)**:
- After ([PR 4051](https://github.com/infor-design/enterprise/pull/4051)) merged
- Pull and build this branch
- Go to http://localhost:4200/ids-enterprise-ng-demo/tree-expand-target
- Should see plus-minus icon to parent nodes 
- Should only do expand/collapse by icon (not by clicking on node text)
- Should show children count beside the node name text
- Should see updated children count soon rearrange the children nodes by drag/drop

Button `Add Node`
- Select any leaf node (node without any children) click on `Add Node`
- It should convert selected node to parent (folder type) and add new node as child under selected node
- Select any parent (folder type) node and click on `Add Node` 
- It should add new node as child under selected node
- Now if you do not select any node and click on `Add Node`
- It should add new node under root node

Button `Remove Node`
- Select any tree node and click on button `Remove Node`
- It should remove selected node from tree

Button `Update Node`
- Select any tree node and click on button `Update Node`
- It should change node text to `Node Updated Text` for selected node

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
