### PR TITLE
901 - Add Autocomplete + Templates Homepages sample, Test enter key

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { ApplicationMenuLazyMenuDemoComponent } from './application-menu/applica
 import { ApplicationMenuLazyService } from './application-menu/application-menu-lazy-service.demo';
 import { AreaDemoComponent } from './area/area.demo';
 import { AutocompleteDemoComponent } from './autocomplete/autocomplete.demo';
+import { AutocompleteTemplatesDemoComponent } from './autocomplete/autocomplete-templates.demo';
 import { BarDemoComponent } from './bar/bar.demo';
 import { BarGroupedDemoComponent } from './bar-grouped/bar-grouped.demo';
 import { BarStackedDemoComponent } from './bar-stacked/bar-stacked.demo';
@@ -252,6 +253,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     ApplicationMenuTestPerfDemoComponent,
     AreaDemoComponent,
     AutocompleteDemoComponent,
+    AutocompleteTemplatesDemoComponent,
     BarDemoComponent,
     BarGroupedDemoComponent,
     BarStackedDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { AlertDemoComponent } from './alert/alert.demo';
 import { ApplicationMenuLazyDemoComponent } from './application-menu/application-menu-lazy.demo';
 import { AreaDemoComponent } from './area/area.demo';
 import { AutocompleteDemoComponent } from './autocomplete/autocomplete.demo';
+import { AutocompleteTemplatesDemoComponent } from './autocomplete/autocomplete-templates.demo';
 import { BarDemoComponent } from './bar/bar.demo';
 import { BarStackedDemoComponent } from './bar-stacked/bar-stacked.demo';
 import { BarGroupedDemoComponent } from './bar-grouped/bar-grouped.demo';
@@ -201,6 +202,7 @@ export const routes: Routes = [
   { path: 'application-menu-test-performance', component: ApplicationMenuTestPerfDemoComponent },
   { path: 'area', component: AreaDemoComponent },
   { path: 'autocomplete', component: AutocompleteDemoComponent },
+  { path: 'autocomplete-templates', component: AutocompleteTemplatesDemoComponent },
   { path: 'bar', component: BarDemoComponent },
   { path: 'bar-grouped', component: BarGroupedDemoComponent },
   { path: 'bar-stacked', component: BarStackedDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -12,6 +12,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['application-menu-test-performance']"><span>Application Menu Test Performance</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['area']"><span>Area Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['autocomplete']"><span>Autocomplete</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['autocomplete-templates']"><span>Autocomplete with Custom Templates</span></a></div>
   </div>
 
   <!-- B -->
@@ -233,7 +234,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['tabs-dropdown']"><span>Tabs - Dropdown</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tabs-datadriven']"><span>Tabs - Data-driven</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tabs-dynamic']"><span>Tabs - Dynamic</span></a></div>
-    <div class="accordion-header list-item"><a [routerLink]="['tabs-resize']"><span>Tabs - Resize</span></a></div> 
+    <div class="accordion-header list-item"><a [routerLink]="['tabs-resize']"><span>Tabs - Resize</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tabs-module']">Tabs - Module</a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tabs-vertical']"><span>Tabs - Vertical</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tags']"><span>Tags</span></a></div>

--- a/src/app/autocomplete/autocomplete-templates.demo.html
+++ b/src/app/autocomplete/autocomplete-templates.demo.html
@@ -1,0 +1,11 @@
+<div class="row">
+  <div class="twelve columns">
+    <p>
+        The (selected) event is not triggered when selecting an item with "enter", if it has a custom template.
+    </p>
+    <div class="field">
+      <label soho-label>Last selected: {{secondsSinceLastSelect | async}} seconds ago.</label>
+      <input soho-autocomplete [source]="source" [template]="template" [(ngModel)]="model" (selected)="resetSelectCount()" placeholder="Type something and select with enter">
+    </div>
+  </div>
+</div>

--- a/src/app/autocomplete/autocomplete-templates.demo.ts
+++ b/src/app/autocomplete/autocomplete-templates.demo.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { Observable, interval } from 'rxjs';
+import { startWith, map } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-autocomplete-templates',
+  templateUrl: './autocomplete-templates.demo.html'
+})
+export class AutocompleteTemplatesDemoComponent {
+
+  model: string;
+  source: SohoAutoCompleteSource = [
+    'Hello',
+    'World',
+    'Alice',
+    'Bob',
+  ];
+  secondsSinceLastSelect: Observable<number>;
+  template = `<script type="text/html">
+  <li id="{{listItemId}}" {{#hasValue}} data-value="{{value}}" {{/hasValue}} role="listitem">
+    <a tabindex="-1">
+      <span class="display-value">Custom template {{{label}}}</span>
+    </a>
+  </li>
+</script>`;
+
+  resetSelectCount() {
+    this.secondsSinceLastSelect = interval(1000).pipe(map(n => n + 1), startWith(0));
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a sample from @anhallbe for a bugfix needed for the Homepages team.  The actual bug is fixed in an IDS Enterprise PR, and before this is merged, it should be tested against that EP branch.  The PR will fix a bug related to Autocomplete lists, where it wasn't previously possible to select an Autocomplete result with the enter key.

**Related github/jira issue (required)**:
Closes #901 
Related to infor-design/enterprise#4349

**Steps necessary to review your pull request (required)**:
- Pull this branch, build against infor-design/enterprise#4349, run the NG demoapp
- Open http://localhost:4200/ids-enterprise-ng-demo/autocomplete-templates
- In the Autocomplete, type the letter "A".
- Use the arrow keys and the enter key to select the result labeled `Custom template Alice`.  The item should be selected, the list should close, and the timer above the field should be set/reset to 0.