### PR TITLE
4251 - Added fix for loosing tab context

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,10 @@
 # What's New with Enterprise-NG
 
-## v8.0.3
+## v8.1.0
 
-### 8.0.3 Fixes
+### 8.1.0 Fixes
 
-- `[General]` Fixes an incorrect default for popup menu `isSelectable`.  `TJM`
+- `[Tabs]` Added a new method `refresh` which can be called when updating the tab count in a dynamic tab scenario). When called it will force a UI refresh to the tabs. Typical situations are changing all the tab header contents so the size is changed. If using `disableAutoUpdatedCall=true` you should call this when tab counts or names are changed. This did not introduce any breaking change.  ([#4521](https://github.com/infor-design/enterprise/issues/4521)) `TJM`
 
 ## v8.0.2
 

--- a/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
@@ -574,6 +574,17 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
   }
 
   /**
+   * Manually call updated and refresh out of the zone.
+   */
+  public refresh(): void {
+    this.ngZone.runOutsideAngular(() => {
+      setTimeout(() => {
+        this.tabs.updated();
+      }, 1);
+    });
+  }
+
+  /**
    * Adds a new tab into the tab component
    * @param tabId The tabId of the tab to be added
    * @param options ?

--- a/projects/ids-enterprise-typings/lib/tabs/soho-tabs.d.ts
+++ b/projects/ids-enterprise-typings/lib/tabs/soho-tabs.d.ts
@@ -66,6 +66,8 @@ interface SohoTabsStatic {
 
   rename(tabId: string, name: string): void;
 
+  refresh(): void;
+
   getTab(event: SohoTabsEvent, tabId: string): any;
 
   getActiveTab(): JQuery;

--- a/src/app/tabs/tabs-dismissible.demo.html
+++ b/src/app/tabs/tabs-dismissible.demo.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="twelve columns">
 
-    <div soho-tabs [disableAutoUpdatedCall]="true">
+    <div soho-tabs registerForEvents="beforeClose" [beforeCloseCallback]="onBeforeClose" [disableAutoUpdatedCall]="true">
       <div soho-tab-list-container>
         <ul soho-tab-list>
           <li soho-tab><a soho-tab-title tabId="tabs-dismissible-firefox">Tab 1</a></li>

--- a/src/app/tabs/tabs-dismissible.demo.html
+++ b/src/app/tabs/tabs-dismissible.demo.html
@@ -1,15 +1,15 @@
 <div class="row">
   <div class="twelve columns">
 
-    <div soho-tabs registerForEvents="beforeClose" [beforeCloseCallback]="onBeforeClose">
+    <div soho-tabs [disableAutoUpdatedCall]="true">
       <div soho-tab-list-container>
         <ul soho-tab-list>
-          <li soho-tab><a soho-tab-title tabId="tabs-dismissible-firefox">Firefox</a></li>
-          <li soho-tab selected="true"><a soho-tab-title tabId="tabs-dismissible-chrome">Chrome</a></li>
-          <li soho-tab dismissible="true"><a soho-tab-title tabId="tabs-dismissible-internetExplorer">Internet Explorer</a></li>
-          <li soho-tab dismissible="true"><a soho-tab-title tabId="tabs-dismissible-opera">Opera</a></li>
-          <li soho-tab dismissible="true"><a soho-tab-title tabId="tabs-dismissible-form">Form</a></li>
-          <li soho-tab dismissible="true"><a soho-tab-title tabId="tabs-dismissible-safari">Safari</a></li>
+          <li soho-tab><a soho-tab-title tabId="tabs-dismissible-firefox">Tab 1</a></li>
+          <li soho-tab selected="true"><a soho-tab-title tabId="tabs-dismissible-chrome">Tab 2 (Iframe)</a></li>
+          <li soho-tab dismissible="true"><a soho-tab-title tabId="tabs-dismissible-internetExplorer">Tab 3</a></li>
+          <li soho-tab dismissible="true"><a soho-tab-title tabId="tabs-dismissible-opera">Tab 4</a></li>
+          <li soho-tab dismissible="true"><a soho-tab-title tabId="tabs-dismissible-form">Tab 5</a></li>
+          <li soho-tab dismissible="true"><a soho-tab-title tabId="tabs-dismissible-safari">Tab 6</a></li>
         </ul>
       </div>
     </div>
@@ -20,10 +20,10 @@
       </div>
       <div soho-tab-panel tabId="tabs-dismissible-chrome">
         <p>Back-end e-services end-to-end streamline portals methodologies post relationships enable e-markets users B2B, paradigms monetize eyeballs. Rich front-end, "dynamic webservices users revolutionary enterprise wireless capture orchestrate blogging; synergize; mindshare models engage!" Portals networkeffects mission-critical embrace, orchestrate, incentivize; relationships, platforms incentivize. Scalable applications world-class beta-test, target synergies frictionless synergies evolve web-readiness niches incentivize orchestrate.</p>
-        <iframe src="https://www.bing.com" style="width: 100%; height: 300px;"></iframe>
+        <iframe src="https://www.bing.com" style="width: 100%; height: 500px;"></iframe>
       </div>
       <div soho-tab-panel tabId="tabs-dismissible-internetExplorer">
-        <p>If you try to dismiss this tab, it will not close.</p>
+        <p>edge strategic embedded integrateAJAX-enabled matrix proactive architect, "experiences, scale streamline." Open-source standards-compliant infomediaries visionary systems user-centred applications.</p>
       </div>
       <div soho-tab-panel tabId="tabs-dismissible-opera">
         <p>Podcasts e-enable, robust viral rich-clientAPIs widgets cutting-edge strategic embedded integrateAJAX-enabled matrix proactive architect, "experiences, scale streamline." Open-source standards-compliant infomediaries visionary systems user-centred applications.</p>

--- a/src/app/tabs/tabs-dynamic.demo.html
+++ b/src/app/tabs/tabs-dynamic.demo.html
@@ -10,7 +10,7 @@
 <div class="row">
   <div class="twelve columns">
 
-    <div soho-tabs registerForEvents="activated" (activated)="onActivated($event)">
+    <div soho-tabs registerForEvents="activated" (activated)="onActivated($event)" [disableAutoUpdatedCall]="true">
       <div soho-tab-list-container>
         <ul soho-tab-list>
           <li soho-tab *ngFor="let tab of tabs"><a soho-tab-title [tabId]="tab.id">{{tab.title}}</a></li>

--- a/src/app/tabs/tabs-dynamic.demo.ts
+++ b/src/app/tabs/tabs-dynamic.demo.ts
@@ -64,6 +64,8 @@ export class TabsDynamicDemoComponent implements OnInit {
 
     this.tabs = this.tabsData[this.currentTabsIndex];
     this.currentTabTitleChangeNumber = 1;
+
+    this.sohoTabsComponent.refresh();
   }
 
   onChangeTitles() {
@@ -78,6 +80,7 @@ export class TabsDynamicDemoComponent implements OnInit {
     }
 
     this.currentTabTitleChangeNumber++;
+    this.sohoTabsComponent.refresh();
   }
 
   onActivated(event: SohoTabsEvent) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

At the moment to work with dynamic tabs the tabs component will check the tab count and trigger an update to rebuild tabs when the tab counts change. This can cause issues as describe in the bug where the rebuild causes iframes and maybe other things to reset their states.

To get around this i added a new method `refresh` than can be called manually that will rebuild the tabs. It will update and rebuild and you will loose context but you can do it only when its safe. Could not think of any other safe fixes.


**Related github/jira issue (required)**:
Fixes infor-design/enterprise#4521

**Steps necessary to review your pull request (required)**:
- pull branch
- npm run build && npm run start
- test the buttons on http://localhost:4200/ids-enterprise-ng-demo/tabs-dynamic will size the UI correctly
- go to http://localhost:4200/ids-enterprise-ng-demo/tabs-dismissible
- to to tab 2 and google something
- then click tab 3 and then close it
- when you are put back on tab 2 the iframe/google search should be in the same place as before.