### PR TITLE
890 timepicker typings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[General]` Added several new types in Modal, Datepicker, Message and EmptyMessage from 4.31. `TJM` ([#3609](https://github.com/infor-design/enterprise/issues/3609))
 - `[Lookup]` Fixed an issue where the console error was appearing after the modal close. ([#871](https://github.com/infor-design/enterprise/issues/871))
 - `[Masthead]` Updated styles and flow in the masthead and made it use flex toolbar by default. Older versions should work ok but you may want to update to the latest markup. See `masthead.demo.html`. ([#800](https://github.com/infor-design/enterprise-ng/issues/800))
+- `[TimePicker]` Updated typings support for locale, language, secondInterval, parentElement and returnFocus. `MAF` ([#890](https://github.com/infor-design/enterprise-ng/issues/890))
 
 ## v7.4.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `[General]` Added several new types in Modal, Datepicker, Message and EmptyMessage from 4.31. `TJM` ([#3609](https://github.com/infor-design/enterprise/issues/3609))
 - `[Lookup]` Fixed an issue where the console error was appearing after the modal close. ([#871](https://github.com/infor-design/enterprise/issues/871))
 - `[Masthead]` Updated styles and flow in the masthead and made it use flex toolbar by default. Older versions should work ok but you may want to update to the latest markup. See `masthead.demo.html`. ([#800](https://github.com/infor-design/enterprise-ng/issues/800))
-- `[TimePicker]` Updated typings support for locale, language, secondInterval, parentElement and returnFocus. `MAF` ([#890](https://github.com/infor-design/enterprise-ng/issues/890))
+- `[TimePicker]` Updated typings support for locale, language, secondInterval, parentElement and returnFocus. Updated timepicker demo. `MAF` ([#890](https://github.com/infor-design/enterprise-ng/issues/890))
 
 ## v7.4.1
 

--- a/projects/ids-enterprise-ng/src/lib/timepicker/soho-timepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/timepicker/soho-timepicker.component.ts
@@ -39,7 +39,12 @@ export class SohoTimePickerComponent extends BaseControlValueAccessor<any> imple
     mode: undefined,
     timeFormat: undefined,
     minuteInterval: undefined,
-    roundToInterval: false
+    roundToInterval: false,
+    locale: undefined,
+    language: undefined,
+    secondInterval: undefined,
+    parentElement: undefined,
+    returnFocus: true
   };
 
   /**
@@ -78,6 +83,58 @@ export class SohoTimePickerComponent extends BaseControlValueAccessor<any> imple
    */
   @Input() set roundToInterval(roundToInterval: boolean) {
     this.options.roundToInterval = roundToInterval;
+    if (this.timepicker) {
+      this.markForRefresh();
+    }
+  }
+
+  /**
+   * The name of the locale to use for this instance. If not set, the current locale will be used.
+   */
+  @Input() set locale(locale: string) {
+    this.options.locale = locale;
+    if (this.timepicker) {
+      this.markForRefresh();
+    }
+  }
+
+  /**
+   * The name of the language to use for this instance. If not set, the current locale will be used or the the passed locale will be used.
+   */
+  @Input() set language(language: string) {
+    this.options.language = language;
+    if (this.timepicker) {
+      this.markForRefresh();
+    }
+  }
+
+  /**
+   * An integer from 1 to 60; multiples of this value are displayed as options in the seconds dropdown;
+   * default value is 5.
+   */
+  @Input() set secondInterval(secondInterval: number) {
+    this.options.secondInterval = secondInterval;
+    if (this.timepicker) {
+      this.markForRefresh();
+    }
+  }
+
+  /**
+   * If defined as a JQuery-wrapped element, will be used as the target element.
+   */
+  @Input() set parentElement(parentElement: JQuery) {
+    this.options.parentElement = parentElement;
+    if (this.timepicker) {
+      this.markForRefresh();
+    }
+  }
+
+  /**
+   * If set to false, focus will not be returned to the calling element;
+   * default value is true.
+   */
+  @Input() set returnFocus(returnFocus: boolean) {
+    this.options.returnFocus = returnFocus;
     if (this.timepicker) {
       this.markForRefresh();
     }

--- a/projects/ids-enterprise-ng/src/lib/timepicker/soho-timepicker.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/timepicker/soho-timepicker.d.ts
@@ -20,6 +20,21 @@ interface SohoTimePickerOptions {
 
   /** Rounding. */
   roundToInterval: boolean;
+
+  /** Locale to use for this instance; if not set, the current locale is used. */
+  locale: string;
+
+  /** Name of the language to use for this instance; if not set, the current locale is used or the passed locale is used. */
+  language: string;
+
+  /** Second interval. */
+  secondInterval: number;
+
+  /** If set, will be used as the target element. */
+  parentElement: JQuery;
+
+  /** If false, focus will not be returned to the calling element. */
+  returnFocus: boolean;
 }
 
 interface SohoTimePickerEvent extends JQuery.TriggeredEvent {

--- a/src/app/timepicker/timepicker.demo.html
+++ b/src/app/timepicker/timepicker.demo.html
@@ -36,6 +36,13 @@
         </div>
         <div class="four columns">
           <div class="field">
+            <label for="standard12hhmmss" class="label">Standard Time (h:mm:ss a)</label>
+            <input soho-timepicker name="standard12hhmmss" timeFormat="h:mm:ss a" mode="standard" minuteInterval=1 secondInterval=1
+              [(ngModel)]="model.hhmmss" (change)="onChange($event)"/>
+          </div>
+        </div>
+        <div class="four columns">
+          <div class="field">
             <label for="standard24" class="label">Standard Time (24 hr)</label>
             <input soho-timepicker name="standard24" timeFormat="HH:mm" mode="standard" [(ngModel)]="model.HHmm24" (change)="onChange($event)"/>
           </div>

--- a/src/app/timepicker/timepicker.demo.ts
+++ b/src/app/timepicker/timepicker.demo.ts
@@ -18,6 +18,7 @@ export class TimePickerDemoComponent implements OnInit {
 
   public model = { // tslint:disable-line
     hhmm: '1:23 PM',
+    hhmmss: '1:23:43 PM',
     HHmm24: '17:50'
   };
   public showModel = false;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated typings support for locale, language, secondInterval, parentElement and returnFocus settings. Updated the demo to display seconds and minuteInterval and secondInterval of 1.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #890 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- run this branch (npm run build && npm run start)
- go to http://localhost:4200/ids-enterprise-ng-demo/timepicker
- using the Standard Time (h:mm:ss a) field, verify that the minutes and seconds dropdowns display an interval of 1

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
