### PR TITLE
836 - Add Blockgrid paging API endpoints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 7.5.0 Fixes
 
 - `[General]` Uses EP version 4.31.0.  `TJM`
+- `[Blockgrid]` Enable settings and API types for interactions with Blockgrid Pager. `EPC` ([#836](https://github.com/infor-design/enterprise-ng/issues/836))
 - `[Lookup]` Fixed an issue where the console error was appearing after the modal close. ([#871](https://github.com/infor-design/enterprise/issues/871))
 
 ## v7.4.1

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -46,7 +46,8 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   public set selectable(selectable: SohoBlockGridSelectable) {
     this.options.selectable = selectable;
     if (this.blockgrid) {
-      this.updated(this.options);
+      this.blockgrid.settings.selectable = selectable;
+      this.updated(this.blockgrid.settings);
     }
   }
   public get selectable(): SohoBlockGridSelectable {
@@ -61,7 +62,8 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   public set paging(paging: boolean) {
     this.options.paging = paging;
     if (this.blockgrid) {
-      this.updated(this.options);
+      this.blockgrid.settings.paging = paging;
+      this.updated(this.blockgrid.settings);
     }
   }
   public get paging(): boolean {
@@ -76,7 +78,8 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   public set pagesize(pagesize: Number) {
     this.options.pagesize = pagesize;
     if (this.blockgrid) {
-      this.updated(this.options);
+      this.blockgrid.settings.pagesize = pagesize;
+      this.updated(this.blockgrid.settings);
     }
   }
   public get pagesize(): Number {
@@ -91,7 +94,8 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   public set pagesizes(pagesizes: Array<Number>) {
     this.options.pagesizes = pagesizes;
     if (this.blockgrid) {
-      this.updated(this.options);
+      this.blockgrid.settings.pagesizes = pagesizes;
+      this.updated(this.blockgrid.settings);
     }
   }
   public get pagesizes(): Array<Number> {

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -165,19 +165,19 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
         return; // safety check
       }
 
-      this.blockgrid.selectBlock($(blockChildren[idx]), false);
+      this.blockgrid.select($(blockChildren[idx]), false);
     });
   }
 
   public deactivateBlock(): void {
-    this.blockgrid.selectBlock($(), false);
+    this.blockgrid.select($(), false);
   }
 
   public selectBlocks(idx: number[]) {
     this.ngZone.runOutsideAngular(() => {
       const blockChildren: NodeList = this.element.nativeElement.querySelectorAll('.block');
       const blockChildrenArray = Array.from(blockChildren).filter((blockChild, index) => idx.includes(index));
-      this.blockgrid.selectBlock($(blockChildrenArray), true);
+      this.blockgrid.select($(blockChildrenArray), true);
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -46,8 +46,7 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   public set selectable(selectable: SohoBlockGridSelectable) {
     this.options.selectable = selectable;
     if (this.blockgrid) {
-      this.blockgrid.settings.selectable = selectable;
-      this.updated(this.blockgrid.settings);
+      this.updated(this.options);
     }
   }
   public get selectable(): SohoBlockGridSelectable {
@@ -57,11 +56,58 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
     return this.blockgrid.settings.selectable;
   }
 
+  /** Defines whether or not paging is active. */
+  @Input()
+  public set paging(paging: boolean) {
+    this.options.paging = paging;
+    if (this.blockgrid) {
+      this.updated(this.options);
+    }
+  }
+  public get paging(): boolean {
+    if (!this.blockgrid) {
+      return this.options.paging;
+    }
+    return this.blockgrid.settings.paging;
+  }
+
+  /** Defines the current page size */
+  @Input()
+  public set pagesize(pagesize: Number) {
+    this.options.pagesize = pagesize;
+    if (this.blockgrid) {
+      this.updated(this.options);
+    }
+  }
+  public get pagesize(): Number {
+    if (!this.blockgrid) {
+      return this.options.pagesize;
+    }
+    return this.blockgrid.settings.pagesize;
+  }
+
+  /** Defines the array of selectable page sizes */
+  @Input()
+  public set pagesizes(pagesizes: Array<Number>) {
+    this.options.pagesizes = pagesizes;
+    if (this.blockgrid) {
+      this.updated(this.options);
+    }
+  }
+  public get pagesizes(): Array<Number> {
+    if (!this.blockgrid) {
+      return this.options.pagesizes;
+    }
+    return this.blockgrid.settings.pagesizes;
+  }
+
   /* Events*/
   @Output() selected: EventEmitter<Object[]> = new EventEmitter<Object[]>();
   @Output() deselected: EventEmitter<Object[]> = new EventEmitter<Object[]>();
   @Output() activated: EventEmitter<Object[]> = new EventEmitter<Object[]>();
   @Output() deactivated: EventEmitter<Object[]> = new EventEmitter<Object[]>();
+  @Output() page: EventEmitter<Object[]> = new EventEmitter<Object[]>();
+  @Output() pagesizechange: EventEmitter<Object[]> = new EventEmitter<Object[]>();
 
   /** Options. */
   private options: SohoBlockGridOptions = {};
@@ -85,6 +131,11 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
       this.jQueryElement.on('deselected', (... args) => this.onDeselected(args));
       this.jQueryElement.on('activated', (... args) => this.onActivated(args));
       this.jQueryElement.on('deactivated', (... args) => this.onDeactivated(args));
+
+      if (this.blockgrid.pagerAPI) {
+        this.jQueryElement.on('page', (... args) => this.onPage(args));
+        this.jQueryElement.on('pagesizechange', (... args) => this.onPageSizeChange(args));
+      }
     });
   }
 
@@ -144,5 +195,13 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
 
   private onDeactivated(args: any[]) {
     this.ngZone.run(() => this.deactivated.emit(args));
+  }
+
+  private onPage(args: any[]) {
+    this.ngZone.run(() => this.page.emit(args));
+  }
+
+  private onPageSizeChange(args: any[]) {
+    this.ngZone.run(() => this.pagesizechange.emit(args));
   }
 }

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
@@ -34,13 +34,13 @@ interface SohoBlockGrid {
 
   pagerAPI?: SohoPagerStatic;
 
-  select(activeBlock: JQuery<HTMLElement>, isCheckbox: boolean): void;
+  select(activeBlock: JQuery<Node[]|Node>, isCheckbox: boolean): void;
 
   /**
    * @deprecated (use `select()`)
    * Selects a block in the blockgrid
    */
-  selectBlock(activeBlock: JQuery<HTMLElement>, isCheckbox: boolean): void;
+  selectBlock(activeBlock: JQuery<Node[]|Node>, isCheckbox: boolean): void;
 
   /** Updates the blockgrid with any new settings. */
   updated(settings?: SohoBlockGridOptions): void;

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
@@ -15,6 +15,15 @@ interface SohoBlockGridOptions {
 
   /** Selection Mode Property */
   selectable?: SohoBlockGridSelectable;
+
+  /** If true, enables paging in the Blockgrid */
+  paging?: boolean;
+
+  /** If paging is active, defines the number of records allowed on the current page */
+  pagesize?: Number;
+
+  /** If paging is active, defines the various record sizes the pager will allow */
+  pagesizes?: Array<Number>;
 }
 
 /**
@@ -23,8 +32,15 @@ interface SohoBlockGridOptions {
 interface SohoBlockGrid {
   settings: SohoBlockGridOptions;
 
-  /** Select a block */
-  selectBlock(activeBlock: JQuery<Node | Node[]>, isCheckbox: boolean): void;
+  pagerAPI?: SohoPagerStatic;
+
+  select(activeBlock: JQuery<HTMLElement>, isCheckbox: boolean): void;
+
+  /**
+   * @deprecated (use `select()`)
+   * Selects a block in the blockgrid
+   */
+  selectBlock(activeBlock: JQuery<HTMLElement>, isCheckbox: boolean): void;
 
   /** Updates the blockgrid with any new settings. */
   updated(settings?: SohoBlockGridOptions): void;

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
@@ -30,7 +30,7 @@ const pagingTestData = [
   { image: 'https://randomuser.me/api/portraits/med/women/17.jpg', title: 'Emily Bronte', subtitle: 'Infor, Architect' }
 ];
 
-fdescribe('Soho blockgrid Unit Tests', () => {
+describe('Soho blockgrid Unit Tests', () => {
   let comp: SohoBlockGridComponent;
   let fixture: ComponentFixture<SohoBlockGridComponent>;
   let de: DebugElement;
@@ -50,19 +50,21 @@ fdescribe('Soho blockgrid Unit Tests', () => {
 
   it('Check Inputs', () => {
     const emptyData: any[] = [];
-    const selectable: SohoBlockGridSelectable = 'single';
-    let paging = false;
+    let selectable: SohoBlockGridSelectable = 'single';
     let pageSize = 5;
     let pageSizes = [5, 10, 25];
 
     // check that block grid options buffer variable is working.
     comp.dataset = emptyData;
     comp.selectable = selectable;
-    comp.paging = paging;
+    comp.paging = false;
     comp.pagesize = pageSize;
     comp.pagesizes = pageSizes;
     expect(comp.dataset).toEqual(emptyData);
     expect(comp.selectable).toEqual(selectable);
+    expect(comp.paging).toBeFalsy();
+    expect(comp.pagesize).toEqual(pageSize);
+    expect(comp.pagesizes).toEqual(pageSizes);
 
     // detect changes to cause the blockgrid component to be built.
     fixture.detectChanges();
@@ -77,31 +79,37 @@ fdescribe('Soho blockgrid Unit Tests', () => {
     const updatedSpy = spyOn(comp, 'updated').and.callThrough();
     const blockgridUpdatedSpy = spyOn<any>((comp as any).blockgrid, 'updated');
 
-    const mixedSelectable: SohoBlockGridSelectable = 'mixed';
+    selectable = 'mixed';
     comp.dataset = blockGridTestData;
-    comp.selectable = mixedSelectable;
+    comp.selectable = selectable;
+    fixture.detectChanges();
 
     expect(comp.dataset).toEqual(blockGridTestData);
-    expect(comp.selectable).toEqual(mixedSelectable);
+    expect(comp.selectable).toEqual(selectable);
 
     expect(updatedSpy).toHaveBeenCalledTimes(2);
     expect(blockgridUpdatedSpy).toHaveBeenCalledTimes(2);
 
     // Check paging inputs
-    paging = true;
+    selectable = 'multiple';
     comp.dataset = pagingTestData;
-    comp.paging = paging;
+    comp.paging = true;
+    comp.selectable = selectable;
+    fixture.detectChanges();
 
     expect(comp.dataset).toEqual(pagingTestData);
-    expect(comp.paging).toEqual(paging);
+    expect(comp.paging).toBeTruthy();
+    expect(comp.selectable).toEqual(selectable);
 
     pageSize = 3;
     comp.pagesize = 3;
+    fixture.detectChanges();
 
     expect(comp.pagesize).toEqual(pageSize);
 
     pageSizes = [10, 20];
     comp.pagesizes = pageSizes;
+    fixture.detectChanges();
 
     expect(comp.pagesizes).toEqual(pageSizes);
   });

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.spec.ts
@@ -17,7 +17,20 @@ const blockGridTestData = [
   { img: 'https://randomuser.me/api/portraits/med/women/12.jpg', maintxt: 'Sheena Taylor', subtxt: 'Infor, Architect' }
 ];
 
-describe('Soho blockgrid Unit Tests', () => {
+const pagingTestData = [
+  { image: 'https://randomuser.me/api/portraits/med/women/8.jpg', title: 'Sheena Taylor', subtitle: 'Infor, Developer' },
+  { image: 'https://randomuser.me/api/portraits/med/women/9.jpg', title: 'Jane Taylor', subtitle: 'Infor, Developer' },
+  { image: 'https://randomuser.me/api/portraits/med/women/10.jpg', title: 'Sam Smith', subtitle: 'Infor, SVP' },
+  { image: 'https://randomuser.me/api/portraits/med/women/11.jpg', title: 'Mary Pane', subtitle: 'Infor, Developer' },
+  { image: 'https://randomuser.me/api/portraits/med/women/12.jpg', title: 'Paula Paulson', subtitle: 'Infor, Architect' },
+  { image: 'https://randomuser.me/api/portraits/med/women/13.jpg', title: 'Danielle Land', subtitle: 'Infor, Developer' },
+  { image: 'https://randomuser.me/api/portraits/med/women/14.jpg', title: 'Donna Horrocks', subtitle: 'Infor, Developer' },
+  { image: 'https://randomuser.me/api/portraits/med/women/15.jpg', title: 'Mary McConnel', subtitle: 'Infor, SVP' },
+  { image: 'https://randomuser.me/api/portraits/med/women/16.jpg', title: 'Julie Ayers', subtitle: 'Infor, Developer' },
+  { image: 'https://randomuser.me/api/portraits/med/women/17.jpg', title: 'Emily Bronte', subtitle: 'Infor, Architect' }
+];
+
+fdescribe('Soho blockgrid Unit Tests', () => {
   let comp: SohoBlockGridComponent;
   let fixture: ComponentFixture<SohoBlockGridComponent>;
   let de: DebugElement;
@@ -37,11 +50,17 @@ describe('Soho blockgrid Unit Tests', () => {
 
   it('Check Inputs', () => {
     const emptyData: any[] = [];
-    let selectable: SohoBlockGridSelectable = 'single';
+    const selectable: SohoBlockGridSelectable = 'single';
+    let paging = false;
+    let pageSize = 5;
+    let pageSizes = [5, 10, 25];
 
     // check that block grid options buffer variable is working.
     comp.dataset = emptyData;
     comp.selectable = selectable;
+    comp.paging = paging;
+    comp.pagesize = pageSize;
+    comp.pagesizes = pageSizes;
     expect(comp.dataset).toEqual(emptyData);
     expect(comp.selectable).toEqual(selectable);
 
@@ -58,21 +77,42 @@ describe('Soho blockgrid Unit Tests', () => {
     const updatedSpy = spyOn(comp, 'updated').and.callThrough();
     const blockgridUpdatedSpy = spyOn<any>((comp as any).blockgrid, 'updated');
 
-    selectable = 'mixed';
+    const mixedSelectable: SohoBlockGridSelectable = 'mixed';
     comp.dataset = blockGridTestData;
-    comp.selectable = selectable;
+    comp.selectable = mixedSelectable;
 
     expect(comp.dataset).toEqual(blockGridTestData);
-    expect(comp.selectable).toEqual(selectable);
+    expect(comp.selectable).toEqual(mixedSelectable);
 
     expect(updatedSpy).toHaveBeenCalledTimes(2);
     expect(blockgridUpdatedSpy).toHaveBeenCalledTimes(2);
+
+    // Check paging inputs
+    paging = true;
+    comp.dataset = pagingTestData;
+    comp.paging = paging;
+
+    expect(comp.dataset).toEqual(pagingTestData);
+    expect(comp.paging).toEqual(paging);
+
+    pageSize = 3;
+    comp.pagesize = 3;
+
+    expect(comp.pagesize).toEqual(pageSize);
+
+    pageSizes = [10, 20];
+    comp.pagesizes = pageSizes;
+
+    expect(comp.pagesizes).toEqual(pageSizes);
   });
 
   it('Check Outputs', () => {
     const selectable: SohoBlockGridSelectable = 'mixed';
-    comp.dataset = blockGridTestData;
+    comp.dataset = pagingTestData;
     comp.selectable = selectable;
+    comp.paging = true;
+    comp.pagesize = 3;
+    comp.pagesizes = [3, 5, 10, 20];
 
     // detect changes to cause the blockgrid component to be built.
     fixture.detectChanges();
@@ -82,6 +122,8 @@ describe('Soho blockgrid Unit Tests', () => {
     TestHelper.testFireEvent(comp['element'].nativeElement, 'deselected', comp['deselected']);
     TestHelper.testFireEvent(comp['element'].nativeElement, 'activated', comp['activated']);
     TestHelper.testFireEvent(comp['element'].nativeElement, 'deactivated', comp['deactivated']);
+    TestHelper.testFireEvent(comp['element'].nativeElement, 'page', comp['page']);
+    TestHelper.testFireEvent(comp['element'].nativeElement, 'pagesizechange', comp['pagesizechange']);
   });
 
   it('Check public functions', () => {
@@ -93,31 +135,31 @@ describe('Soho blockgrid Unit Tests', () => {
     expect((comp as any).blockgrid).not.toBeUndefined();
 
     // check activateBlock happy path
-    const selectBlockSpy = spyOn((comp as any).blockgrid, 'selectBlock');
+    const selectSpy = spyOn((comp as any).blockgrid, 'select');
     comp.activateBlock(1);
-    expect(selectBlockSpy).toHaveBeenCalledTimes(1);
-    expect(selectBlockSpy.calls.mostRecent().args.length).toEqual(2);
-    expect(selectBlockSpy.calls.mostRecent().args[1]).toEqual(false);
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+    expect(selectSpy.calls.mostRecent().args.length).toEqual(2);
+    expect(selectSpy.calls.mostRecent().args[1]).toEqual(false);
 
     // check activateBlock safety checks
-    selectBlockSpy.calls.reset();
+    selectSpy.calls.reset();
     comp.activateBlock(-1); // lower out of bounds index
-    expect(selectBlockSpy).not.toHaveBeenCalled();
+    expect(selectSpy).not.toHaveBeenCalled();
     comp.activateBlock(5); // upper out of bounds index
-    expect(selectBlockSpy).not.toHaveBeenCalled();
+    expect(selectSpy).not.toHaveBeenCalled();
 
     // check deactivateBlock
-    selectBlockSpy.calls.reset();
+    selectSpy.calls.reset();
     comp.deactivateBlock();
-    expect(selectBlockSpy).toHaveBeenCalledTimes(1);
-    expect(selectBlockSpy.calls.mostRecent().args.length).toEqual(2);
-    expect(selectBlockSpy.calls.mostRecent().args[1]).toEqual(false);
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+    expect(selectSpy.calls.mostRecent().args.length).toEqual(2);
+    expect(selectSpy.calls.mostRecent().args[1]).toEqual(false);
 
-    selectBlockSpy.calls.reset();
+    selectSpy.calls.reset();
     comp.selectBlocks([2, 3]);
-    expect(selectBlockSpy).toHaveBeenCalledTimes(1);
-    expect(selectBlockSpy.calls.mostRecent().args.length).toEqual(2);
-    expect(selectBlockSpy.calls.mostRecent().args[1]).toEqual(true);
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+    expect(selectSpy.calls.mostRecent().args.length).toEqual(2);
+    expect(selectSpy.calls.mostRecent().args[1]).toEqual(true);
 
     // todo: Cannot test deselectBlock functionality. No EP API in blockgrid.js is available. 2/19/2019
   });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { BlockGridCustomContentDemoComponent } from './blockgrid/blockgrid-custo
 import { BlockGridMixedSelectionDemoComponent } from './blockgrid/blockgrid-mixed-selection.demo';
 import { BlockGridMultiSelectionDemoComponent } from './blockgrid/blockgrid-multi-selection.demo';
 import { BlockGridSingleSelectionDemoComponent } from './blockgrid/blockgrid-single-selection.demo';
+import { BlockGridPagingDemoComponent } from './blockgrid/blockgrid-paging.demo';
 import { BreadcrumbDemoComponent } from './breadcrumb/breadcrumb.demo';
 import { BreadcrumbGauntletDemoComponent } from './breadcrumb/breadcrumb-gauntlet.demo';
 import { BubbleDemoComponent } from './bubble/bubble.demo';
@@ -256,6 +257,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     BlockGridMixedSelectionDemoComponent,
     BlockGridMultiSelectionDemoComponent,
     BlockGridSingleSelectionDemoComponent,
+    BlockGridPagingDemoComponent,
     BreadcrumbDemoComponent,
     BreadcrumbGauntletDemoComponent,
     BubbleDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { BlockGridCustomContentDemoComponent } from './blockgrid/blockgrid-custo
 import { BlockGridMixedSelectionDemoComponent } from './blockgrid/blockgrid-mixed-selection.demo';
 import { BlockGridMultiSelectionDemoComponent } from './blockgrid/blockgrid-multi-selection.demo';
 import { BlockGridSingleSelectionDemoComponent } from './blockgrid/blockgrid-single-selection.demo';
+import { BlockGridPagingDemoComponent } from './blockgrid/blockgrid-paging.demo';
 import { BreadcrumbDemoComponent } from './breadcrumb/breadcrumb.demo';
 import { BreadcrumbGauntletDemoComponent } from './breadcrumb/breadcrumb-gauntlet.demo';
 import { BubbleDemoComponent } from './bubble/bubble.demo';
@@ -207,6 +208,7 @@ export const routes: Routes = [
   { path: 'blockgrid-mixed-selection', component: BlockGridMixedSelectionDemoComponent },
   { path: 'blockgrid-multi-selection', component: BlockGridMultiSelectionDemoComponent },
   { path: 'blockgrid-single-selection', component: BlockGridSingleSelectionDemoComponent },
+  { path: 'blockgrid-paging', component: BlockGridPagingDemoComponent },
   { path: 'bubble', component: BubbleDemoComponent },
   { path: 'bullet', component: BulletDemoComponent },
   { path: 'button', component: ButtonDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -23,6 +23,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-custom-content']"><span>BlockGrid - Custom Content</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-mixed-selection']"><span>BlockGrid - Mixed Selection</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-multi-selection']"><span>BlockGrid - Multi Selection</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['blockgrid-paging']"><span>BlockGrid - Paging</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-single-selection']"><span>BlockGrid - Single Selection</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['breadcrumb']"><span>Breadcrumb</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['breadcrumb-gauntlet']"><span>Breadcrumb Gauntlet</span></a></div>

--- a/src/app/blockgrid/blockgrid-demo-data.ts
+++ b/src/app/blockgrid/blockgrid-demo-data.ts
@@ -3,5 +3,10 @@ export const DATA = [
   { image: 'https://randomuser.me/api/portraits/med/women/9.jpg', title: 'Jane Taylor', subtitle: 'Infor, Developer' },
   { image: 'https://randomuser.me/api/portraits/med/women/10.jpg', title: 'Sam Smith', subtitle: 'Infor, SVP' },
   { image: 'https://randomuser.me/api/portraits/med/women/11.jpg', title: 'Mary Pane', subtitle: 'Infor, Developer' },
-  { image: 'https://randomuser.me/api/portraits/med/women/12.jpg', title: 'Paula Paulson', subtitle: 'Infor, Architect' }
+  { image: 'https://randomuser.me/api/portraits/med/women/12.jpg', title: 'Paula Paulson', subtitle: 'Infor, Architect' },
+  { image: 'https://randomuser.me/api/portraits/med/women/13.jpg', title: 'Danielle Land', subtitle: 'Infor, Developer' },
+  { image: 'https://randomuser.me/api/portraits/med/women/14.jpg', title: 'Donna Horrocks', subtitle: 'Infor, Developer' },
+  { image: 'https://randomuser.me/api/portraits/med/women/15.jpg', title: 'Mary McConnel', subtitle: 'Infor, SVP' },
+  { image: 'https://randomuser.me/api/portraits/med/women/16.jpg', title: 'Julie Ayers', subtitle: 'Infor, Developer' },
+  { image: 'https://randomuser.me/api/portraits/med/women/17.jpg', title: 'Emily Bronte', subtitle: 'Infor, Architect' }
 ];

--- a/src/app/blockgrid/blockgrid-paging.demo.html
+++ b/src/app/blockgrid/blockgrid-paging.demo.html
@@ -1,0 +1,16 @@
+<div class="row">
+  <div class="twelve columns">
+    <h1 class="section-title">Block Grid Paging</h1>
+    <div soho-blockgrid
+      [dataset]="data"
+      [selectable]="'single'"
+      (selected)="onSelected($event)"
+      (deselected)="onDeselected($event)"
+      [paging]=true
+      [pagesize]=3
+      [pagesizes]="[3, 5, 10, 25]"
+      (page)="onPage($event)"
+      (pagesizechange)="onPageSizeChange($event)">
+    </div>
+  </div>
+</div>

--- a/src/app/blockgrid/blockgrid-paging.demo.ts
+++ b/src/app/blockgrid/blockgrid-paging.demo.ts
@@ -1,0 +1,39 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  ViewChild
+} from '@angular/core';
+
+import {
+  DATA
+} from './blockgrid-demo-data';
+
+@Component({
+  selector: 'app-blockgrid-paging-demo',
+  templateUrl: 'blockgrid-paging.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BlockGridPagingDemoComponent {
+
+  constructor(private elementRef: ElementRef) {
+  }
+
+  public data = DATA;
+
+  onSelected(args) {
+    console.log('onSelected', args);
+  }
+
+  onDeselected(args) {
+    console.log('onDeselect', args);
+  }
+
+  onPage(args) {
+    console.log('onPage', args);
+  }
+
+  onPageSizeChange(args) {
+    console.log('onPageSizeChange', args);
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR extends the existing IDS Enterprise Blockgrid API to include its pager controls.  This PR also adds tests for the feature and a demo page.  

**Related github/jira issue (required)**:
- Closes #836 
- Depends on infor-design/enterprise#4204 to be merged to EP `master`

**Steps necessary to review your pull request (required)**:
- Pull this branch.  If necessary, pull, build and link infor-design/enterprise#4204.  Then build, and run the NG demoapp.
- Open http://localhost:4200/ids-enterprise-ng-demo/blockgrid-paging
- Try the paging controls and make sure they work.  Check a dev tools console and make sure the `page` and `pagesizeselector` events are being captured.
