### PR TITLE
885 - Add fix / example for multiselect dropdown issues [v4.31.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,8 @@
 - `[General]` Uses EP version 4.31.0.  `TJM`
 - `[General]` Added several new types in Modal, Datepicker, Message and EmptyMessage from 4.31. `TJM` ([#3609](https://github.com/infor-design/enterprise/issues/3609))
 - `[Lookup]` Fixed an issue where the console error was appearing after the modal close. ([#871](https://github.com/infor-design/enterprise/issues/871))
-- `[Masthead]` Updated styles and flow in the masthead and made it use flex toolbar by default. Older versions should work ok but you may want to update to the latest markup. See `masthead.demo.html`. ([#800](https://github.com/infor-design/enterprise-ng/issues/800))
+- `[Masthead]` Updated styles and flow in the masthead and made it use flex toolbar by default. Older versions should work ok but you may want to update to the latest markup. See `masthead.demo.html`. ([#800](https://github.com/infor-design/enterprise-ng/issues/800
+- `[Multiselect]` Added an example showing how an ajax request where only part the results are returned. ([#800](https://github.com/infor-design/enterprise-ng/issues/885))
 
 ## v7.4.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `[General]` Uses EP version 4.31.0.  `TJM`
 - `[General]` Added several new types in Modal, Datepicker, Message and EmptyMessage from 4.31. `TJM` ([#3609](https://github.com/infor-design/enterprise/issues/3609))
 - `[Lookup]` Fixed an issue where the console error was appearing after the modal close. ([#871](https://github.com/infor-design/enterprise/issues/871))
-- `[Masthead]` Updated styles and flow in the masthead and made it use flex toolbar by default. Older versions should work ok but you may want to update to the latest markup. See `masthead.demo.html`. ([#800](https://github.com/infor-design/enterprise-ng/issues/800
+- `[Masthead]` Updated styles and flow in the masthead and made it use flex toolbar by default. Older versions should work ok but you may want to update to the latest markup. See `masthead.demo.html`. ([#800](https://github.com/infor-design/enterprise-ng/issues/800))
 - `[Multiselect]` Added an example showing how an ajax request where only part the results are returned. ([#800](https://github.com/infor-design/enterprise-ng/issues/885))
 
 ## v7.4.1

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -118,6 +118,7 @@ import { DropdownAsyncBusyDemoComponent } from './dropdown/dropdown-async-busy.d
 import { DropdownAsyncDemoComponent } from './dropdown/dropdown-async.demo';
 import { DropdownDemoComponent } from './dropdown/dropdown.demo';
 import { DropdownMultiselectDemoComponent } from './dropdown/dropdown-multiselect.demo';
+import { DropdownMultiselectLandmarkDemoComponent } from './dropdown/dropdown-multiselect-landmark.demo';
 import { DropdownReactiveDemoComponent } from './dropdown/dropdown-reactive.demo';
 import { DropdownSimpleDemoComponent } from './dropdown/dropdown-simple.demo';
 import { DropdownTypeaheadDemoComponent } from './dropdown/dropdown-typeahead.demo';
@@ -338,6 +339,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     DropdownAsyncDemoComponent,
     DropdownDemoComponent,
     DropdownMultiselectDemoComponent,
+    DropdownMultiselectLandmarkDemoComponent,
     DropdownReactiveDemoComponent,
     DropdownSimpleDemoComponent,
     DropdownTypeaheadDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -80,6 +80,7 @@ import { DropdownAsyncBusyDemoComponent } from './dropdown/dropdown-async-busy.d
 import { DropdownAsyncDemoComponent } from './dropdown/dropdown-async.demo';
 import { DropdownDemoComponent } from './dropdown/dropdown.demo';
 import { DropdownMultiselectDemoComponent } from './dropdown/dropdown-multiselect.demo';
+import { DropdownMultiselectLandmarkDemoComponent } from './dropdown/dropdown-multiselect-landmark.demo';
 import { DropdownReactiveDemoComponent } from './dropdown/dropdown-reactive.demo';
 import { DropdownSimpleDemoComponent } from './dropdown/dropdown-simple.demo';
 import { DropdownTypeaheadDemoComponent } from './dropdown/dropdown-typeahead.demo';
@@ -276,6 +277,7 @@ export const routes: Routes = [
   { path: 'dropdown-async-busy', component: DropdownAsyncBusyDemoComponent },
   { path: 'dropdown-async', component: DropdownAsyncDemoComponent },
   { path: 'dropdown-multi', component: DropdownMultiselectDemoComponent },
+  { path: 'dropdown-multi-landmark', component: DropdownMultiselectLandmarkDemoComponent },
   { path: 'dropdown-reactive', component: DropdownReactiveDemoComponent },
   { path: 'dropdown-simple', component: DropdownSimpleDemoComponent },
   { path: 'dropdown-typeahead', component: DropdownTypeaheadDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -103,6 +103,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['dropdown-async']"><span>Dropdown - Async</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['dropdown-async-busy']"><span>Dropdown - Async Busy</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['dropdown-multi']"><span>Dropdown - Multi-Select</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['dropdown-multi-landmark']"><span>Dropdown - Multi-Select (Keep Selected)</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['dropdown-reactive']"><span>Dropdown - Reactive Form</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['dropdown']"><span>Dropdown - Single-Select</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['dropdown-simple']"><span>Dropdown - Simple</span></a></div>

--- a/src/app/dropdown/dropdown-multiselect-landmark.demo.html
+++ b/src/app/dropdown/dropdown-multiselect-landmark.demo.html
@@ -1,0 +1,31 @@
+<form>
+  <div class="row top-padding">
+    <div class="twelve columns">
+      <p>This example show a case where values are initially selected and when you request new data by typing only part the values are brought back. Type c and Alaska and California should remain selected</p>
+      <br />
+      <div class="field">
+        <label for="states-multi-source-alpha" class="label">Using alpha source & tooltip</label>
+        <select soho-dropdown name="states-multi-source-alpha" id="states-multi-source-alpha" multiple [source]="sourceAlpha" [showSearchUnderSelected]="true" [reload]="'typeahead'" [moveSelected]="'all'"
+                soho-tooltip content="{{stateAsText}}" [(ngModel)]="model.value">
+          <option *ngFor="let option of model.options" selected="{{option.selected}}" [value]="option.value">{{option.label}}</option>
+        </select>
+      </div>
+      <div class="field">
+        <label for="states-multi-source-alpha-ro" class="label">Readonly using alpha source & tooltip</label>
+        <select soho-dropdown name="states-multi-source-alpha-ro" id="states-multi-source-alpha-ro" readOnly multiple [source]="sourceAlpha"
+                soho-tooltip content="{{stateAsText}}" [(ngModel)]="model.value">
+          <option *ngFor="let option of model.options" selected="{{option.selected}}" [value]="option.value">{{option.label}}</option>
+        </select>
+      </div>
+    </div>
+      <div class="row">
+        <div class="twelve columns">
+          <button soho-button (click)="toggleModel()">{{showModel ? 'Hide' : 'Show'}} Model</button>
+          <div *ngIf="showModel">
+            <hr>
+            <h3>{{ model | json }}</h3>
+          </div>
+        </div>
+      </div>
+  </div>
+</form>

--- a/src/app/dropdown/dropdown-multiselect-landmark.demo.ts
+++ b/src/app/dropdown/dropdown-multiselect-landmark.demo.ts
@@ -1,0 +1,140 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnInit,
+  ViewChild
+} from '@angular/core';
+
+import { SohoDropDownComponent } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-dropdown-multiselect-landmark-demo',
+  templateUrl:     './dropdown-multiselect-landmark.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DropdownMultiselectLandmarkDemoComponent implements OnInit {
+  @ViewChild(SohoDropDownComponent) dropdown: SohoDropDownComponent;
+  @ViewChild(SohoDropDownComponent, { read: ElementRef }) dropdownElement: ElementRef;
+
+  public counter = 0;
+  public model: Options = {
+    value: [ 'AK', 'CA' ],
+    options: [
+      { value: 'AK', label: 'Alaska', selected: true },
+      { value: 'CA', label: 'California', selected: true }
+    ]
+  };
+
+  public showModel = false;
+
+  private statesAlpha: Array<OptionValue> = [
+    { value: 'AK', label: 'Alaska' },
+    { value: 'AZ', label: 'Arizona' },
+    { value: 'CA', label: 'California' },
+    { value: 'CO', label: 'Colorado' },
+    { value: 'MN', label: 'Minnesota' },
+    { value: 'ND', label: 'North Dakota' },
+    { value: 'OR', label: 'Oregon' },
+    { value: 'WA', label: 'Washington' },
+    { value: 'WY', label: 'Wyoming' }
+  ];
+
+  private aStates: Array<OptionValue> = [
+    { value: 'AL', label: 'Alabama' },
+    { value: 'AK', label: 'Alaska' },
+    { value: 'AS', label: 'American Samoa' },
+    { value: 'AZ', label: 'Arizona' },
+    { value: 'AR', label: 'Arkansas' }];
+
+  private ctodStates: Array<OptionValue> = [
+    { value: 'CA', label: 'California' },
+    { value: 'CO', label: 'Colorado' },
+    { value: 'CT', label: 'Connecticut' },
+    { value: 'DE', label: 'Delaware' },
+    { value: 'DC', label: 'District Of Columbia' },
+    { value: 'FM', label: 'Federated States Of Micronesia' },
+    { value: 'FL', label: 'Florida' },
+    { value: 'GA', label: 'Georgia' },
+    { value: 'GU', label: 'Guam'
+    }];
+
+  constructor() {}
+  ngOnInit() {}
+
+  toggleModel() {
+    this.showModel = !this.showModel;
+  }
+
+  sourceAlpha = (response: SohoDropDownResponseFunction, searchTerm: any) => {
+    const responseValues = [];
+    const selectedValues = this.dropdownElement.nativeElement.querySelectorAll('option:checked');
+
+    for (let i = 0; i < selectedValues.length; i++) {
+      const optionValue = selectedValues[i].value;
+      const array = optionValue.split(':');
+      const tempValue1 = array[1];
+      const tempValue2 = tempValue1.split('\'');
+      const finalValue = tempValue2[1];
+
+      responseValues.push({
+        value: finalValue,
+        label: selectedValues[i].label,
+        selected: true
+      });
+    }
+
+    if (searchTerm.length > 0 && searchTerm === 'c') {
+      const diff = this.diffContains(this.ctodStates, responseValues);
+
+      const returnArray = diff.concat(this.ctodStates);
+      this.model.options = returnArray;
+      response(returnArray, true);
+    } else {
+      const diff = this.diffContains(this.aStates, responseValues);
+
+      const returnArray = diff.concat(this.aStates);
+      this.model.options = returnArray;
+      response(returnArray, true);
+    }
+  }
+
+  private diffContains(containsArray, valueArray): Array<OptionValue> {
+    let diffArray = [];
+    if (containsArray.length < 1) {
+      return valueArray;
+    }
+
+    diffArray = valueArray.filter(x => !this.arrayContains(containsArray, x.value));
+    return diffArray;
+  }
+
+  private arrayContains(array, value): boolean {
+    return array.find(x => x.value === value);
+  }
+
+  public get stateAsText(): string {
+    if (this.model.options.length > 0) {
+      return this.model.options.filter( (state) => {
+        if (this.model.value.includes(state.value)) {
+          return state;
+        }
+      }).map( (state) => {
+        return state.label;
+      }).join(', ');
+    }
+
+    return '';
+  }
+}
+
+interface Options {
+  value: any;
+  options: Array<OptionValue>;
+}
+
+interface OptionValue {
+  value: any;
+  label: string;
+  selected ?: boolean;
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds an example in combination with https://github.com/infor-design/enterprise/pull/4246 that shows that its possible to make ajax work with NG when you return incomplete results

**Related github/jira issue (required)**:
Fixes #885 

**Steps necessary to review your pull request (required)**:
- get the branch from https://github.com/infor-design/enterprise/pull/4246 and build and npm link or copy into node_modules/ids-enterprise
- run this branch (npm run build && npm run start)
- go to http://localhost:4200/ids-enterprise-ng-demo/dropdown-multi-landmark
- type "c"
- alaska and california should stay selected even tho they arent both in the result set returned from the ajax call