### PR TITLE
887/888 - Fix destroy and overwrite settings with context menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 7.7.0 Fixes
 
+- `[Context Menu]` Fixes a bug where using *ngIf directive to destroy the component was not working properly. ([#887](https://github.com/infor-design/enterprise-ng/issues/887))
+- `[Context Menu]` Fixes a bug where api settings were not overwriting the default settings. ([#888](https://github.com/infor-design/enterprise-ng/issues/888))
 - `[Datagrid]` Added support to disable column buttons. ([1590](https://github.com/infor-design/enterprise/issues/1590))
 - `[Popupmenu]` Expose is-selectable, is-multiselectable, and multi-selectable-section as input properties. ([#907](https://github.com/infor-design/enterprise-ng/issues/907)) `CL`
 

--- a/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.directive.ts
@@ -2,21 +2,96 @@
 
 import {
   AfterViewInit,
+  Component,
   Directive,
   ElementRef,
   EventEmitter,
+  HostBinding,
   Input, NgZone,
   OnDestroy,
   Output
 } from '@angular/core';
 
+/**
+ * SUB COMPONENT: SOHO-CONTEXT-MENU-HEADING
+ */
+@Component({
+  selector: 'li[soho-context-menu-heading]', // tslint:disable-line
+  template: `<ng-content></ng-content>`
+})
+export class SohoContextMenuHeadingComponent {
+  @HostBinding('class.heading') get isHeading() { return true; }
+}
+
+/**
+ * SUB COMPONENT: SOHO-CONTEXT-MENU-SHORTCUT-TEXT
+ */
+@Component({
+  selector: 'span[soho-context-menu-shortcut-text]', // tslint:disable-line
+  template: `<ng-content></ng-content>`
+})
+export class SohoContextMenuShortCutTextComponent {
+  @HostBinding('class.shortcut-text') get isShortCutText() { return true; }
+}
+
+/**
+ * SUB COMPONENT: SOHO-CONTEXT-MENU-SEPARATOR
+ */
+@Component({
+  selector: 'li[soho-context-menu-separator]', // tslint:disable-line
+  template: `<ng-content></ng-content>`
+})
+export class SohoContextMenuSeparatorComponent {
+  @HostBinding('class.separator') get isSeparator() { return true; }
+  @HostBinding('class.single-selectable-section') @Input() singleSelectableSection = false;
+  @HostBinding('class.multi-selectable-section') @Input() multiSelectableSection = false;
+}
+
+/**
+ * SUB COMPONENT: SOHO-CONTEXT-MENU-LABEL
+ */
+@Component({
+  selector: 'a[soho-context-menu-label]', // tslint:disable-line
+  template: `<ng-content></ng-content>`
+})
+export class SohoContextMenuItemLabelComponent {
+  @HostBinding('attr.href') get hrefAttr() {
+    if (this.menuId) {
+      return '#' + this.menuId;
+    }
+    if (this.menuUrl) {
+      return this.menuUrl;
+    }
+    return '#';
+  }
+  @Input() menuId: string;
+  @Input() menuUrl: string;
+}
+
+/**
+ * SUB COMPONENT: SOHO-CONTEXT-MENU-ITEM
+ */
+@Component({
+  selector: 'li[soho-context-menu-item]', // tslint:disable-line
+  template: `<ng-content></ng-content>`
+})
+export class SohoContextMenuItemComponent {
+  @HostBinding('class.is-checked') @Input() isChecked: boolean;
+  @HostBinding('class.is-selectable') @Input() isSelectable = false;
+  @HostBinding('class.is-disabled') @Input() isDisabled = false;
+  @HostBinding('class.is-indented') @Input() isIndented = false;
+  @HostBinding('class.submenu') @Input() subMenu = false;
+}
+
+/**
+ * MAIN DIRECTIVE: SOHO-CONTEXT-MENU
+ */
 @Directive({
   selector: '[soho-context-menu]', // tslint:disable-line
 })
 
 export class SohoContextMenuDirective implements AfterViewInit, OnDestroy {
   private jQueryElement: JQuery;
-
   private contextMenu: SohoPopupMenuStatic;
 
   // -------------------------------------------
@@ -54,6 +129,93 @@ export class SohoContextMenuDirective implements AfterViewInit, OnDestroy {
     }
   }
 
+  /** Auto Focus */
+  @Input() set autoFocus(autoFocus: boolean) {
+    this.options.autoFocus = autoFocus;
+    if (this.contextMenu) {
+      this.contextMenu.settings.autoFocus = autoFocus;
+    }
+  }
+
+  get autoFocus(): boolean {
+    if (this.contextMenu) {
+      return this.contextMenu.settings.autoFocus;
+    }
+    return this.options.autoFocus;
+  }
+
+  /** Mouse focus. */
+  @Input() set mouseFocus(mouseFocus: boolean) {
+    this.options.mouseFocus = mouseFocus;
+    if (this.contextMenu) {
+      this.contextMenu.settings.mouseFocus = mouseFocus;
+    }
+  }
+
+  get mouseFocus(): boolean {
+    if (this.contextMenu) {
+      return this.contextMenu.settings.mouseFocus;
+    }
+    return this.options.mouseFocus;
+  }
+
+  /** Attach to body. */
+  @Input() set attachToBody(attachToBody: boolean) {
+    this.options.attachToBody = attachToBody;
+    if (this.contextMenu) {
+      this.contextMenu.settings.attachToBody = attachToBody;
+    }
+  }
+
+  get attachToBody(): boolean {
+    if (this.contextMenu) {
+      return this.contextMenu.settings.attachToBody;
+    }
+    return this.options.attachToBody;
+  }
+
+  @Input() set placementOpts(placementOpts: SohoPopupmenuPlacementOpts) {
+    this.options.placementOpts = placementOpts;
+    if (this.contextMenu) {
+      this.contextMenu.settings.placementOpts = placementOpts;
+    }
+  }
+
+  get placementOpts(): SohoPopupmenuPlacementOpts {
+    if (this.contextMenu) {
+      return this.contextMenu.settings.placementOpts;
+    }
+    return this.options.placementOpts;
+  }
+
+  @Input() set offset(offset: SohoPopupmenuOffset) {
+    this.options.offset = offset;
+    if (this.contextMenu) {
+      this.contextMenu.settings.offset = offset;
+    }
+  }
+
+  get offset(): SohoPopupmenuOffset {
+    if (this.contextMenu) {
+      return this.contextMenu.settings.offset;
+    }
+    return this.options.offset;
+  }
+
+  @Input() set removeOnDestroy(removeOnDestroy: boolean) {
+    this.options.removeOnDestroy = removeOnDestroy;
+    if (this.contextMenu) {
+      this.contextMenu.settings.removeOnDestroy = removeOnDestroy;
+    }
+  }
+
+  get removeOnDestroy(): boolean {
+    if (this.contextMenu) {
+      return this.contextMenu.settings.removeOnDestroy;
+    }
+    return this.options.removeOnDestroy;
+  }
+
   /** beforeOpen - ajax callback for open event */
   @Input() set beforeOpen(beforeOpen: SohoPopupMenuSourceFunction) {
     this.options.beforeOpen = beforeOpen;
@@ -66,7 +228,6 @@ export class SohoContextMenuDirective implements AfterViewInit, OnDestroy {
     if (this.contextMenu) {
       return this.contextMenu.settings.beforeOpen;
     }
-
     return this.options.beforeOpen;
   }
 

--- a/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.module.ts
@@ -1,12 +1,31 @@
 import { NgModule } from '@angular/core';
-import { SohoContextMenuDirective } from './soho-context-menu.directive';
+import { CommonModule } from '@angular/common';
+import {
+  SohoContextMenuDirective,
+  SohoContextMenuHeadingComponent,
+  SohoContextMenuShortCutTextComponent,
+  SohoContextMenuItemComponent,
+  SohoContextMenuItemLabelComponent,
+  SohoContextMenuSeparatorComponent
+} from './soho-context-menu.directive';
 
 @NgModule({
+  imports: [ CommonModule ],
   declarations: [
-    SohoContextMenuDirective
+    SohoContextMenuDirective,
+    SohoContextMenuHeadingComponent,
+    SohoContextMenuShortCutTextComponent,
+    SohoContextMenuItemComponent,
+    SohoContextMenuItemLabelComponent,
+    SohoContextMenuSeparatorComponent
   ],
   exports: [
-    SohoContextMenuDirective
+    SohoContextMenuDirective,
+    SohoContextMenuHeadingComponent,
+    SohoContextMenuShortCutTextComponent,
+    SohoContextMenuItemComponent,
+    SohoContextMenuItemLabelComponent,
+    SohoContextMenuSeparatorComponent
   ]
 })
 export class SohoContextMenuModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -53,6 +53,7 @@ import { CodeBlockComponent } from './code-block/code-block.component';
 import { CodeBlockDemoComponent } from './code-block/code-block.demo';
 import { CompletionChartDemoComponent } from './completion-chart/completion-chart.demo';
 import { ContextMenuDemoComponent } from './context-menu/context-menu.demo';
+import { ContextMenuToggleDemoComponent } from './context-menu/context-menu-toggle.demo';
 import { ContextualActionPanelDemoModule } from './contextual-action-panel/contextual-action-panel.demo.module';
 import { DataGridBreadcrumbDemoComponent } from './datagrid/datagrid-breadcrumb.demo';
 import {
@@ -288,6 +289,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     CodeBlockEditorComponent,
     CompletionChartDemoComponent,
     ContextMenuDemoComponent,
+    ContextMenuToggleDemoComponent,
     DataGridBreadcrumbDemoComponent,
     DataGridCardDemoComponent,
     DataGridAngularEditorDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -38,6 +38,7 @@ import { ColumnGroupedXaxisTwolineDemoComponent } from './column-grouped/column-
 import { ColumnStackedDemoComponent } from './column-stacked/column-stacked.demo';
 import { CompletionChartDemoComponent } from './completion-chart/completion-chart.demo';
 import { ContextMenuDemoComponent } from './context-menu/context-menu.demo';
+import { ContextMenuToggleDemoComponent } from './context-menu/context-menu-toggle.demo';
 import { ContextualActionPanelDemoComponent } from './contextual-action-panel/contextual-action-panel.demo';
 import { DataGridAngularEditorDemoComponent } from './datagrid/datagrid-angular-editor.demo';
 import { DataGridAngularFormatterDemoComponent } from './datagrid/datagrid-angular-formatter.demo';
@@ -234,6 +235,7 @@ export const routes: Routes = [
   { path: 'column-stacked', component: ColumnStackedDemoComponent },
   { path: 'completion-chart', component: CompletionChartDemoComponent },
   { path: 'context-menu', component: ContextMenuDemoComponent },
+  { path: 'context-menu-toggle', component: ContextMenuToggleDemoComponent },
   { path: 'contextual-action-panel', component: ContextualActionPanelDemoComponent },
   { path: 'datagrid-breadcrumb', component: DataGridBreadcrumbDemoComponent },
   { path: 'datagrid-dirty-indication', component: DataGridDirtyIndicationDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -54,6 +54,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['column-stacked']"><span>Column Chart-Stacked</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['completion-chart']"><span>Completion Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['context-menu']"><span>Context Menu</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['context-menu-toggle']"><span>Context Menu (toggle)</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['contextual-action-panel']"><span>Contextual Action Panel</span></a></div>
   </div>
 

--- a/src/app/context-menu/context-menu-toggle.demo.html
+++ b/src/app/context-menu/context-menu-toggle.demo.html
@@ -1,0 +1,53 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Soho Context Menu</h2>
+    <p>
+      This demo illustrates two things as below<br>
+      1) Toggle the context menu using *ngIf<br>
+      2) Overwrite default settings
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <button soho-button
+      (click)="toggleShowContextMenu()">ShowContextMenu: {{isShowContextMenu}}</button><br><br>
+
+    <button soho-button
+      [disabled]="!isShowContextMenu"
+      (click)="toggleAutoFocus()">autoFocus: {{isAutoFocus}}</button><br><br>
+
+    <button soho-button
+      [disabled]="!isShowContextMenu"
+      (click)="toggleAttachToBody()">attachToBody: {{isAttachToBody}}</button>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label soho-label id="label1" name="label1" for="field1" >{{labelText}}</label>
+      <input soho-context-menu
+        id="field1"
+        name="field1"
+        value="Right Click Here"
+        [menu]="isShowContextMenu ? 'test-contextmenu-01': null"
+        [autoFocus]="isAutoFocus"
+        [attachToBody]="isAttachToBody"
+        (selected)="onSelected()"
+        (beforeopen)="onBeforeOpen()"
+        (close)="onClose()"
+        (open)="onOpen()" />
+
+      <ul id="test-contextmenu-01" *ngIf="isShowContextMenu">
+        <li soho-context-menu-item *ngFor="let item of contextmenuItems" [isDisabled]="item.disabled">
+          <a soho-context-menu-label *ngIf="!item.url" menuId="{{item.id}}">{{item.displayString}}<span class="shortcut-text">{{item.shortcut}}</span></a>
+          <a soho-context-menu-label *ngIf="item.url" menuUrl="{{item.url}}">{{item.displayString}}<span class="shortcut-text">{{item.shortcut}}</span></a>
+        </li>
+      </ul>
+    </div>
+
+  </div>
+</div>

--- a/src/app/context-menu/context-menu-toggle.demo.ts
+++ b/src/app/context-menu/context-menu-toggle.demo.ts
@@ -1,0 +1,141 @@
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  ChangeDetectorRef,
+  ChangeDetectionStrategy
+} from '@angular/core';
+
+import { SohoTextAreaComponent, SohoContextMenuDirective } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-context-menu-toggle-demo',
+  templateUrl: 'context-menu-toggle.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ContextMenuToggleDemoComponent implements OnInit {
+  @ViewChild(SohoTextAreaComponent, { static: true }) textarea: SohoTextAreaComponent;
+  @ViewChild(SohoContextMenuDirective) contextMenu: SohoContextMenuDirective;
+
+  public labelText: string;
+  public isShowContextMenu: boolean;
+  public isAutoFocus: boolean;
+  public isAttachToBody: boolean;
+
+  public contextmenuItems: Array<TypeContextMenuItems>;
+
+  private buildContextMenu(): Array<TypeContextMenuItems> {
+    const items: Array<TypeContextMenuItems> = [];
+
+    items.push({
+      displayString: 'Cutx',
+      disabled: false,
+      shortcut: '⌘+X'
+    });
+
+    items.push({
+      displayString: 'Copy',
+      disabled: false,
+      shortcut: '⌘+C'
+    });
+
+    items.push({
+      displayString: 'Paste',
+      disabled: false,
+      shortcut: '⌘+V'
+    });
+
+    items.push({
+      displayString: 'Name and project range',
+      id: 'range',
+      disabled: false
+    });
+
+    items.push({
+      displayString: 'Insert comment',
+      disabled: true
+    });
+
+    items.push({
+      displayString: 'Insert note',
+      disabled: false
+    });
+
+    items.push({
+      displayString: 'Clear notes',
+      disabled: true
+    });
+
+    items.push({
+      displayString: 'Google',
+      url: 'http://www.google.com',
+      disabled: false
+    });
+
+    return items;
+  }
+
+  constructor(private changeDetectorRef: ChangeDetectorRef) { }
+
+  ngOnInit() {
+    this.isShowContextMenu = true;
+    this.isAutoFocus = true;
+    this.isAttachToBody = true;
+    this.contextmenuItems = this.buildContextMenu();
+    this.setLabelText();
+  }
+
+  onSelected() {
+  }
+
+  onBeforeOpen() {
+  }
+
+  onClose() {
+  }
+
+  onOpen() {
+  }
+
+  toggleShowContextMenu() {
+    this.isShowContextMenu = !this.isShowContextMenu;
+    this.setLabelText();
+    this.setContextMenu();
+  }
+
+  toggleAutoFocus() {
+    this.isAutoFocus = !this.isAutoFocus;
+    this.updateSettings();
+  }
+
+  toggleAttachToBody() {
+    this.isAttachToBody = !this.isAttachToBody;
+    this.updateSettings();
+  }
+
+  updateSettings() {
+    this.changeDetectorRef.detectChanges();
+    this.contextMenu.updated();
+  }
+
+  setContextMenu() {
+    this.changeDetectorRef.detectChanges();
+    if (this.isShowContextMenu) {
+      this.contextMenu.ngAfterViewInit();
+    } else {
+      this.contextMenu.ngOnDestroy();
+    }
+  }
+
+  setLabelText() {
+    this.labelText = `Example (show ${this.isShowContextMenu ? 'custom' : 'browser default'} context menu)`;
+  }
+}
+
+export interface TypeContextMenuItems {
+  displayString: string;
+  id?: string;
+  url?: string;
+  disabled?: boolean;
+  shortcut?: string;
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed using *ngIf directive to destroy the component and overwrite api settings was not working properly with Context Menu.

**Related github/jira issue (required)**:
Closes #887
Closes #888

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
Navigate to: http://localhost:4200/ids-enterprise-ng-demo/context-menu-toggle

Issue: 887
- Use button `ShowContextMenu` to toggle
- Right click on the bottom text box to see the context menu
- True - should show custom context menu
- False - should show browser default context menu

Issue: 888
- Use button `autoFocus` to toggle (if disabled toggle `ShowContextMenu` to `true`)
- Right click on the bottom text box to open context menu
- True - should be focused first item
- False - should NOT be focused first item
- Open developer tools
- Use button `attachToBody` to toggle (if disabled toggle `ShowContextMenu` to `true`)
- Run in console `$('body > .popupmenu-wrapper').length;`
- True - should return `3`
- False - should return `2`

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
