### PR TITLE
894 - Fix chart container example page with homepage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 7.6.0 Fixes
 
-- `[Homepage]` Fixed an issue where the chart container was pushed down a lot cutting off the bottom by removing css class `full-width` on example page. ([#894](https://github.com/infor-design/enterprise-ng/issues/894))
+- `[Homepage]` Fixed an issue where the chart container was misaligning on example page. ([#894](https://github.com/infor-design/enterprise-ng/issues/894))
 
 ## v7.5.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 7.6.0 Fixes
 
+- `[Homepage]` Fixed an issue where the chart container was pushed down a lot cutting off the bottom by removing css class `full-width` on example page. ([#894](https://github.com/infor-design/enterprise-ng/issues/894))
+
 ## v7.5.0
 
 ### 7.5.0 Fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 7.6.0 Fixes
 
-- `[Homepage]` Fixed an issue where the chart container was misaligning on example page. ([#894](https://github.com/infor-design/enterprise-ng/issues/894))
+- `[Homepage]` Fixed an issue where the chart container was misaligned on example page. ([#894](https://github.com/infor-design/enterprise-ng/issues/894))
 
 ## v7.5.0
 

--- a/src/app/homepage/homepage.demo.html
+++ b/src/app/homepage/homepage.demo.html
@@ -6,7 +6,7 @@
         <button soho-button="icon" icon="more" soho-context-menu menu="action-popupmenu" trigger="click" class="btn-actions"></button>
       </div>
       <div soho-widget-content>
-        <div class="full-width chart-container" style="height:100%">
+        <div class="chart-container" style="height:100%">
           <div soho-chart
             [dataSet]="getBarChartData()"
             type="bar"
@@ -40,7 +40,7 @@
         <button soho-button="icon" icon="more" soho-context-menu menu="action-popupmenu" trigger="click" class="btn-actions"></button>
       </div>
       <div soho-widget-content>
-        <div class="full-width chart-container" style="height:100%">
+        <div class="chart-container" style="height:100%">
           <div soho-chart
             [dataSet]="getPieChartData()"
             type="pie"


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the chart container was misaligned on example page with Soho Homepage.

**Related github/jira issue (required)**:
Closes #894

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4200/ids-enterprise-ng-demo/homepage
- See the first card container `bar chart` legend should show properly (it was cutting off bottom)

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
