### PR TITLE
860 - Expose Tabs `handleResize()`, Add homepages demo for resizing

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
@@ -570,9 +570,9 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
   /**
    * Call resize manually when tab titles change so that the underline width matches.
    */
-  public handleResize(): void {
+  public handleResize(doResponsiveCheck?: boolean): void {
     // call outside the angular zone so change detection isn't triggered by the soho component.
-    this.ngZone.runOutsideAngular(() => this.tabs.handleResize());
+    this.ngZone.runOutsideAngular(() => this.tabs.handleResize(doResponsiveCheck));
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.d.ts
@@ -80,7 +80,8 @@ interface SohoTabsStatic {
 
   enable(): void;
 
-  handleResize(): void;
+  /** Manually refreshes the component, with an optional check to swap the component to/from responsive mode (if applicable). */
+  handleResize(doResponsiveCheck?: boolean): void;
 
   /**
    * Destructor,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -194,6 +194,7 @@ import { TabsDataDrivenDemoComponent } from './tabs/tabs-datadriven.demo';
 import { TabsDismissibleDemoComponent } from './tabs/tabs-dismissible.demo';
 import { TabsDropdownDemoComponent } from './tabs/tabs-dropdown.demo';
 import { TabsDynamicDemoComponent } from './tabs/tabs-dynamic.demo';
+import { TabsResizeDemoComponent } from './tabs/tabs-resize.demo';
 import { TabsModuleDemoComponent } from './tabs/tabs-module.demo';
 import { TabsVerticalDemoComponent } from './tabs/tabs-vertical.demo';
 import { TagDemoComponent } from './tag/tag.demo';
@@ -412,6 +413,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     TabsDismissibleDemoComponent,
     TabsDropdownDemoComponent,
     TabsDynamicDemoComponent,
+    TabsResizeDemoComponent,
     TabsModuleDemoComponent,
     TabsVerticalDemoComponent,
     TagDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -150,6 +150,7 @@ import { TabsDataDrivenDemoComponent } from './tabs/tabs-datadriven.demo';
 import { TabsDismissibleDemoComponent } from './tabs/tabs-dismissible.demo';
 import { TabsDropdownDemoComponent } from './tabs/tabs-dropdown.demo';
 import { TabsDynamicDemoComponent } from './tabs/tabs-dynamic.demo';
+import { TabsResizeDemoComponent } from './tabs/tabs-resize.demo';
 import { TabsModuleDemoComponent } from './tabs/tabs-module.demo';
 import { TabsVerticalDemoComponent } from './tabs/tabs-vertical.demo';
 import { TagDemoComponent } from './tag/tag.demo';
@@ -348,6 +349,7 @@ export const routes: Routes = [
   { path: 'tabs-dismissible', component: TabsDismissibleDemoComponent },
   { path: 'tabs-dropdown', component: TabsDropdownDemoComponent },
   { path: 'tabs-dynamic', component: TabsDynamicDemoComponent },
+  { path: 'tabs-resize', component: TabsResizeDemoComponent },
   { path: 'tabs-module', component: TabsModuleDemoComponent },
   { path: 'tabs-vertical', component: TabsVerticalDemoComponent },
   { path: 'tags', component: TagDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -232,6 +232,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['tabs-dropdown']"><span>Tabs - Dropdown</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tabs-datadriven']"><span>Tabs - Data-driven</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tabs-dynamic']"><span>Tabs - Dynamic</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['tabs-resize']"><span>Tabs - Resize</span></a></div> 
     <div class="accordion-header list-item"><a [routerLink]="['tabs-module']">Tabs - Module</a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tabs-vertical']"><span>Tabs - Vertical</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tags']"><span>Tags</span></a></div>

--- a/src/app/tabs/tabs-resize.demo.css
+++ b/src/app/tabs/tabs-resize.demo.css
@@ -1,0 +1,10 @@
+.draggable-container {
+  max-height: 500px;
+  overflow: hidden;
+  resize: both;
+}
+
+.tab-panel-container {
+  overflow: scroll;
+  max-height: inherit;
+}

--- a/src/app/tabs/tabs-resize.demo.html
+++ b/src/app/tabs/tabs-resize.demo.html
@@ -1,0 +1,51 @@
+<div class="row">
+    <section class="six columns">
+        <p>Use the resize handle to resize the tabbed section below. The "more" menu, separator, and gradient is present even if the element is sized such that all the tabs should fit.</p>
+        <p>You can force it to update by triggering a</p>
+        <p>
+          <button soho-button="primary" (click)="triggerResize()">
+            <span>Window Resize Event</span>
+          </button>
+        </p>
+    </section>
+</div>
+<div class="row top-padding">
+    <section class="draggable-container three columns">
+        <div soho-tabs>
+            <div soho-tab-list-container>
+                <ul soho-tab-list>
+                    <li soho-tab>
+                        <a soho-tab-title tabId="tab-a">
+                            Tab Section A
+                        </a>
+                    </li>
+                    <li soho-tab>
+                        <a soho-tab-title tabId="tab-b">
+                            Tab Section B
+                        </a>
+                    </li>
+                    <li soho-tab>
+                        <a soho-tab-title tabId="tab-c">
+                            Tab Section C
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div soho-tab-panel-container>
+            <div soho-tab-panel tabId="tab-a">
+                <h1>Tab A</h1>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            </div>
+            <div soho-tab-panel tabId="tab-b">
+                <h1>Tab B</h1>
+            </div>
+            <div soho-tab-panel tabId="tab-c">
+                <h1>Tab C</h1>
+            </div>
+        </div>
+    </section>
+</div>

--- a/src/app/tabs/tabs-resize.demo.ts
+++ b/src/app/tabs/tabs-resize.demo.ts
@@ -1,0 +1,17 @@
+import { Component, HostListener } from '@angular/core';
+
+@Component({
+  selector: 'app-tabs',
+  templateUrl: './tabs-resize.demo.html',
+  styleUrls: ['./tabs-resize.demo.css']
+})
+export class TabsResizeDemoComponent {
+
+  @HostListener('window:resize') resized() {
+    console.log(`Window resized. Width:${window.innerWidth}, Height:${window.innerHeight}`);
+  }
+
+  triggerResize() {
+    window.dispatchEvent(new Event('resize'));
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR helps along an enhancement to the IDS Enterprise Tabs, which enables internal detection for when the element is resized by way of a `ResizeObserver`.  The PR contains:
- Properly exposing `handleResize()` in the NG wrappers by optionally allowing for responsive checks (enables programmatic control of refreshing the Tab List's current state)
- Adding a similar test to @anhallbe's example provided in the original issue. 

**Related github/jira issue (required)**:
Closes #860
Depends on infor-design/enterprise#4229

**Steps necessary to review your pull request (required)**:
- Pull this branch.  If necessary, link the contents of [IDS Enterprise PR#4229](infor-design/enterprise#4229), build, and run the NG demoapp.
- Open http://localhost:4200/ids-enterprise-ng-demo/tabs-resize
- Observe at the bottom-right of the Tab Panel area is a draggable handle.  When dragging this handle, the Tab List's state should automatically update, causing the "More Tabs" button to disappear when no Tabs are overflowed, and reappear when there are Tabs overflowed.