### PR TITLE
836 - Followup Fixes for enabling Blockgrid Pager [v7.5.x]

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.component.ts
@@ -20,6 +20,15 @@ import {
 })
 export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
 
+  /** Options. */
+  private options: SohoBlockGridOptions = {
+    pagerSettings: {
+      position: 'bottom'
+    }
+  };
+  private jQueryElement: JQuery;
+  private blockgrid: SohoBlockGrid;
+
   @HostBinding('class.blockgrid') get isBlockGrid() {
     return true;
   }
@@ -75,34 +84,34 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
 
   /** Defines the current page size */
   @Input()
-  public set pagesize(pagesize: Number) {
-    this.options.pagesize = pagesize;
+  public set pagesize(pagesize: number) {
+    this.options.pagerSettings.pagesize = pagesize;
     if (this.blockgrid) {
-      this.blockgrid.settings.pagesize = pagesize;
+      this.blockgrid.settings.pagerSettings.pagesize = pagesize;
       this.updated(this.blockgrid.settings);
     }
   }
-  public get pagesize(): Number {
+  public get pagesize(): number {
     if (!this.blockgrid) {
-      return this.options.pagesize;
+      return this.options.pagerSettings.pagesize;
     }
-    return this.blockgrid.settings.pagesize;
+    return this.blockgrid.settings.pagerSettings.pagesize;
   }
 
   /** Defines the array of selectable page sizes */
   @Input()
-  public set pagesizes(pagesizes: Array<Number>) {
-    this.options.pagesizes = pagesizes;
+  public set pagesizes(pagesizes: Array<number>) {
+    this.options.pagerSettings.pagesizes = pagesizes;
     if (this.blockgrid) {
-      this.blockgrid.settings.pagesizes = pagesizes;
+      this.blockgrid.settings.pagerSettings.pagesizes = pagesizes;
       this.updated(this.blockgrid.settings);
     }
   }
-  public get pagesizes(): Array<Number> {
+  public get pagesizes(): Array<number> {
     if (!this.blockgrid) {
-      return this.options.pagesizes;
+      return this.options.pagerSettings.pagesizes;
     }
-    return this.blockgrid.settings.pagesizes;
+    return this.blockgrid.settings.pagerSettings.pagesizes;
   }
 
   /* Events*/
@@ -112,11 +121,6 @@ export class SohoBlockGridComponent implements AfterViewInit, OnDestroy {
   @Output() deactivated: EventEmitter<Object[]> = new EventEmitter<Object[]>();
   @Output() page: EventEmitter<Object[]> = new EventEmitter<Object[]>();
   @Output() pagesizechange: EventEmitter<Object[]> = new EventEmitter<Object[]>();
-
-  /** Options. */
-  private options: SohoBlockGridOptions = {};
-  private jQueryElement: JQuery;
-  private blockgrid: SohoBlockGrid;
 
   constructor(
     private element: ElementRef,

--- a/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/blockgrid/soho-blockgrid.d.ts
@@ -19,10 +19,21 @@ interface SohoBlockGridOptions {
   /** If true, enables paging in the Blockgrid */
   paging?: boolean;
 
-  /** If paging is active, defines the number of records allowed on the current page */
+  /**
+   * If defined, passes along a set of Pager options to the inline Pager.
+   */
+  pagerSettings: SohoPagerOptions;
+
+  /**
+   * @deprecated
+   * If paging is active, defines the number of records allowed on the current page
+   */
   pagesize?: Number;
 
-  /** If paging is active, defines the various record sizes the pager will allow */
+  /**
+   * @deprecated
+   * If paging is active, defines the various record sizes the pager will allow
+   */
   pagesizes?: Array<Number>;
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug discovered in the Blockgrid Pager, where it was incorrectly showing the first and last pager buttons.  By default, the inline Blockgrid pager doesn't show these buttons.  This PR changes the Soho Blockgrid types to allow for the definition of a full Pager settings object and sets the standard defaults.

**Related github/jira issue (required)**:
Related to #836 
Depends on infor-design/enterprise#4216

**Steps necessary to review your pull request (required)**:
- Pull this branch.  If necessary, link the `ids-enterprise` project using the [corresponding branch of EP](https://github.com/infor-design/enterprise/pull/4216).
- Build and run the NG demoapp
- Open http://localhost:4200/ids-enterprise-ng-demo/blockgrid-paging.  Observe that the pager should not be showing the "First" and "Last" pager buttons (only Next/Previous/Page Size Selector).  Also check that no JS errors related to the `pagerSettings` object occur.