### PR TITLE
1590 - Add support to disable column buttons with soho datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 7.7.0 Fixes
 
+- `[Datagrid]` Added support to disable column buttons. ([1590](https://github.com/infor-design/enterprise/issues/1590))
 - `[Popupmenu]` Expose is-selectable, is-multiselectable, and multi-selectable-section as input properties. ([#907](https://github.com/infor-design/enterprise-ng/issues/907)) `CL`
 
 ## v7.6.0

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -697,6 +697,14 @@ type SohoDataGridColumnCssClassFunction = (
   rowData: Object
 ) => string;
 
+type SohoDataGridColumnDisableButtonFunction = (
+  row: number,
+  cell: any,
+  fieldValue: any,
+  columnDef: SohoDataGridColumn,
+  rowData: any
+) => boolean;
+
 type SohoDataGridColumnColSpanFunction = (
   row: number,
   cell: any,
@@ -798,6 +806,9 @@ interface SohoDataGridColumn {
 
   /** css class  */
   cssClass?: SohoDataGridColumnCssClassFunction | string;
+
+  /** disable button  */
+  disableButton?: SohoDataGridColumnDisableButtonFunction;
 
   /** @todo fix type from any.  */
   dateShowFormat?: any;

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.d.ts
@@ -697,7 +697,7 @@ type SohoDataGridColumnCssClassFunction = (
   rowData: Object
 ) => string;
 
-type SohoDataGridColumnDisableButtonFunction = (
+type SohoDataGridColumnDisabledFunction = (
   row: number,
   cell: any,
   fieldValue: any,
@@ -807,8 +807,8 @@ interface SohoDataGridColumn {
   /** css class  */
   cssClass?: SohoDataGridColumnCssClassFunction | string;
 
-  /** disable button  */
-  disableButton?: SohoDataGridColumnDisableButtonFunction;
+  /** disabled  */
+  disabled?: SohoDataGridColumnDisabledFunction;
 
   /** @todo fix type from any.  */
   dateShowFormat?: any;

--- a/src/app/datagrid/datagrid-angular-formatter.demo.ts
+++ b/src/app/datagrid/datagrid-angular-formatter.demo.ts
@@ -42,7 +42,7 @@ export class DataGridAngularFormatterDemoComponent {
     { id: 'button-formatter', name: 'Edit', text: 'Edit Row',
       sortable: false, icon: 'edit', align: 'center',
       formatter: Soho.Formatters.Button, click: (e, args) => this.onClick(args),
-      disableButton: this.disableButton },
+      disabled: this.disableButton },
     { id: 'button', name: 'Settings',
       sortable: false, align: 'center', postRender: true,
       component: ButtonCellFormatterComponent,

--- a/src/app/datagrid/datagrid-angular-formatter.demo.ts
+++ b/src/app/datagrid/datagrid-angular-formatter.demo.ts
@@ -41,7 +41,8 @@ export class DataGridAngularFormatterDemoComponent {
       formatter: Soho.Formatters.Readonly },
     { id: 'button-formatter', name: 'Edit', text: 'Edit Row',
       sortable: false, icon: 'edit', align: 'center',
-      formatter: Soho.Formatters.Button, click: (e, args) => this.onClick(args) },
+      formatter: Soho.Formatters.Button, click: (e, args) => this.onClick(args),
+      disableButton: this.disableButton },
     { id: 'button', name: 'Settings',
       sortable: false, align: 'center', postRender: true,
       component: ButtonCellFormatterComponent,
@@ -60,5 +61,8 @@ export class DataGridAngularFormatterDemoComponent {
 
   onClick(args) {
     console.log('click');
+  }
+  disableButton(row: number, cell: any, data: any, col: SohoDataGridColumn, item: any) {
+    return (item.productId === 214221 || item.productId === 214222);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to disable column buttons with Soho Datagrid.

**Related github/jira issue (required)**:
Closes infor-design/enterprise#1590

**Steps necessary to review your pull request (required)**:
- Pull and build this branch
- Pull ([EP master](https://github.com/infor-design/enterprise.git))
- If [PR 4379](https://github.com/infor-design/enterprise/pull/4379) not merged then switch to branch `git checkout 1590-datagrid-disable-buttons`
- Build EP project
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Run NG project
- Navigate to: http://localhost:4200/ids-enterprise-ng-demo/datagrid-angular-formatter
- See icon buttons in 2nd and 3rd row for column `Edit`
- The buttons should be disabled

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
