### PR TITLE
884 - Fix submit button remains disabled even when the fields has data

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Blockgrid]` Enable settings and API types for interactions with Blockgrid Pager. `EPC` ([#836](https://github.com/infor-design/enterprise-ng/issues/836))
 - `[Calendar]` Added new types for `dayLegend`, `disabled` and allow event overrides for `color` and `borderColor`. `TJM` ([#3893](https://github.com/infor-design/enterprise/issues/3893))
 - `[Datagrid]` Added several new types in datagrid from 4.31. `TJM` ([#3609](https://github.com/infor-design/enterprise/issues/3609))
+- `[Dropdown]` Fixed a bug where the submit button remains disabled even when the fields has data. `EA` ([#884](https://github.com/infor-design/enterprise-ng/issues/884))
 - `[General]` Uses EP version 4.31.0.  `TJM`
 - `[General]` Added several new types in Modal, Datepicker, Message and EmptyMessage from 4.31. `TJM` ([#3609](https://github.com/infor-design/enterprise/issues/3609))
 - `[Lookup]` Fixed an issue where the console error was appearing after the modal close. ([#871](https://github.com/infor-design/enterprise/issues/871))

--- a/src/app/modal-dialog/example-fullsize-modal.component.html
+++ b/src/app/modal-dialog/example-fullsize-modal.component.html
@@ -1,13 +1,23 @@
-<div class="row form-responsive no-indent">
-  <div class="full-width column">
+<div class="full-width column">
     <div class="field">
       <label for="context-name" class="required">Name</label>
-      <input id="context-name"  aria-required="true" name="context-name" type="text"/>
+      <input id="context-name" aria-required="true" data-validate="required" name="context-name" type="text" value="John" />
+    </div>
+  
+    <div class="field">
+      <label for="context-type" class="required label">Type</label>
+      <select soho-dropdown id="context-type" name="type" data-validate="required">
+        <option value=""></option>
+        <option value="1" selected>Context 01</option>
+        <option value="2">Context 02</option>
+        <option value="3">Context 03</option>
+        <option value="4">Context 04</option>
+        <option value="5">Context 05</option>
+      </select>
     </div>
 
     <div class="field">
-     <label for="context-desc" class="required">Page Title</label>
-     <textarea id="context-desc" aria-required="true" name="context-desc" maxlength="50"></textarea>
+      <label for="context-desc" class="required">Page Title</label>
+      <textarea id="context-desc" aria-required="true" data-validate="required" name="context-desc" maxlength="50">Test Desc</textarea>
     </div>
   </div>
-</div>

--- a/src/app/modal-dialog/modal-dialog.demo.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.ts
@@ -65,7 +65,7 @@ export class ModalDialogDemoComponent {
         ref.buttonsetAPI.at(2).disabled = true;
         return true;
       }).afterOpen((_: any, ref: SohoModalDialogRef<FullSizeModalDialogComponent>) => {
-        ref.buttonsetAPI.at(3).disabled = true;
+        ref.buttonsetAPI.at(3).disabled = false;
         return true;
       })
       .open();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the submit button being remain disabled even when the fields has initial data. Updating the template to make sure it uses the `data-validate="required"` option to all fields, and changing the  value of the submit button to false in `afterOpen()` event.

**Related github/jira issue (required)**:
 
Closes https://github.com/infor-design/enterprise-ng/issues/884

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/modal-dialog
- Click on `Full On Tablet` button
- Submit button should enabled once the modal open
<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
