### PR TITLE
fix for cypress build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: node_js
 # use version in `.nvmrc`
 node_js:
 cache:
+  # cache both npm modules and Cypress binary
   directories:
     - node_modules
+    - ~/.cache/Cypress
 env:
   - TEST_SUITE=lint
   - TEST_SUITE=functional
@@ -12,6 +14,10 @@ env:
 install:
   - npm install
 before_script:
+  - npx cypress install
+  - npx cypress verify
+  - npx cypress cache path
+  - npx cypress cache list
   - npm install -g codecov
   - if [ $TEST_SUITE != lint ]; then npm run build; fi
 script:

--- a/cypress/integration/locale/locale-format.spec.ts
+++ b/cypress/integration/locale/locale-format.spec.ts
@@ -15,13 +15,9 @@ describe('Locale Tests', () => {
 
       // select locale
       cy.get('#dropdown-list')
-        .should('exist')
         .contains(name)
         .should('exist')
         .click();
-
-      cy.get('#dropdown-list')
-        .should('not.exist');
 
       cy.get('div.dropdown-wrapper')
         .contains(name)


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes the build for missing cypress error. Cypress recommends using `npm ci` because `npm install` is known to be causing cypress binary cache issues. So for now the solution is to do `cypress install` adding 15 sec to the build which I think is negligible for now.

**Related github/jira issue (required)**:
NA

**Steps necessary to review your pull request (required)**:
NA. Build should pass
