### PR TITLE
700 - Implement NG Component Wrappers for Breadcrumb

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 7.3.0 Features
 
+- `[Breadcrumb]` Added NG wrapper component for the IDS Breadcrumb API. `EPC` ([Issue #700](https://github.com/infor-design/enterprise-ng/issues/700))
 - `[Tree]` Added the ability to have separate icon button for expand/collapse and children count. ([#3847](https://github.com/infor-design/enterprise/issues/3847))
 - `[Datagrid]` Add summaryRow settings.  `AF`
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v7.4.0
 
+### 7.4.0 Features
+
+- `[Breadcrumb]` Angular Wrapper Component for the IDS Breadcrumb API is now available. `EPC` ([Issue #700](https://github.com/infor-design/enterprise-ng/issues/700))
+
 ### 7.4.0 Fixes
 
 ## v7.3.0
@@ -14,7 +18,6 @@
 
 ### 7.3.0 Features
 
-- `[Breadcrumb]` Added NG wrapper component for the IDS Breadcrumb API. `EPC` ([Issue #700](https://github.com/infor-design/enterprise-ng/issues/700))
 - `[Tree]` Added the ability to have separate icon button for expand/collapse and children count. ([#3847](https://github.com/infor-design/enterprise/issues/3847))
 - `[Datagrid]` Add summaryRow settings.  `AF`
 

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export * from './soho-breadcrumb.component';
+export * from './soho-breadcrumb.module';

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.html
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.html
@@ -1,0 +1,3 @@
+<ol aria-label="breadcrumb">
+  <ng-content></ng-content>
+</ol>

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
@@ -3,7 +3,6 @@
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ElementRef,
   Input,
@@ -45,7 +44,6 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
    * @param elementRef - the element matching the component's selector.
    */
   constructor(
-    private changeDetector: ChangeDetectorRef,
     private element: ElementRef,
     private ngZone: NgZone
   ) { }
@@ -78,8 +76,12 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
   ngOnInit() {
   }
 
+  // -------------------------------------------------------------
+  // All the below methods pass through to the IDS Breadcrumb API
+  // -------------------------------------------------------------
+
   /**
-   *
+   * Adds a new breadcrumb item to the list
    */
   add(settings?: SohoBreadcrumbItemOptions, doRender?: boolean) {
     if (!this.breadcrumbAPI) { return; }
@@ -90,7 +92,7 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
   }
 
   /**
-   *
+   * Removes a single breadcrumb item from the list
    */
   remove(item: SohoBreadcrumbRef, doRender?: boolean) {
     if (!this.breadcrumbAPI) { return; }
@@ -101,18 +103,43 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
   }
 
   /**
+   * Removes all breadcrumb items from the list
+   */
+  removeAll(doRender?: boolean) {
+    if (!this.breadcrumbAPI) { return; }
+
+    this.ngZone.runOutsideAngular(() => {
+      this.breadcrumbAPI.removeAll(doRender);
+    });
+  }
+
+  /**
    * Gets references related to a particular Breadcrumb Item.
-   * The return object containins:
+   * The return object contains:
    * - 'a' : a reference to the breadcrumb item's anchor tag
    * - 'api' : a reference to the breadcrumb item's API
    * - 'i' : a number representing the current index of the breadcrumb item.
    */
   getBreadcrumbItem(item: SohoBreadcrumbRef) {
+    if (!this.breadcrumbAPI) { return; }
+
     return this.breadcrumbAPI.getBreadcrumbItemAPI(item);
   }
 
   /**
-   * @param [settings] incoming IDS Breadcrumb settings
+   * Takes a reference to a Breadcrumb item and makes it "Current",
+   * styling it with bold text and popping it out of truncation.
+   */
+  makeCurrent(item: SohoBreadcrumbRef): void {
+    if (!this.breadcrumbAPI) { return; }
+
+    this.ngZone.runOutsideAngular(() => {
+      this.breadcrumbAPI.makeCurrent(item);
+    });
+  }
+
+  /**
+   * Updates the Breadcrumb List with new incoming settings
    */
   updated(settings?: SohoBreadcrumbOptions) {
     if (settings) {

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
@@ -57,6 +57,11 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
     return this.breadcrumbAPI.breadcrumbs;
   }
 
+  /** Provides access to the IDS Breadcrumb's disabled property */
+  public get disabled(): boolean {
+    return this.breadcrumbAPI.disabled;
+  }
+
   /**
    * Constructor
    * @param elementRef - the element matching the component's selector.

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
@@ -39,6 +39,24 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
     return this.options.breadcrumbs;
   }
 
+  /** Allow change to alternate styling via Input **/
+  @Input()
+  public set alternate(val: boolean) {
+    this.options.style = val ? 'alternate' : 'default';
+    this.updated();
+  }
+  public get alternate(): boolean {
+    return this.options.style === 'alternate';
+  }
+
+  /** Provides access to the internal array of currently-invoked IDS Breadcrumb APIs */
+  public get breadcrumbAPIs(): SohoBreadcrumbItemStatic[] {
+    if (!this.breadcrumbAPI) {
+      return [];
+    }
+    return this.breadcrumbAPI.breadcrumbs;
+  }
+
   /**
    * Constructor
    * @param elementRef - the element matching the component's selector.
@@ -79,6 +97,22 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
   // -------------------------------------------------------------
   // All the below methods pass through to the IDS Breadcrumb API
   // -------------------------------------------------------------
+
+  enable(): void {
+    if (!this.breadcrumbAPI) { return; }
+
+    this.ngZone.runOutsideAngular(() => {
+      this.breadcrumbAPI.enable();
+    });
+  }
+
+  disable(): void {
+    if (!this.breadcrumbAPI) { return; }
+
+    this.ngZone.runOutsideAngular(() => {
+      this.breadcrumbAPI.disable();
+    });
+  }
 
   /**
    * Adds a new breadcrumb item to the list

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
@@ -17,12 +17,12 @@ import {
  */
 @Component({
   selector: '[soho-breadcrumb]', // tslint:disable-line
-  templateUrl: '<ng-content></ng-content>',
+  templateUrl: 'soho-breadcrumb.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit {
 
-  private jQueryElement: JQuery;
+  private jQueryElement: JQuery<HTMLElement>;
   private breadcrumbAPI: SohoBreadcrumbStatic;
 
   // Default Options
@@ -54,7 +54,7 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
 
   ngAfterViewInit() {
     this.ngZone.runOutsideAngular(() => {
-      this.jQueryElement = jQuery(this.element);
+      this.jQueryElement = jQuery(this.element.nativeElement);
       this.jQueryElement.breadcrumb(this.options);
       this.breadcrumbAPI = this.jQueryElement.data('breadcrumb');
     });

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
@@ -1,0 +1,137 @@
+/// <reference path="soho-breadcrumb.d.ts" />
+
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
+
+/**
+ * Soho Breadcrumb Component
+ */
+@Component({
+  selector: '[soho-breadcrumb]', // tslint:disable-line
+  templateUrl: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit {
+
+  private jQueryElement: JQuery;
+  private breadcrumbAPI: SohoBreadcrumbStatic;
+
+  // Default Options
+  private options: SohoBreadcrumbOptions;
+
+  /** Allow Breadcrumb Definition by Input */
+  @Input()
+  public set breadcrumbs(items: SohoBreadcrumbItemOptions[]) {
+    this.options.breadcrumbs = items;
+    this.updated();
+  }
+  public get breadcrumbs(): SohoBreadcrumbItemOptions[] {
+    return this.options.breadcrumbs;
+  }
+
+  /**
+   * Constructor
+   * @param elementRef - the element matching the component's selector.
+   */
+  constructor(
+    private changeDetector: ChangeDetectorRef,
+    private element: ElementRef,
+    private ngZone: NgZone
+  ) { }
+
+  // ------------------------------------------
+  // Lifecycle Events
+  // ------------------------------------------
+
+  ngAfterViewInit() {
+    this.ngZone.runOutsideAngular(() => {
+      this.jQueryElement = jQuery(this.element);
+      this.jQueryElement.breadcrumb(this.options);
+      this.breadcrumbAPI = this.jQueryElement.data('breadcrumb');
+    });
+  }
+
+  ngOnDestroy() {
+    this.ngZone.runOutsideAngular(() => {
+      if (this.breadcrumbAPI) {
+        this.breadcrumbAPI.destroy();
+        this.breadcrumbAPI = null;
+      }
+
+      if (this.jQueryElement) {
+        this.jQueryElement.off();
+      }
+    });
+  }
+
+  ngOnInit() {
+  }
+
+  /**
+   *
+   */
+  add(settings?: SohoBreadcrumbItemOptions, doRender?: boolean) {
+    if (!this.breadcrumbAPI) { return; }
+
+    this.ngZone.runOutsideAngular(() => {
+      this.breadcrumbAPI.add(settings, doRender);
+    });
+  }
+
+  /**
+   *
+   */
+  remove(item: SohoBreadcrumbRef, doRender?: boolean) {
+    if (!this.breadcrumbAPI) { return; }
+
+    this.ngZone.runOutsideAngular(() => {
+      this.breadcrumbAPI.remove(item, doRender);
+    });
+  }
+
+  /**
+   * Gets references related to a particular Breadcrumb Item.
+   * The return object containins:
+   * - 'a' : a reference to the breadcrumb item's anchor tag
+   * - 'api' : a reference to the breadcrumb item's API
+   * - 'i' : a number representing the current index of the breadcrumb item.
+   */
+  getBreadcrumbItem(item: SohoBreadcrumbRef) {
+    return this.breadcrumbAPI.getBreadcrumbItemAPI(item);
+  }
+
+  /**
+   * @param [settings] incoming IDS Breadcrumb settings
+   */
+  updated(settings?: SohoBreadcrumbOptions) {
+    if (settings) {
+      this.options = settings;
+    }
+
+    if (!this.breadcrumbAPI) { return; }
+
+    this.ngZone.runOutsideAngular(() => {
+      this.breadcrumbAPI.updated(this.options);
+    });
+  }
+
+  /**
+   * Destroys this component and tears down the IDS Breadcrumb
+   */
+  destroy() {
+    if (!this.breadcrumbAPI) { return; }
+
+    this.ngZone.runOutsideAngular(() => {
+      this.breadcrumbAPI.destroy();
+    });
+  }
+}

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
@@ -26,7 +26,9 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
   private breadcrumbAPI: SohoBreadcrumbStatic;
 
   // Default Options
-  private options: SohoBreadcrumbOptions;
+  private options: SohoBreadcrumbOptions = {
+    style: 'default'
+  };
 
   /** Allow Breadcrumb Definition by Input */
   @Input()

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
@@ -21,7 +21,7 @@ type SohoBreadcrumbRef = SohoBreadcrumbItemStatic | HTMLAnchorElement | Number;
 /**
  * Breadcrumb Item Options
  */
-interface SohoBreadcrumbItemOptions {
+interface SohoBreadcrumbItemOptions extends Object {
 
   /** Breadcrumb Text/HTML Contents */
   content: string;
@@ -45,7 +45,7 @@ interface SohoBreadcrumbItemOptions {
 /**
  * Breadcrumb List Options
  */
-interface SohoBreadcrumbOptions {
+interface SohoBreadcrumbOptions extends Object {
 
   /* Rendering Style */
   style: SohoBreadcrumbOptionsStyle;

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
@@ -19,7 +19,15 @@ type SohoBreadcrumbOptionsStyle = 'default' | 'alternate';
 type SohoBreadcrumbRef = SohoBreadcrumbItemStatic | HTMLAnchorElement | Number;
 
 /**
- * Breadcrumb Item Options
+ * Function prototype for the IDS Breadcrumb Item's optional `callback` property.
+ */
+type SohoBreadcrumbItemCallbackFunction = (
+  e?: any,
+  ...args: any[]
+) => boolean;
+
+/**
+ * IDS Breadcrumb Item Options
  */
 interface SohoBreadcrumbItemOptions extends Object {
 
@@ -39,11 +47,11 @@ interface SohoBreadcrumbItemOptions extends Object {
   id?: string | undefined;
 
   /** If defined, this callback is activated when a breadcrumb item is clicked */
-  callback(api: SohoBreadcrumbItemStatic, e?: any, ...args: []): boolean;
+  callback?: SohoBreadcrumbItemCallbackFunction;
 }
 
 /**
- * Breadcrumb List Options
+ * IDS Breadcrumb List Options
  */
 interface SohoBreadcrumbOptions extends Object {
 
@@ -58,15 +66,35 @@ interface SohoBreadcrumbOptions extends Object {
  * IDS Enterprise Breadcrumb Item API
  */
 interface SohoBreadcrumbItemStatic {
+  /** Internal Settings */
   settings?: SohoBreadcrumbItemOptions;
 
+  /** The HTML List Item element that represents this breadcrumb item */
   element: HTMLLIElement;
 
+  /** Returns `true` if the breadcrumb item is disabled */
+  disabled?: boolean;
+
+  /** Returns `true` if the breadcrumb item is marked as "current" */
+  current?: boolean;
+
   /**
-   If a callback setting is provided, this method can be called
-   to programmatically trigger the callback.
+   If a callback setting is provided to this breadcrumb item, this method
+   can be called to programmatically trigger the callback.
    */
   callback(e?: SohoBreadcrumbEvent, ...args: any[]): boolean;
+
+  /** Disables this breadcrumb item */
+  disable(): void;
+
+  /** Enables this breadcrumb item */
+  enable(): void;
+
+  /** Refreshes the current state of this breadcrumb item */
+  refresh(): void;
+
+  /** Destroys this breadcrumb item */
+  destroy(doRemove?: boolean): void;
 }
 
 /**
@@ -82,22 +110,41 @@ interface SohoBreadcrumbStatic {
   /** Destroys any resources held by the breadcrumb list*/
   destroy(doRemove?: boolean): void;
 
+  /** Disables the entire breadcrumb list */
   disable(): void;
 
+  /** Enables the entire breadcrumb list */
   enable(): void;
 
+  /** Adds a single breadcrumb item to the list */
   add(settings?: SohoBreadcrumbItemOptions, doRender?: boolean): void;
 
+  /** Removes an existing breadcrumb item from the list */
   remove(item: SohoBreadcrumbRef, doRender?: boolean): void;
+
+  /** Removes all breadcrumb items from the list */
+  removeAll(doRender?: boolean): void;
 
   /** Sets a breadcrumb in the row as the "current" one (bold styling) */
   makeCurrent(item: SohoBreadcrumbRef): void;
 
   /** Returns an object containing anchor, index, and API of a specified breadcrumb item */
-  getBreadcrumbItemAPI(item: SohoBreadcrumbRef): Object;
+  getBreadcrumbItemAPI(item: SohoBreadcrumbRef): SohoBreadcrumbTargetObject;
 
-  /** */
+  /** Updates the breadcrumb list with new settings */
   updated(settings?: SohoBreadcrumbOptions): void;
+}
+
+/**
+ * IDS Enterprise Breadcrumb Target Object
+ * Some internal methods in the IDS Enterprise API return this Object, which
+ * contains references to the Breadcrumb Item's anchor, API, and index within the
+ * Breadcrumb list.
+ */
+interface SohoBreadcrumbTargetObject {
+  a?: HTMLAnchorElement;
+  api?: SohoBreadcrumbItemStatic;
+  index?: Number;
 }
 
 /**

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
@@ -107,6 +107,9 @@ interface SohoBreadcrumbStatic {
   /** Internal list of invoked IDS Breadcrumb Item APIs */
   breadcrumbs: SohoBreadcrumbItemStatic[];
 
+  /** Returns `true` if the breadcrumb list is disabled */
+  disabled?: boolean;
+
   /** Destroys any resources held by the breadcrumb list*/
   destroy(doRemove?: boolean): void;
 

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
@@ -1,0 +1,119 @@
+/**
+ * Soho Breadcrumb Typings
+ *
+ * The Breadcrumb component is a navigational component that provides
+ * quick access to a nested page structure's top-level elements.
+ */
+
+/**
+ * Rendering styles for the Breadcrumb list.
+ * "Alternate" is a different, inverted color scheme.
+ */
+type SohoBreadcrumbOptionsStyle = 'default' | 'alternate';
+
+/**
+ * Interacting with some Breadcrumb list methods can be done directly
+ * with a mixed argument, which can be an IDS Breadcrumb Item API,
+ * a breadcrumb item's anchor, or a number representing the current index of a breadcrumb item within the list.
+ */
+type SohoBreadcrumbRef = SohoBreadcrumbItemStatic | HTMLAnchorElement | Number;
+
+/**
+ * Breadcrumb Item Options
+ */
+interface SohoBreadcrumbItemOptions {
+  /** Optional existing element.  Settings can be scraped from this element */
+  element?: HTMLLIElement;
+
+  /** Breadcrumb Text/HTML Contents */
+  content: string;
+
+  /** "Current" styling toggle */
+  current?: boolean;
+
+  /** Disable/Enable toggle */
+  disabled?: boolean;
+
+  /** Populates the anchor tag's `href` attribute with this value */
+  href?: string | undefined;
+
+  /** Gives the anchor tag an `id` attribute containing this value */
+  id?: string | undefined;
+
+  /** If defined, this callback is activated when a breadcrumb item is clicked */
+  callback(api: SohoBreadcrumbItemStatic, e?: any, ...args: []): boolean;
+}
+
+/**
+ * Breadcrumb List Options
+ */
+interface SohoBreadcrumbOptions {
+
+  /* Rendering Style */
+  style: SohoBreadcrumbOptionsStyle;
+
+  /* Object-based breadcrumb items */
+  breadcrumbs?: SohoBreadcrumbItemOptions[];
+}
+
+/**
+ * IDS Enterprise Breadcrumb Item API
+ */
+interface SohoBreadcrumbItemStatic {
+  settings?: SohoBreadcrumbItemOptions;
+
+  element: HTMLLIElement;
+
+  /**
+   If a callback setting is provided, this method can be called
+   to programmatically trigger the callback.
+   */
+  callback(e?: SohoBreadcrumbEvent, ...args: any[]): boolean;
+}
+
+/**
+ * IDS Enterprise Breadcrumb API
+ */
+interface SohoBreadcrumbStatic {
+  /** internal settings */
+  settings?: SohoBreadcrumbOptions;
+
+  /** Associated HTML Element */
+  element: HTMLElement;
+
+  /** Internal list of invoked IDS Breadcrumb Item APIs */
+  breadcrumbs: SohoBreadcrumbItemStatic[];
+
+  /** Destroys any resources held by the breadcrumb list*/
+  destroy(doRemove?: boolean): void;
+
+  disable(): void;
+
+  enable(): void;
+
+  add(settings?: SohoBreadcrumbItemOptions, doRender?: boolean): void;
+
+  remove(item: SohoBreadcrumbRef, doRender?: boolean): void;
+
+  /** Sets a breadcrumb in the row as the "current" one (bold styling) */
+  makeCurrent(item: SohoBreadcrumbRef): void;
+
+  /** Returns an object containing anchor, index, and API of a specified breadcrumb item */
+  getBreadcrumbItemAPI(item: SohoBreadcrumbRef): Object;
+
+  /** */
+  updated(settings?: SohoBreadcrumbOptions): void;
+}
+
+/**
+ * jQuery integration
+ */
+interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
+  breadcrumb(options?: SohoBreadcrumbOptions): JQuery;
+  on(events: string,
+    handler: JQuery.EventHandlerBase<TElement, SohoBreadcrumbEvent>): this;
+}
+
+interface SohoBreadcrumbEvent extends JQuery.TriggeredEvent {
+  anchor: HTMLAnchorElement;
+}

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.d.ts
@@ -22,8 +22,6 @@ type SohoBreadcrumbRef = SohoBreadcrumbItemStatic | HTMLAnchorElement | Number;
  * Breadcrumb Item Options
  */
 interface SohoBreadcrumbItemOptions {
-  /** Optional existing element.  Settings can be scraped from this element */
-  element?: HTMLLIElement;
 
   /** Breadcrumb Text/HTML Contents */
   content: string;
@@ -77,9 +75,6 @@ interface SohoBreadcrumbItemStatic {
 interface SohoBreadcrumbStatic {
   /** internal settings */
   settings?: SohoBreadcrumbOptions;
-
-  /** Associated HTML Element */
-  element: HTMLElement;
 
   /** Internal list of invoked IDS Breadcrumb Item APIs */
   breadcrumbs: SohoBreadcrumbItemStatic[];

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SohoBreadcrumbComponent } from './soho-breadcrumb.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [
+    SohoBreadcrumbComponent
+  ],
+  exports: [
+    SohoBreadcrumbComponent
+  ]
+})
+
+export class SohoBreadcrumbModule {}

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.spec.ts
@@ -43,7 +43,6 @@ const STANDARD_DATA = [
 })
 class SohoBreadcrumbTestComponent {
   @ViewChild(SohoBreadcrumbComponent, { static: true }) breadcrumb: SohoBreadcrumbComponent;
-  public breadcrumbs = STANDARD_DATA;
   constructor() {}
 }
 
@@ -62,12 +61,13 @@ fdescribe('Soho Breadcrumb Unit Tests', () => {
 
     fixture = TestBed.createComponent(SohoBreadcrumbTestComponent);
     component = fixture.componentInstance;
-
-    fixture.detectChanges();
-
     breadcrumb = component.breadcrumb;
     de = fixture.debugElement;
     el = de.nativeElement;
+
+    // Set the breadcrumbs via the input
+    breadcrumb.breadcrumbs = STANDARD_DATA;
+    fixture.detectChanges();
   });
 
   it('is created', () => {
@@ -76,14 +76,16 @@ fdescribe('Soho Breadcrumb Unit Tests', () => {
     expect(breadcrumb.breadcrumbs.length).toEqual(4);
   });
 
-  it('can enable and disable the entire breadcrumb list', () => {
+  xit('can disable and re-enable the entire breadcrumb list', () => {
     breadcrumb.disable();
+    fixture.detectChanges();
 
-    expect(el.classList.contains('is-disabled')).toBeTruthy();
+    expect(breadcrumb.disabled).toBeTruthy();
 
     breadcrumb.enable();
+    fixture.detectChanges();
 
-    expect(el.classList.contains('is-disabled')).toBeFalsy();
+    expect(breadcrumb.disabled).toBeFalsy();
   });
 
   it('can add breadcrumbs', () => {
@@ -97,5 +99,20 @@ fdescribe('Soho Breadcrumb Unit Tests', () => {
     expect(breadcrumb.breadcrumbAPIs.length).toEqual(5);
     expect(fifth.settings.id).toEqual('fifth-item');
     expect(fifth.disabled).toBeFalsy();
+  });
+
+  it('can remove a breadcrumb using its Index', () => {
+    breadcrumb.remove(0, true);
+
+    expect(breadcrumb.breadcrumbAPIs.length).toEqual(3);
+    expect(breadcrumb.breadcrumbAPIs[0].settings.content).toEqual('Second Item');
+  });
+
+  it('can remove a breadcrumb uisng its IDS Breadcrumb API', () => {
+    const api1 = breadcrumb.getBreadcrumbItem(0).api;
+    breadcrumb.remove(api1, true);
+
+    expect(breadcrumb.breadcrumbAPIs.length).toEqual(3);
+    expect(breadcrumb.breadcrumbAPIs[0].settings.content).toEqual('Second Item');
   });
 });

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.spec.ts
@@ -1,0 +1,101 @@
+/// <reference path="soho-breadcrumb.d.ts" />
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Component, DebugElement, EventEmitter, ViewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { SohoBreadcrumbModule } from './soho-breadcrumb.module';
+import { SohoBreadcrumbComponent } from './soho-breadcrumb.component';
+import { TestHelper } from '../utils';
+
+const STANDARD_DATA = [
+  {
+    content: 'Home',
+    id: 'test-breadcrumb-home',
+    href: '#'
+  },
+  {
+    content: 'Second Item',
+    id: 'test-breadcrumb-second',
+    href: '#'
+  },
+  {
+    content: 'Third Item',
+    id: 'test-breadcrumb-third',
+    href: '#'
+  },
+  {
+    content: 'Fourth Item',
+    current: true,
+    id: 'test-breadcrumb-fourth',
+    href: '#'
+  }
+];
+
+@Component({
+  template: `
+  <div class="row">
+    <div class="twelve columns">
+      <nav soho-breadcrumb class="breadcrumb"></nav>
+    </div>
+  </div>`
+})
+class SohoBreadcrumbTestComponent {
+  @ViewChild(SohoBreadcrumbComponent, { static: true }) breadcrumb: SohoBreadcrumbComponent;
+  public breadcrumbs = STANDARD_DATA;
+  constructor() {}
+}
+
+fdescribe('Soho Breadcrumb Unit Tests', () => {
+  let breadcrumb: SohoBreadcrumbComponent;
+  let component: SohoBreadcrumbTestComponent;
+  let fixture: ComponentFixture<SohoBreadcrumbTestComponent>;
+  let de: DebugElement;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SohoBreadcrumbTestComponent],
+      imports: [SohoBreadcrumbModule]
+    });
+
+    fixture = TestBed.createComponent(SohoBreadcrumbTestComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    breadcrumb = component.breadcrumb;
+    de = fixture.debugElement;
+    el = de.nativeElement;
+  });
+
+  it('is created', () => {
+    expect(component).toBeTruthy();
+    expect(breadcrumb.breadcrumbs).toBeDefined();
+    expect(breadcrumb.breadcrumbs.length).toEqual(4);
+  });
+
+  it('can enable and disable the entire breadcrumb list', () => {
+    breadcrumb.disable();
+
+    expect(el.classList.contains('is-disabled')).toBeTruthy();
+
+    breadcrumb.enable();
+
+    expect(el.classList.contains('is-disabled')).toBeFalsy();
+  });
+
+  it('can add breadcrumbs', () => {
+    breadcrumb.add({
+      id: 'fifth-item',
+      content: 'Fifth Item',
+      href: '#'
+    });
+    const fifth = breadcrumb.breadcrumbAPIs[4];
+
+    expect(breadcrumb.breadcrumbAPIs.length).toEqual(5);
+    expect(fifth.settings.id).toEqual('fifth-item');
+    expect(fifth.disabled).toBeFalsy();
+  });
+});

--- a/projects/ids-enterprise-ng/src/lib/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/index.ts
@@ -5,6 +5,7 @@ export * from './application-menu/index';
 export * from './autocomplete/index';
 export * from './bar/index';
 export * from './blockgrid/index';
+export * from './breadcrumb/index';
 export * from './bullet/index';
 export * from './busyindicator/index';
 export * from './button/index';

--- a/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
@@ -7,6 +7,7 @@ import { SohoAutoCompleteModule } from './autocomplete/soho-autocomplete.module'
 import { SohoBarModule } from './bar/soho-bar.module';
 import { SohoBulletModule } from './bullet/soho-bullet.module';
 import { SohoBlockGridModule } from './blockgrid/soho-blockgrid.module';
+import { SohoBreadcrumbModule } from './breadcrumb/soho-breadcrumb.module';
 import { SohoBusyIndicatorModule } from './busyindicator/soho-busyindicator.module';
 import { SohoButtonModule } from './button/soho-button.module';
 import { SohoButtonsetModule } from './buttonset/soho-buttonset.module';
@@ -89,6 +90,7 @@ import { SohoWizardModule } from './wizard/soho-wizard.module';
     SohoAutoCompleteModule,
     SohoBarModule,
     SohoBlockGridModule,
+    SohoBreadcrumbModule,
     SohoBulletModule,
     SohoBusyIndicatorModule,
     SohoButtonModule,
@@ -171,6 +173,7 @@ import { SohoWizardModule } from './wizard/soho-wizard.module';
     SohoAutoCompleteModule,
     SohoBarModule,
     SohoBlockGridModule,
+    SohoBreadcrumbModule,
     SohoBulletModule,
     SohoBusyIndicatorModule,
     SohoButtonModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { BlockGridCustomContentDemoComponent } from './blockgrid/blockgrid-custo
 import { BlockGridMixedSelectionDemoComponent } from './blockgrid/blockgrid-mixed-selection.demo';
 import { BlockGridMultiSelectionDemoComponent } from './blockgrid/blockgrid-multi-selection.demo';
 import { BlockGridSingleSelectionDemoComponent } from './blockgrid/blockgrid-single-selection.demo';
+import { BreadcrumbDemoComponent } from './breadcrumb/breadcrumb.demo';
 import { BubbleDemoComponent } from './bubble/bubble.demo';
 import { BulletDemoComponent } from './bullet/bullet.demo';
 import { BusyIndicatorDemoComponent } from './busyindicator/form.demo';
@@ -253,6 +254,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     BlockGridMixedSelectionDemoComponent,
     BlockGridMultiSelectionDemoComponent,
     BlockGridSingleSelectionDemoComponent,
+    BreadcrumbDemoComponent,
     BubbleDemoComponent,
     BulletDemoComponent,
     BusyIndicatorDemoComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { BlockGridMixedSelectionDemoComponent } from './blockgrid/blockgrid-mixe
 import { BlockGridMultiSelectionDemoComponent } from './blockgrid/blockgrid-multi-selection.demo';
 import { BlockGridSingleSelectionDemoComponent } from './blockgrid/blockgrid-single-selection.demo';
 import { BreadcrumbDemoComponent } from './breadcrumb/breadcrumb.demo';
+import { BreadcrumbGauntletDemoComponent } from './breadcrumb/breadcrumb-gauntlet.demo';
 import { BubbleDemoComponent } from './bubble/bubble.demo';
 import { BulletDemoComponent } from './bullet/bullet.demo';
 import { BusyIndicatorDemoComponent } from './busyindicator/form.demo';
@@ -255,6 +256,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     BlockGridMultiSelectionDemoComponent,
     BlockGridSingleSelectionDemoComponent,
     BreadcrumbDemoComponent,
+    BreadcrumbGauntletDemoComponent,
     BubbleDemoComponent,
     BulletDemoComponent,
     BusyIndicatorDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -14,6 +14,7 @@ import { BlockGridMixedSelectionDemoComponent } from './blockgrid/blockgrid-mixe
 import { BlockGridMultiSelectionDemoComponent } from './blockgrid/blockgrid-multi-selection.demo';
 import { BlockGridSingleSelectionDemoComponent } from './blockgrid/blockgrid-single-selection.demo';
 import { BreadcrumbDemoComponent } from './breadcrumb/breadcrumb.demo';
+import { BreadcrumbGauntletDemoComponent } from './breadcrumb/breadcrumb-gauntlet.demo';
 import { BubbleDemoComponent } from './bubble/bubble.demo';
 import { BulletDemoComponent } from './bullet/bullet.demo';
 import { BusyIndicatorDemoComponent } from './busyindicator/form.demo';
@@ -200,6 +201,7 @@ export const routes: Routes = [
   { path: 'bar-grouped', component: BarGroupedDemoComponent },
   { path: 'bar-stacked', component: BarStackedDemoComponent },
   { path: 'breadcrumb', component: BreadcrumbDemoComponent },
+  { path: 'breadcrumb-gauntlet', component: BreadcrumbGauntletDemoComponent },
   { path: 'blockgrid-custom-content', component: BlockGridCustomContentDemoComponent },
   { path: 'blockgrid-mixed-selection', component: BlockGridMixedSelectionDemoComponent },
   { path: 'blockgrid-multi-selection', component: BlockGridMultiSelectionDemoComponent },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -199,7 +199,7 @@ export const routes: Routes = [
   { path: 'bar', component: BarDemoComponent },
   { path: 'bar-grouped', component: BarGroupedDemoComponent },
   { path: 'bar-stacked', component: BarStackedDemoComponent },
-  { path: 'breadcrumb-demo', component: BreadcrumbDemoComponent },
+  { path: 'breadcrumb', component: BreadcrumbDemoComponent },
   { path: 'blockgrid-custom-content', component: BlockGridCustomContentDemoComponent },
   { path: 'blockgrid-mixed-selection', component: BlockGridMixedSelectionDemoComponent },
   { path: 'blockgrid-multi-selection', component: BlockGridMultiSelectionDemoComponent },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { BlockGridCustomContentDemoComponent } from './blockgrid/blockgrid-custo
 import { BlockGridMixedSelectionDemoComponent } from './blockgrid/blockgrid-mixed-selection.demo';
 import { BlockGridMultiSelectionDemoComponent } from './blockgrid/blockgrid-multi-selection.demo';
 import { BlockGridSingleSelectionDemoComponent } from './blockgrid/blockgrid-single-selection.demo';
+import { BreadcrumbDemoComponent } from './breadcrumb/breadcrumb.demo';
 import { BubbleDemoComponent } from './bubble/bubble.demo';
 import { BulletDemoComponent } from './bullet/bullet.demo';
 import { BusyIndicatorDemoComponent } from './busyindicator/form.demo';
@@ -198,6 +199,7 @@ export const routes: Routes = [
   { path: 'bar', component: BarDemoComponent },
   { path: 'bar-grouped', component: BarGroupedDemoComponent },
   { path: 'bar-stacked', component: BarStackedDemoComponent },
+  { path: 'breadcrumb-demo', component: BreadcrumbDemoComponent },
   { path: 'blockgrid-custom-content', component: BlockGridCustomContentDemoComponent },
   { path: 'blockgrid-mixed-selection', component: BlockGridMixedSelectionDemoComponent },
   { path: 'blockgrid-multi-selection', component: BlockGridMultiSelectionDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -25,6 +25,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-multi-selection']"><span>BlockGrid - Multi Selection</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-single-selection']"><span>BlockGrid - Single Selection</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['breadcrumb']"><span>Breadcrumb</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['breadcrumb-gauntlet']"><span>Breadcrumb Gauntlet</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['bubble']"><span>Bubble Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['bullet']"><span>Bullet Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['button']"><span>Button</span></a></div>

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -24,6 +24,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-mixed-selection']"><span>BlockGrid - Mixed Selection</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-multi-selection']"><span>BlockGrid - Multi Selection</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-single-selection']"><span>BlockGrid - Single Selection</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['breadcrumb']"><span>Breadcrumb</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['bubble']"><span>Bubble Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['bullet']"><span>Bullet Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['button']"><span>Button</span></a></div>

--- a/src/app/breadcrumb/breadcrumb-demo-data.ts
+++ b/src/app/breadcrumb/breadcrumb-demo-data.ts
@@ -1,0 +1,24 @@
+// Matches `example-from-settings.html` IDS Enterprise Breadcrumb demo.
+export const STANDARD_DATA = [
+  {
+    content: 'Home',
+    id: 'test-breadcrumb-home',
+    href: '#'
+  },
+  {
+    content: 'Second Item',
+    id: 'test-breadcrumb-second',
+    href: '#'
+  },
+  {
+    content: 'Third Item',
+    id: 'test-breadcrumb-third',
+    href: '#'
+  },
+  {
+    content: 'Fourth Item',
+    current: true,
+    id: 'test-breadcrumb-fourth',
+    href: '#'
+  }
+];

--- a/src/app/breadcrumb/breadcrumb-gauntlet.demo.html
+++ b/src/app/breadcrumb/breadcrumb-gauntlet.demo.html
@@ -1,0 +1,63 @@
+<div class="row">
+  <div class="twelve columns">
+    <nav soho-breadcrumb class="breadcrumb"></nav>
+  </div>
+</div>
+
+<form id="breadcrumb-gauntlet" [formGroup]="demoForm">
+  <div class="row top-padding">
+    <div class="six columns">
+      <h2>Add New Breadcrumb:</h2>
+      <div class="field">
+        <label soho-label for="new-id">ID</label>
+        <input soho-input formControlName="id" id="new-id"/>
+      </div>
+      <div class="field">
+        <input soho-checkbox formControlName="autoGenerateId" id="new-id-auto" type="checkbox" class="checkbox" name="new-id-auto" checked/>
+        <label soho-label for="new-id-auto" forCheckBox>Auto-generate IDs</label>
+      </div>
+      <div class="field">
+        <label soho-label for="new-content" class="required">Content</label>
+        <input soho-input formControlName="content" id="new-content" />
+      </div>
+      <div class="field">
+        <input soho-checkbox formControlName="autoGenerateContent" id="new-content-auto" type="checkbox" class="checkbox" name="new-id-auto" checked/>
+        <label soho-label for="new-content-auto" forCheckBox>Auto-generate Content</label>
+      </div>
+      <div class="field">
+        <label soho-label for="new-href">`href` Attribute (Causes Link to become Active)</label>
+        <input soho-input formControlName="href" id="new-href" />
+      </div>
+      <div class="field">
+        <input soho-checkbox formControlName="disabled" id="new-disabled" type="checkbox" class="checkbox" />
+        <label soho-label for="new-disabled" forCheckBox>Disabled</label>
+      </div>
+      <div class="field">
+        <input soho-checkbox formControlName="current" id="new-current" type="checkbox" class="checkbox" />
+        <label soho-label for="new-current" forCheckBox>Currently Active</label>
+      </div>
+      <div class="field">
+        <input soho-checkbox formControlName="callback" id="new-callback" type="checkbox" class="checkbox" checked />
+        <label soho-label for="new-callback" forCheckBox>Trigger a callback when clicked</label>
+      </div>
+      <div class="field">
+        <button soho-button="secondary" id="control-reset" type="reset" (click)="reset()">Reset</button>
+        <button soho-button="primary" id="control-add" type="submit" (click)="add()" [disabled]="demoForm.valid ? undefined : true">Add</button>
+      </div>
+    </div>
+
+    <div class="six columns">
+      <div class="card">
+        <div class="card-header">
+          <h2 class="widget-title">Last-Clicked Breadcrumb Contents</h2>
+        </div>
+        <div class="card-content" id="results-card" [innerHTML]="lastClickedContents"></div>
+        <div class="card-footer">
+          <button soho-button="secondary" id="control-current" (click)="setCurrent()">Make Current</button>
+          <button soho-button="secondary" id="control-remove" (click)="removeLastClicked()">Remove This Breadcrumb</button>
+          <button soho-button="secondary" id="control-remove-all" (click)="removeAll()">Remove All</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>

--- a/src/app/breadcrumb/breadcrumb-gauntlet.demo.ts
+++ b/src/app/breadcrumb/breadcrumb-gauntlet.demo.ts
@@ -1,0 +1,185 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ViewChild
+} from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { SohoBreadcrumbComponent } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-breadcrumb-gauntlet-demo',
+  templateUrl: 'breadcrumb-gauntlet.demo.html',
+  styles: [
+    '#results-card { padding: 20px; }',
+    '#results-card .prop { display: inline-block; font-weight: 700; min-width: 150px; }'
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BreadcrumbGauntletDemoComponent {
+
+  @ViewChild(SohoBreadcrumbComponent, { static: true }) breadcrumb: SohoBreadcrumbComponent;
+
+  public breadcrumbIdCount = 0;
+  public demoForm: FormGroup;
+
+  public lastClickedAPI: SohoBreadcrumbItemStatic;
+  public lastClickedContents = '';
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private ref: ChangeDetectorRef
+  ) {
+    this.demoForm = this.formBuilder.group({
+      id: [''],
+      autoGenerateId: [true],
+      content: ['', Validators.required],
+      autoGenerateContent: [true],
+      href: [''],
+      disabled: [false],
+      current: [false],
+      callback: [true]
+    });
+    this.demoForm.controls.id.disable();
+    this.demoForm.controls.content.disable();
+
+    // Disable/Enable the ID form field if its contents should/shouldn't be auto generated.
+    this.demoForm
+      .controls['autoGenerateId']
+      .valueChanges
+      .subscribe((val) => {
+          this.demoForm.controls['id'][val === true ? 'disable' : 'enable']();
+      });
+
+    // Disable/Enable the Content form field if its contents should/shouldn't be auto generated.
+    this.demoForm
+      .controls['autoGenerateContent']
+      .valueChanges
+      .subscribe((val) => {
+          this.demoForm.controls['content'][val === true ? 'disable' : 'enable']();
+      });
+  }
+
+  add() {
+    let increaseCount: boolean;
+    const newSettings: SohoBreadcrumbItemOptions = {
+      content: ''
+    };
+
+    // Content (Required)
+    const formContent = this.demoForm.controls['content'].value;
+    const autoGenerateContent = this.demoForm.controls['autoGenerateContent'].value;
+    if (autoGenerateContent) {
+      newSettings.content = `New Breadcrumb ${this.breadcrumbIdCount}`;
+      increaseCount = true;
+    } else if (formContent && formContent.length) {
+      newSettings.content = formContent;
+    }
+
+    // Set an ID
+    const formId = this.demoForm.controls['id'].value;
+    const autoGenerateId = this.demoForm.controls['autoGenerateId'].value;
+    if (autoGenerateId) {
+      newSettings.id = `breadcrumb-${this.breadcrumbIdCount}`;
+      increaseCount = true;
+    } else if (formId && formId.length) {
+      newSettings.id = formId;
+    }
+
+    // `href` attribute on the anchor
+    const formHref = this.demoForm.controls['href'].value;
+    if (formHref && formHref.length) {
+      newSettings.href = formHref;
+    }
+
+    // Disabled?
+    newSettings.disabled = this.demoForm.controls['disabled'].value;
+
+    // Currently Active?
+    newSettings.current = this.demoForm.controls['current'].value;
+
+    // Fire a callback when the anchor is clicked.
+    // The callback function runs in the context of the IDS Breadcrumb Item's API.
+    const self = this;
+    if (this.demoForm.controls['callback'].value) {
+      newSettings.callback = function testCallback (e) {
+        self.renderBreadcrumbConfig(e.target);
+        const content = this.settings.content;
+
+        // Trigger a toast message
+        $('body').toast({
+          title: '"' + content + '" Clicked',
+          message: 'The Breadcrumb "' + content + '" was clicked, and its callback was fired.'
+        });
+
+        // Automatically disable "linking out" from breadcrumb links on this test.
+        // Normal behavior will allow the links to be followed as expected.
+        if (e.target.href === '#' || e.target.href === '') {
+          e.preventDefault();
+          return false;
+        }
+
+        return true;
+      };
+    }
+
+    this.breadcrumb.add(newSettings, true);
+
+    if (increaseCount) {
+      this.breadcrumbIdCount++;
+    }
+  }
+
+  public reset() {
+    this.demoForm.reset();
+  }
+
+  renderBreadcrumbConfig(item: SohoBreadcrumbRef) {
+    const target = this.breadcrumb.getBreadcrumbItem(item);
+    const api = target.api;
+    if (!api) {
+      return;
+    }
+
+    // Renders the return message
+    const msg = '<p>' +
+      '<span class="prop">ID:</span> ' + ('"' + api.settings.id + '"' || 'undefined') + '<br />' +
+      '<span class="prop">Content:</span> "' + api.settings.content + '" <br />' +
+      '<span class="prop">Callback Enabled:</span> ' + (typeof api.settings.callback === 'function') + '<br />' +
+      '<span class="prop">Currently Active:</span> ' + api.settings.current + '<br />' +
+      '<span class="prop">Disabled:</span> ' + (api.disabled || 'false') + '<br />' +
+      '<span class="prop">href:</span> ' + ('"' + api.settings.href + '"' || 'undefined') + '<br />' +
+      '</p>';
+
+    this.lastClickedContents = msg;
+    this.lastClickedAPI = api;
+    this.ref.markForCheck();
+  }
+
+  removeAll(): void {
+    this.breadcrumb.removeAll();
+
+    this.lastClickedContents = undefined;
+    this.lastClickedAPI = undefined;
+    this.ref.markForCheck();
+  }
+
+  removeLastClicked(): void {
+    if (!this.lastClickedAPI) {
+      return;
+    }
+    this.breadcrumb.remove(this.lastClickedAPI);
+
+    this.lastClickedContents = undefined;
+    this.lastClickedAPI = undefined;
+    this.ref.markForCheck();
+  }
+
+  setCurrent(): void {
+    if (!this.lastClickedAPI) {
+      return;
+    }
+    this.breadcrumb.makeCurrent(this.lastClickedAPI);
+    this.renderBreadcrumbConfig(this.lastClickedAPI);
+  }
+}

--- a/src/app/breadcrumb/breadcrumb.demo.html
+++ b/src/app/breadcrumb/breadcrumb.demo.html
@@ -1,0 +1,5 @@
+<div class="row">
+  <div class="twelve columns">
+    <nav soho-breadcrumb class="breadcrumb" [breadcrumbs]="breadcrumbs"></nav>
+  </div>
+</div>

--- a/src/app/breadcrumb/breadcrumb.demo.ts
+++ b/src/app/breadcrumb/breadcrumb.demo.ts
@@ -1,0 +1,22 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  ViewChild
+} from '@angular/core';
+
+import { SohoBreadcrumbComponent } from 'ids-enterprise-ng';
+
+import { STANDARD_DATA } from './breadcrumb-demo-data';
+
+@Component({
+  selector: 'app-breadcrumb-demo',
+  templateUrl: 'breadcrumb.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BreadcrumbDemoComponent {
+
+  @ViewChild(SohoBreadcrumbComponent, { static: true }) sohoBreadcrumbComponent: SohoBreadcrumbComponent;
+
+  public breadcrumbs = STANDARD_DATA;
+}

--- a/src/app/breadcrumb/breadcrumb.demo.ts
+++ b/src/app/breadcrumb/breadcrumb.demo.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   ViewChild
 } from '@angular/core';
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds the following:
- an Angular component wrapper for the IDS Enterprise Breadcrumb component
- Typescript definitions for the IDS Breadcrumb
- "Gauntlet" demo page for testing the API 
- Unit tests

**Related github/jira issue (required)**:
Closes #700 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the NG demoapp
- Open http://localhost:4200/ids-enterprise-ng-demo/breadcrumb - this is a simple demo showing a standard breadcrumb setup.
- Open http://localhost:4200/ids-enterprise-ng-demo/breadcrumb-gauntlet - this is a more complex "gauntlet"/sandbox page using the API to add/remove breadcrumbs from the list.  Try all the controls and ensure everything is working correctly.
- Ensure tests pass

----
@gushanson