### PR TITLE
datagrid : add missing types for summary row

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Datagrid]` Added target property for hyperlink formatter column. ([#3731](https://github.com/infor-design/enterprise/issues/3731))
 - `[Datagrid]` Build expanded datagrid row with dynamic component. Special case: nested datagrid.  `AF` ([Issue #206](https://github.com/infor-design/enterprise-ng/issues/206))
 - `[DataGrid]` Added optional data object param to setDirtyIndicator to match soho datagrid setDirtyIndicator. `PWP` ([Issue #829](https://github.com/infor-design/enterprise-ng/issues/829))
+- `[Datagrid]` Add missings types to manage summaryRow with an example.  `AF` ([Issue #852](https://github.com/infor-design/enterprise-ng/issues/852))
 - `[Lookup]` Resynced the lookup api settings, methods and events with the core component. Also made sure everything is using ngZone. `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))
 - `[Lookup]` And added an example showing how to use the buttonsetAPI to enable and disable buttons.  `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))
 - `[Lookup]` And added an example showing how to use a dataset as an input to populate the lookup.  `TJM` ([Issue #236](https://github.com/infor-design/enterprise/issues/236))

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -327,6 +327,9 @@ interface SohoDataGridOptions {
 
   /* The inputs for dynamic component  */
   rowTemplateComponentInputs?: any;
+
+  /* add summary row */
+  summaryRow?: boolean;
 }
 
 type SohoDataGridModifiedRows = { [index: number]: SohoDataGridModifiedRow };
@@ -911,6 +914,19 @@ interface SohoDataGridColumn {
 
   /* Array of objects with a value and label to be used as options in the filter row dropdown. */
   filterRowEditorOptions?: SohoGridCellOption[];
+
+  /* formatter summary */
+  summaryRowFormatter?: SohoDataGridColumnFormatterFunction | string;
+
+  /* aggregator */
+  aggregator?: string;
+
+  /* summary Text */
+  summaryText?: string;
+
+  /* summary text placement */
+  summaryTextPlacement?: string;
+
 }
 
 interface SohoDataGridColumnNumberFormat {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -107,6 +107,7 @@ import { DataGridTreeGridLazyDemoComponent } from './datagrid/datagrid-treegrid-
 import { DatagridTreegridDynamicfilteringDemoComponent } from './datagrid/datagrid-treegrid-dynamicfiltering.demo';
 import { ExpandedDemoComponent, DataGridExpandableRowDynamicDemoComponent } from './datagrid/datagrid-expandable-row-dynamic.demo';
 import { NestedDatagridDemoComponent, DataGridExpandableRowNestedDemoComponent } from './datagrid/datagrid-expandable-row-nested.demo';
+import { DataGridSummaryRowDemoComponent } from './datagrid/datagrid-summary-row.demo';
 import { DatepickerDemoComponent } from './datepicker/datepicker.demo';
 import { DonutDemoComponent } from './donut/donut.demo';
 import { DropdownAsyncBusyDemoComponent } from './dropdown/dropdown-async-busy.demo';
@@ -317,6 +318,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     ExpandedDemoComponent,
     DataGridExpandableRowNestedDemoComponent,
     DataGridExpandableRowDynamicDemoComponent,
+    DataGridSummaryRowDemoComponent,
     DatepickerDemoComponent,
     DemoCellInputEditorComponent,
     DemoCellFormatterComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -185,7 +185,6 @@ import { DataGridExpandableRowNestedDemoComponent } from './datagrid/datagrid-ex
 import { DataGridExpandableRowDynamicDemoComponent } from './datagrid/datagrid-expandable-row-dynamic.demo';
 import { DataGridSummaryRowDemoComponent } from './datagrid/datagrid-summary-row.demo';
 
-
 export const routes: Routes = [
   { path: '', redirectTo: '', pathMatch: 'full' }, // default
   { path: 'about', component: AboutDemoComponent },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -183,6 +183,8 @@ import { DataGridTreeGridCubeDemoComponent } from './datagrid/datagrid-treegrid-
 import { WeekViewDemoComponent } from './week-view/week-view.demo';
 import { DataGridExpandableRowNestedDemoComponent } from './datagrid/datagrid-expandable-row-nested.demo';
 import { DataGridExpandableRowDynamicDemoComponent } from './datagrid/datagrid-expandable-row-dynamic.demo';
+import { DataGridSummaryRowDemoComponent } from './datagrid/datagrid-summary-row.demo';
+
 
 export const routes: Routes = [
   { path: '', redirectTo: '', pathMatch: 'full' }, // default
@@ -243,6 +245,7 @@ export const routes: Routes = [
   { path: 'datagrid-expandable-row', component: DataGridExpandableRowDemoComponent },
   { path: 'datagrid-expandable-row-dynamic', component: DataGridExpandableRowDynamicDemoComponent },
   { path: 'datagrid-expandable-row-nested', component: DataGridExpandableRowNestedDemoComponent },
+  { path: 'datagrid-summary-row', component: DataGridSummaryRowDemoComponent },
   { path: 'datagrid-standalone-pager', component: DatagridStandalonePagerDemoComponent },
   { path: 'datagrid-treegrid', component: DataGridTreeGridDemoComponent },
   { path: 'datagrid-treegrid-lazy', component: DataGridTreeGridLazyDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -93,6 +93,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-expandable-row']"><span>DataGrid - Expandable Row</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-expandable-row-dynamic']"><span>DataGrid - Expandable Row (dynamic component)</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-expandable-row-nested']"><span>DataGrid - Expandable Row (Nested)</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['datagrid-summary-row']"><span>DataGrid - Summary Row</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datepicker']"><span>Date Picker</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['donut']"><span>Donut Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['dropdown-async']"><span>Dropdown - Async</span></a></div>

--- a/src/app/datagrid/datagrid-summary-row.demo.html
+++ b/src/app/datagrid/datagrid-summary-row.demo.html
@@ -1,0 +1,15 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Soho Data Grid - Summary Row</h2>
+    <p>
+      This demo illustrates the use of a summary row.
+    </p>
+  </div>
+</div>
+
+<br>
+<div class="row top-padding">
+  <div class="twelve columns demo" role="main">
+    <div soho-datagrid *ngIf="gridOptions" [gridOptions]="gridOptions"></div>
+  </div>
+</div>

--- a/src/app/datagrid/datagrid-summary-row.demo.ts
+++ b/src/app/datagrid/datagrid-summary-row.demo.ts
@@ -63,9 +63,6 @@ export const SUMMARY_COLUMNS: SohoDataGridColumn[] = [
     align: 'right',
     numberFormat: { minimumFractionDigits: 2, maximumFractionDigits: 2 },
     editor: Soho.Editors.Input
-    //,
-    //editorComponent: DemoCellInputEditorComponent,
-    //editorComponentInputs: {}
   },
   {
     id: 'percentage',
@@ -80,17 +77,11 @@ export const SUMMARY_COLUMNS: SohoDataGridColumn[] = [
     summaryTextPlacement: 'after',
     align: 'right',
     editor: Soho.Editors.Input
-    //,
-    //editorComponent: DemoCellInputEditorComponent,
-    //editorComponentInputs: {}
   }
-
-
-  
 ];
 
 @Component({
-  selector: 'soho-datagrid-summary-row',
+  selector: 'app-soho-datagrid-summary-row',
   templateUrl: 'datagrid-summary-row.demo.html'
 })
 export class DataGridSummaryRowDemoComponent implements OnInit {

--- a/src/app/datagrid/datagrid-summary-row.demo.ts
+++ b/src/app/datagrid/datagrid-summary-row.demo.ts
@@ -1,0 +1,111 @@
+import { Component, ViewChild, Inject, OnInit } from '@angular/core';
+
+export const SUMMARY_DATA: any[] = [
+
+  { id: 1, location: 'CA, USA', firstname: 'Jonathon', lastname: 'Hardy', phone: '(312) 555 - 7854', purchases: 56.48, percentage: 24.32 },
+  { id: 2, location: 'Germany', firstname: 'Coyle', lastname: 'Rita', phone: '+ 49(897) 104 - 6155', purchases: 16.00, percentage: 6.89 },
+  { id: 3, location: 'GOR, USA', firstname: 'Mike', lastname: 'Warneke', phone: '(503) 555 - 1358', purchases: 37.15, percentage: 15.99 },
+  { id: 4, location: 'FL, USA', firstname: 'Marc', lastname: 'Bianco', phone: '(924) 555 - 8609', purchases: 45.37, percentage: 19.53 },
+  { id: 5, location: 'French', firstname: 'Philippe', lastname: 'Martin', phone: '+ 33 135 - 8609', purchases: 77.28, percentage: 33.27 }
+];
+
+export const SUMMARY_COLUMNS: SohoDataGridColumn[] = [
+  {
+    id: 'id',
+    name: 'Customer Id',
+    field: 'id',
+    sortable: true,
+    filterType: 'integer',
+    formatter: Soho.Formatters.Readonly
+  },
+
+  {
+    id: 'location',
+    name: 'Location',
+    field: 'location',
+    sortable: true,
+    filterType: 'text',
+    formatter: Soho.Formatters.Hyperlink
+  },
+  {
+    id: 'firstname',
+    name: 'First Name',
+    field: 'firstname',
+    sortable: true,
+    filterType: 'text',
+    formatter: Soho.Formatters.Readonly
+  },
+  {
+    id: 'lastname',
+    name: 'Last Name',
+    field: 'lastname',
+    sortable: true,
+    filterType: 'text',
+    formatter: Soho.Formatters.Readonly
+  },
+  {
+    id: 'phone',
+    name: 'Phone',
+    field: 'phone',
+    sortable: true,
+    filterType: 'text',
+    formatter: Soho.Formatters.Readonly
+  },
+  {
+    id: 'purchases',
+    name: 'Purchases',
+    field: 'purchases',
+    sortable: false,
+    filterType: 'number',
+    formatter: Soho.Formatters.Decimal,
+    summaryRowFormatter: Soho.Formatters.SummaryRow,
+    aggregator: 'sum',
+    align: 'right',
+    numberFormat: { minimumFractionDigits: 2, maximumFractionDigits: 2 },
+    editor: Soho.Editors.Input
+    //,
+    //editorComponent: DemoCellInputEditorComponent,
+    //editorComponentInputs: {}
+  },
+  {
+    id: 'percentage',
+    name: 'Percentage',
+    field: 'percentage',
+    sortable: false,
+    filterType: 'number',
+    formatter: Soho.Formatters.Decimal,
+    summaryRowFormatter: Soho.Formatters.SummaryRow,
+    aggregator: 'sum',
+    summaryText: ' %',
+    summaryTextPlacement: 'after',
+    align: 'right',
+    editor: Soho.Editors.Input
+    //,
+    //editorComponent: DemoCellInputEditorComponent,
+    //editorComponentInputs: {}
+  }
+
+
+  
+];
+
+@Component({
+  selector: 'soho-datagrid-summary-row',
+  templateUrl: 'datagrid-summary-row.demo.html'
+})
+export class DataGridSummaryRowDemoComponent implements OnInit {
+  gridOptions: SohoDataGridOptions = undefined;
+
+  ngOnInit() {
+    this.gridOptions = {
+      columns: SUMMARY_COLUMNS,
+      dataset: SUMMARY_DATA,
+      selectable: 'single',
+      idProperty: 'id',
+      editable: true,
+      isList: false,
+      summaryRow: true,
+      filterable: true
+    };
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
1. Add the following missing types for manage the summaryRow for example to calculate the total of a column:
- the attribute summaryRow in "SohoDataGridOptions"
- the attribute "aggregator" in "SohoDataGridColumn"
- the attribute "summaryRowFormatter" in "SohoDataGridColumn".
- the attribute "summaryText" in "SohoDataGridColumn".
- the attribute "summaryTextPlacement" in "SohoDataGridColumn".

2. Add new example.

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#852

**Steps necessary to review your pull request (required)**:
- Add the types for one setting
- Pull this branch and build/run the demo app
- (new example) navigate to http://localhost:4200/ids-enterprise-ng-demo/datagrid-summary-row

