### PR TITLE
datagrid add summaryRow setting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 7.3.0 Features
 
 - `[Tree]` Added the ability to have separate icon button for expand/collapse and children count. ([#3847](https://github.com/infor-design/enterprise/issues/3847))
+- `[Datagrid]` Add summaryRow settings.  `AF`
 
 ### 7.3.0 Fixes
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -169,6 +169,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
     this._gridOptions = gridOptions;
 
     this.checkForComponentEditors();
+    this.checkForSummaryRowSettings();
 
     if (this.jQueryElement) {
       // No need to set the 'settings' as the Rebuild will create
@@ -1000,6 +1001,20 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
       });
     }
   }
+
+  /**
+   *
+   * Summary row columns settingss
+   */
+  @Input() set summaryRowColumns(summaryRowColumns: SohoDataGridSummaryRowColumnSettings[]) {
+    this._gridOptions.summaryRowColumns = summaryRowColumns;
+    this.checkForSummaryRowSettings();
+
+    if (this._gridOptions.columns && this.jQueryElement) {
+      this.ngZone.runOutsideAngular(() => this.datagrid.updateColumns(this._gridOptions.columns, this._gridOptions.columnGroups));
+    }
+  }
+
 
   /**
    * The name of the column stretched to fill the width of the datagrid,
@@ -2622,6 +2637,26 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
       }
     });
   }
+
+  private checkForSummaryRowSettings() {
+    if (!this._gridOptions.summaryRowColumns || this._gridOptions.summaryRowColumns.length === 0 ) {
+      this._gridOptions.columns.forEach((c) => {
+        c.summaryRowFormatter = undefined;
+        c.summaryText = undefined;
+        c.aggregator = undefined;
+        c.summaryTextPlacement = undefined;
+      });
+    } else {
+      this._gridOptions.summaryRowColumns.forEach((sc) => {
+        const column = this._gridOptions.columns.find((c) => c.field === sc.field);
+        column.summaryRowFormatter = sc.summaryRowFormatter;
+        column.summaryText = sc.summaryText;
+        column.aggregator = sc.aggregator;
+        column.summaryTextPlacement = sc.summaryTextPlacement;
+      });
+    }
+  }
+
 }
 
 /**

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1015,7 +1015,6 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
     }
   }
 
-
   /**
    * The name of the column stretched to fill the width of the datagrid,
    * or 'last' where the last column will be stretched to fill the

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -330,6 +330,10 @@ interface SohoDataGridOptions {
 
   /* add summary row */
   summaryRow?: boolean;
+
+  /* summary row columns settings*/
+  summaryRowColumns?: SohoDataGridSummaryRowColumnSettings[];
+
 }
 
 type SohoDataGridModifiedRows = { [index: number]: SohoDataGridModifiedRow };
@@ -1375,6 +1379,26 @@ interface SohoDataGridGroupable {
   // Formatter for group row
   groupRowFormatter?: SohoDataGridColumnFormatterFunction;
 }
+
+/**
+ * Part of the column options, indicates what specific grid settings to manage summaryRow
+ */
+interface SohoDataGridSummaryRowColumnSettings {
+  /* Field */
+  field: string;
+  /* formatter summary */
+  summaryRowFormatter?: SohoDataGridColumnFormatterFunction | string;
+
+  /* aggregator */
+  aggregator?: SohoDataGridAggregator;
+
+  /* summary Text */
+  summaryText?: string;
+
+  /* summary text placement */
+  summaryTextPlacement?: string;
+}
+
 
 type SohoDataGridAggregator = 'sum' | 'min' | 'max' | 'list' | 'avg' | 'count' | string;
 

--- a/src/app/datagrid/datagrid-summary-row.demo.ts
+++ b/src/app/datagrid/datagrid-summary-row.demo.ts
@@ -10,74 +10,15 @@ export const SUMMARY_DATA: any[] = [
 ];
 
 export const SUMMARY_COLUMNS: SohoDataGridColumn[] = [
-  {
-    id: 'id',
-    name: 'Customer Id',
-    field: 'id',
-    sortable: true,
-    filterType: 'integer',
-    formatter: Soho.Formatters.Readonly
-  },
-
-  {
-    id: 'location',
-    name: 'Location',
-    field: 'location',
-    sortable: true,
-    filterType: 'text',
-    formatter: Soho.Formatters.Hyperlink
-  },
-  {
-    id: 'firstname',
-    name: 'First Name',
-    field: 'firstname',
-    sortable: true,
-    filterType: 'text',
-    formatter: Soho.Formatters.Readonly
-  },
-  {
-    id: 'lastname',
-    name: 'Last Name',
-    field: 'lastname',
-    sortable: true,
-    filterType: 'text',
-    formatter: Soho.Formatters.Readonly
-  },
-  {
-    id: 'phone',
-    name: 'Phone',
-    field: 'phone',
-    sortable: true,
-    filterType: 'text',
-    formatter: Soho.Formatters.Readonly
-  },
-  {
-    id: 'purchases',
-    name: 'Purchases',
-    field: 'purchases',
-    sortable: false,
-    filterType: 'number',
-    formatter: Soho.Formatters.Decimal,
-    summaryRowFormatter: Soho.Formatters.SummaryRow,
-    aggregator: 'sum',
-    align: 'right',
-    numberFormat: { minimumFractionDigits: 2, maximumFractionDigits: 2 },
-    editor: Soho.Editors.Input
-  },
-  {
-    id: 'percentage',
-    name: 'Percentage',
-    field: 'percentage',
-    sortable: false,
-    filterType: 'number',
-    formatter: Soho.Formatters.Decimal,
-    summaryRowFormatter: Soho.Formatters.SummaryRow,
-    aggregator: 'sum',
-    summaryText: ' %',
-    summaryTextPlacement: 'after',
-    align: 'right',
-    editor: Soho.Editors.Input
-  }
+  { id: 'id', name: 'Customer Id', field: 'id', sortable: true, filterType: 'integer', formatter: Soho.Formatters.Readonly },
+  { id: 'location', name: 'Location', field: 'location', sortable: true, filterType: 'text', formatter: Soho.Formatters.Hyperlink },
+  { id: 'firstname', name: 'First Name', field: 'firstname', sortable: true, filterType: 'text', formatter: Soho.Formatters.Readonly },
+  { id: 'lastname', name: 'Last Name', field: 'lastname', sortable: true, filterType: 'text', formatter: Soho.Formatters.Readonly },
+  { id: 'phone', name: 'Phone', field: 'phone', sortable: true, filterType: 'text', formatter: Soho.Formatters.Readonly },
+  { id: 'purchases', name: 'Purchases', field: 'purchases', sortable: false, filterType: 'number', formatter: Soho.Formatters.Decimal,
+    align: 'right', numberFormat: { minimumFractionDigits: 2, maximumFractionDigits: 2 }, editor: Soho.Editors.Input },
+  { id: 'percentage', name: 'Percentage', field: 'percentage', sortable: false, filterType: 'number', formatter: Soho.Formatters.Decimal,
+    align: 'right', editor: Soho.Editors.Input }
 ];
 
 @Component({
@@ -96,6 +37,10 @@ export class DataGridSummaryRowDemoComponent implements OnInit {
       editable: true,
       isList: false,
       summaryRow: true,
+      summaryRowColumns: [
+        { field: 'purchases', summaryRowFormatter: Soho.Formatters.SummaryRow, aggregator: 'sum' },
+        { field: 'percentage', summaryRowFormatter: Soho.Formatters.SummaryRow, aggregator: 'sum', summaryText: ' %', summaryTextPlacement: 'after' }
+      ],
       filterable: true
     };
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Add summary setting with Input()

**Related github/jira issue (required)**:


**Steps necessary to review your pull request (required)**:
- Add the type summaryRowColumns to datagridOptions like :  summaryRowColumns: [
        { field: 'purchases', summaryRowFormatter: Soho.Formatters.SummaryRow, aggregator: 'sum' },
        { field: 'percentage', summaryRowFormatter: Soho.Formatters.SummaryRow, aggregator: 'sum', summaryText: ' %', summaryTextPlacement: 'after' }
      ]

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
