### PR TITLE
841 - Remove deprecated pager setting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v7.3.0
 
+## v7.3.0 Notes
+
+- `[Datagrid]` The deprecated pager property has been removed. Please use pagerAPI instead. ([#841](https://github.com/infor-design/enterprise/issues/841))
+
 ### 7.3.0 Fixes
 
 - `[Datagrid]` Fixed updatePagingInfo function which was wired on pager now and not working. To fix it i kept it flat on the datagrid object  `TJM` ([Issue #781](https://github.com/infor-design/enterprise-ng/issues/781))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v7.3.0 Notes
 
 - `[Datagrid]` The deprecated pager property has been removed. Please use pagerAPI instead. ([#841](https://github.com/infor-design/enterprise/issues/841))
+
 ### 7.3.0 Features
 
 - `[Tree]` Added the ability to have separate icon button for expand/collapse and children count. ([#3847](https://github.com/infor-design/enterprise/issues/3847))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "classlist.js": "^1.1.20150312",
     "d3": "5.16.0",
     "fix": "0.0.6",
-    "ids-enterprise": "4.30.0-dev.20200611",
+    "ids-enterprise": "4.30.0-dev.20200622",
     "jquery": "^3.5.1",
     "lscache": "^1.3.0",
     "rxjs": "~6.5.5",

--- a/projects/ids-enterprise-ng/package.json
+++ b/projects/ids-enterprise-ng/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@types/jquery": "3.3.29",
     "@types/d3": "4.13.0",
-    "ids-enterprise": "4.30.0-dev.20200611",
+    "ids-enterprise": "4.30.0-dev.20200622",
     "jquery": "3.5.1",
     "d3": "5.16.0"
   },

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1931,7 +1931,6 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
 
   /**
    * Build component for rowTemplate
-   * @private
    */
   private buildRowTemplateComponent(event: any) {
 
@@ -2467,7 +2466,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
       };
 
       // Add the destroy cell callback.
-      this._gridOptions.onDestroyCell = (c, args: SohoDataGridPostRenderCellArgs) => {
+      this._gridOptions.onDestroyCell = (_, args: SohoDataGridPostRenderCellArgs) => {
         this.onDestroyCell(args);
       };
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1354,7 +1354,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   pageSize(): number {
-    return this.datagrid.pager.settings.pagesize;
+    return this.datagrid.pagerAPI.settings.pagesize;
   }
 
   updatePagingInfo(pageInfo: SohoPagerPagingInfo): void {

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -943,12 +943,6 @@ interface SohoDataGridStatic {
   /** Overridable sort function. */
   sortFunction: SohoDataGridSortFunction;
 
-  /**
-   * Reference to pager.
-   *  @deprecated use pagerAPI
-   */
-  pager: SohoPagerStatic;
-
   /** Reference to pager. */
   pagerAPI: SohoPagerStatic;
 

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
@@ -482,8 +482,8 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
         const datagrid: SohoDataGridStatic = args[1],
           modal: SohoModalStatic = args[2];
 
-        if (datagrid.pager) {
-          datagrid.pager.element.on('afterpaging', () => {
+        if (datagrid.pagerAPI) {
+          datagrid.pagerAPI.element.on('afterpaging', () => {
             modal.resize();
           });
         }

--- a/src/app/application-menu/application-menu-roleswitcher.demo.html
+++ b/src/app/application-menu/application-menu-roleswitcher.demo.html
@@ -125,8 +125,8 @@
 
   <div class="application-menu-content">
     <div class="searchfield-wrapper">
-      <label class="audible" for="application-menu-searchfield">Search</label>
-      <input id="application-menu-searchfield" class="searchfield" data-options='{ "clearable": true }' placeholder="Search this menu"/>
+      <label class="audible" for="application-menu-searchfield-roles">Search</label>
+      <input id="application-menu-searchfield-roles" class="searchfield" data-options='{ "clearable": true }' placeholder="Search this menu"/>
     </div>
 
     <div class="accordion panel inverse" data-options="{'allowOnePane': false}" >

--- a/src/app/application-menu/application-menu-roleswitcher.demo.ts
+++ b/src/app/application-menu/application-menu-roleswitcher.demo.ts
@@ -43,7 +43,6 @@ export class ApplicationMenuRoleSwitcherDemoComponent implements AfterViewInit, 
 
   public selectRole($event?: any) {
     const button: any = $event.currentTarget;
-    const url = button.getAttribute('navigationmenuurl');
     this.myRole = button.getAttribute('title');
 
     setTimeout(() => {

--- a/src/app/application-menu/application-menu-test-performance.demo.ts
+++ b/src/app/application-menu/application-menu-test-performance.demo.ts
@@ -8,7 +8,7 @@ import {
 import { SohoToolbarFlexComponent } from 'ids-enterprise-ng';
 
 @Component({
-  selector: 'application-menu-test-performance-demo',
+  selector: 'app-menu-test-performance-demo',
   templateUrl: 'application-menu-test-performance.demo.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Many moons ago pager was changed to pagerAPI. I recently deprecated it but that caused errors in tests and compiling agains the lookup module. Instead removed it entirely and noted in the change log. Just in case. Its probably not used much if at all in that form. If it is code will need adjusting.

**Related github/jira issue (required)**:
Fixes #841 

**Steps necessary to review your pull request (required)**:
- tests pass and build passes