### PR TITLE
831 - Add missing Flex Toolbar typescript defs, Fix incorrect definition in event handler

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 7.4.0 Fixes
 
+- `[Toolbar Flex]` Added missing type definitions. `EPC` ([#831](https://github.com/infor-design/enterprise-ng/issues/831))
+
 ## v7.3.0
 
 ## v7.3.0 Notes

--- a/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
@@ -306,7 +306,7 @@ export class SohoToolbarFlexComponent implements AfterViewChecked, AfterViewInit
       this.jQueryElement.toolbarflex(this._options);
       this.toolbarFlex = this.jQueryElement.data('toolbarFlex');
 
-      this.jQueryElement.on('selected', (event: JQuery.TriggeredEvent, item: HTMLButtonElement | HTMLAnchorElement) =>
+      this.jQueryElement.on('selected', (event: JQuery.TriggeredEvent, item: SohoToolbarFlexItemStatic) =>
         this.ngZone.run(() => {
           this.selected.emit({ event, item });
         }));
@@ -333,7 +333,7 @@ export class SohoToolbarFlexComponent implements AfterViewChecked, AfterViewInit
     });
   }
 
-  updated(settings?) {
+  updated(settings?: SohoToolbarFlexOptions) {
     if (this.toolbarFlex) {
       this.ngZone.runOutsideAngular(() => this.toolbarFlex.updated(settings));
     }

--- a/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.d.ts
@@ -1,34 +1,190 @@
 /**
- * Soho Toolbar Flex Control.
+ * Soho Toolbar Flex Component.
  *
- * This file contains the Typescript mappings for the public
- * interface of the Soho jQuery toolbar control.
+ * This file contains the Typescript mappings for the component's public interface.
  */
+
+/**
+ * Elements within a Toolbar Section can be these types
+ */
+type SohoToolbarFlexElementRef = HTMLButtonElement | HTMLAnchorElement | HTMLInputElement;
+
+/**
+ * Either an IDS Toolbar Flex Item Ref, or an Element Ref
+ */
+type SohoToolbarFlexItemOrElementRef = SohoToolbarFlexItemStatic | SohoToolbarFlexElementRef;
+
+/**
+ * Possible "Item" types (mostly corresponding to other IDS Component types)
+ */
+type SohoToolbarFlexItemType = 'button' |
+  'menubutton' | 'actionbutton' | 'colorpicker' | 'hyperlink' | 'checkbox' |
+  'radio' | 'searchfield' | 'toolbarsearchfield';
+
+/**
+ * Possible Component APIs that can be attached to Toolbar Flex Items (correspond to other IDS Component Interfaces)
+ */
+type SohoToolbarFlexItemComponentAPI = SohoPopupMenuStatic | SohoColorPickerStatic | SohoToolbarFlexSearchFieldStatic;
+
+/**
+ * Possible Component Options types
+ */
+type SohoToolbarFlexItemComponentOptions = SohoPopupMenuOptions | SohoColorPickerOptions | SohoToolbarFlexSearchFieldOptions;
+
+/**
+ * Toolbar Flex Item Options
+ */
+interface SohoToolbarFlexItemOptions {
+  disabled?: boolean;
+  readOnly?: boolean;
+  hidden?: boolean;
+  componentSettings?: SohoToolbarFlexItemComponentOptions;
+  allowTabs?: boolean;
+}
+
+/**
+ * IDS Toolbar Flex Item API
+ */
+interface SohoToolbarFlexItemStatic {
+  /** Identifies a corresponding element/component type of the Toolbar Flex Item */
+  type: SohoToolbarFlexItemType;
+
+  /** Provides a reference to this item's corresponding IDS Component API, if one exists. */
+  componentAPI?: SohoToolbarFlexItemComponentAPI;
+
+  /** Provides a reference to this item's parent IDS Toolbar Flex Component API */
+  toolbarAPI?: SohoToolbarFlexStatic;
+
+  /** Reference to this Toolbar Item's parent `.flex-toolbar` component element */
+  toolbar: HTMLElement;
+
+  /** Reference to this Toolbar Item's parent `.toolbar-section` container element */
+  section: HTMLElement;
+
+  /** If true, this Item is disabled */
+  disabled?: boolean;
+
+  /** If true, it's possible for this Item to become focused. */
+  focusable?: boolean;
+
+  /** If true, this item is the currently focused Toolbar Flex item */
+  focused?: boolean;
+
+  /** returns `true` if this component type is able to be configured as `readonly` */
+  hasReadOnly?: boolean;
+
+  /** (For Action Button types only) if true, this More Actions button contains
+  overflowed items and will visually display the More Actions button. */
+  hasNoOverflowedItems?: boolean;
+
+  /** If true, this Item will not be visible in the main toolbar area,
+  and will be spilled into the "More Actions" menu if one is available. */
+  overflow?: boolean;
+
+  /** (For input types only) If true, this item is configured to be `readonly` */
+  readOnly?: boolean;
+
+  /** If true, this item is the currently "selected" or "active" toolbar item */
+  selected?: boolean;
+
+  /** If true, this item is not hidden (by CSS class, not by overflow) */
+  visible?: boolean;
+
+  /** Programatically triggers a `selected` event on this Toolbar Flex Item for
+  allowed component types (anything except colorpicker and searchfield) */
+  triggerSelectedEvent(): void;
+
+  /** Causes the Toolbar Flex Item to become visible. */
+  show(): void;
+
+  /** Causes the Toolbar Flex Item to become hidden. */
+  hide(): void;
+
+  /** Converts the current state of the toolbar item into a plain object that can
+  be passed to other toolbars/component types, or used for testing. */
+  toData(): any;
+
+  /** (For action/menu button types) Renders the contents of this item's menu into a
+  Popupmenu-compatible plain settings object. */
+  toPopupmenuData(): any;
+
+  /** Causes the Toolbar Flex Item to update/refresh with new settings. */
+  updated(settings?: SohoToolbarFlexItemOptions): void;
+
+  /** Tears down all event handlers and extra HTML markup. */
+  teardown(): void;
+
+  /** Completely destroys the Toolbar Flex Item component instance. */
+  destroy(): void;
+}
 
 /**
  * Toolbar Flex options.
  */
 interface SohoToolbarFlexOptions {
-  /**
-   * Ajax callback for the more menu
-   */
+  /** Allows for keyboard navigation of the Flex Toolbar using Tab/Shift+Tab */
+  allowTabs?: boolean;
+
+  /** Ajax callback for the more menu */
   beforeMoreMenuOpen?: AjaxBeforeMoreMenuOpenFunction;
+
+  /** Shortcut settings object for passing Popupmenu settings to a Toolbar Flex More Actions Item */
+  moreMenuSettings?: SohoPopupMenuOptions;
 }
 
 /**
- * This interface represents the pub Api exposed by the
- * Soho tree control.
+ * IDS Soho Toolbar Flex API
  */
 interface SohoToolbarFlexStatic {
   /** Control options. */
   settings: SohoToolbarFlexOptions;
 
+  /** If applicable, returns a link to the Searchfield Component's API */
+  searchfieldAPI?: SohoToolbarFlexSearchFieldStatic;
+
+  /** If true, the entire Toolbar Flex is disabled */
+  disabled?: boolean;
+
+  /** If an item is currently focused, this property will reference it and can programmatially change it */
+  focusedItem?: SohoToolbarFlexItemStatic;
+
+  /** If true, this toolbar contains items that are currently focusable.  If false, none of the items are focusable. */
+  hasFocusableItems?: boolean;
+
+  /** Contains a list of currently-invoked Toolbar Flex Items */
+  readonly overflowedItems?: Array<SohoToolbarFlexItemStatic>;
+
+  /** Returns a list of HTMLElements representing Toolbar Flex Items inside this Toolbar */
+  getElements(): Array<HTMLElement>;
+
+  /** Takes an IDS Toolbar Flex Item, or an HTMLElement with one attached, and returns the Item API
+  (mostly used internally by the IDS Component) */
+  getItemFromElement(element?: SohoToolbarFlexItemOrElementRef): SohoToolbarFlexItemStatic;
+
+  /** Detects whether or not a Toolbar Flex Item is currently in "overflow" (hidden within the More Actions menu) */
+  isItemOverflowed(element?: SohoToolbarFlexItemOrElementRef): boolean;
+
+  /** Programatically navigates the Toolbar Flex. `direction` can be a positive (move right) or negative (move left) number,
+  or 0 to remain in the current spot. */
+  navigate(direction: Number, currentIndex?: Number, doSetFocus?: boolean): void;
+
+  /** Renders the current state of the component */
+  render(): void;
+
+  /** Selects a Toolbar Flex Item by its Item API or HTMLElement */
+  select(element?: SohoToolbarFlexItemOrElementRef): void;
+
+  /** Converts the state of all current toolbar items into a JSON-like plain object */
+  toData(): any;
+
+  /** Converts the state of all current Toolbar items, except for Searchfields and More Actions
+  menus, to a Popupmenu-friendly, JSON-like plain object */
+  toPopupmenuData(): any;
+
   /** Updates the control with the new settings. */
   updated(settings?: SohoToolbarFlexOptions): void;
 
-  /**
-   * Destructor,
-   */
+  /** Destructor */
   destroy(): void;
 }
 
@@ -37,7 +193,7 @@ interface SohoToolbarFlexSelectedEvent {
   event: JQuery.TriggeredEvent;
 
   /** The element that caused the event. */
-  item: HTMLButtonElement | HTMLAnchorElement | HTMLInputElement;
+  item: SohoToolbarFlexItemStatic;
 }
 
 /*
@@ -91,7 +247,6 @@ interface SohoToolbarFlexSearchFieldStatic {
 /**
  * JQuery Integration
  */
-
 interface JQueryStatic {
   toolbarflex: SohoToolbarFlexStatic;
   toolbarflexsearchfield: SohoToolbarFlexSearchFieldStatic;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fully fleshes out the available public API in [IDS Enterprise's Flex Toolbar](), including individual items, and makes it available to the Angular components.  This PR also fixes an issue on the interface for `selected` events on the Flex Toolbar that was reported by @ayoayco, where the second argument was represented by an HTMLElement instead of an IDS Component API.

**Related github/jira issue (required)**:
Closes #831 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the NG demoapp
- Open http://localhost:4200/ids-enterprise-ng-demo/
- Examine all Toolbar Flex samples and ensure everything works (nothing should have changed).  Ensure all tests pass.