### PR TITLE
Fix issue with install - chalk error

### DIFF
--- a/scripts/version-sync.js
+++ b/scripts/version-sync.js
@@ -10,6 +10,7 @@
 // -------------------------------------
 const fs = require('fs');
 const slash = require('slash');
+const chalk = require('chalk');
 
 // -------------------------------------
 //   Constants


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Error when installing the IDS-NG demo/dev app. 

**Related github/jira issue (required)**:

 https://github.com/infor-design/enterprise-ng/issues/648

**Steps necessary to review your pull request (required)**:

When you run "npm run build" during the initial install you get the error:
console.log(chalk.red('Error!'), msg, '\n');
^

ReferenceError: chalk is not defined


<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
