### PR TITLE
Add 'Close' API to SohoContextMenuDirective

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.directive.ts
@@ -106,7 +106,10 @@ export class SohoContextMenuDirective implements AfterViewInit, OnDestroy {
   @Output() selected = new EventEmitter<SohoContextMenuEvent>();
   @Output() beforeopen = new EventEmitter<SohoContextMenuEvent>();
   @Output() open = new EventEmitter<SohoContextMenuEvent>();
-  @Output() close = new EventEmitter<SohoContextMenuEvent>();
+
+  // using output renaming since close conflicts with the close method
+  // in this class.
+  @Output('close') closeEvent = new EventEmitter<SohoContextMenuEvent>(); //tslint:disable-line
 
   // -------------------------------------------
   // Component Inputs
@@ -245,7 +248,7 @@ export class SohoContextMenuDirective implements AfterViewInit, OnDestroy {
         this.ngZone.run(() => this.beforeopen.emit({ e, args })));
 
       this.jQueryElement.on('close', (e: JQuery.TriggeredEvent, args: JQuery) =>
-        this.ngZone.run(() => this.close.emit({ e, args })));
+        this.ngZone.run(() => this.closeEvent.emit({ e, args })));
 
       this.jQueryElement.on('open', (e: JQuery.TriggeredEvent, args: JQuery) =>
         this.ngZone.run(() => this.open.emit({ e, args })));
@@ -258,6 +261,18 @@ export class SohoContextMenuDirective implements AfterViewInit, OnDestroy {
 
   teardown() {
     this.ngZone.runOutsideAngular(() => this.contextMenu.teardown());
+  }
+
+  /**
+   * Closes the popup menu
+   * @param isCancelled Internally set option used if the operation is a cancel.
+   *  Wont matter for manual api call.
+   * @param noFocus Do not return focus to the calling element (fx a button)
+   */
+  close(isCancelled?: boolean, noFocus?: boolean): void {
+    if (this.contextMenu) {
+      this.ngZone.runOutsideAngular(() => this.contextMenu.close(isCancelled, noFocus));
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/context-menu/context-menu.demo.html
+++ b/src/app/context-menu/context-menu.demo.html
@@ -80,6 +80,11 @@
          (open)="onOpen()">{{editorModel.editorText}}</div>
   </div>
 
+  <div class="field">
+    <span class="label">{{manualCloseLabel}}</span>
+    <a href="#" soho-context-menu menu="menu-one" (open)="onOpenManually($event)">This context menu will close after 2 seconds.</a>
+  </div>
+
   <!-- Context menu used in all examples (except the menu button)-->
   <ul soho-popupmenu id="action-popupmenu">
     <li soho-popupmenu-item *ngFor="let menuEntry of contextEntries" [isDisabled]="menuEntry.disabled">
@@ -99,7 +104,7 @@
     </div>
   </div>
 
-  <ul soho-popupmenu id="menu-one">
+  <ul soho-popupmenu id="menu-one" #menuOne>
     <li soho-popupmenu-item><a soho-popupmenu-label  href="#">Menu One Foo</a></li>
     <li soho-popupmenu-item><a soho-popupmenu-label  href="#">Menu One Bar</a></li>
   </ul>

--- a/src/app/context-menu/context-menu.demo.ts
+++ b/src/app/context-menu/context-menu.demo.ts
@@ -119,7 +119,7 @@ export class ContextMenuDemoComponent implements OnInit {
   onOpenManually(e: SohoContextMenuEvent): void {
     setTimeout(() => {
       this.menuOneContextMenu.close();
-    }, 2000)
+    }, 2000);
   }
 }
 

--- a/src/app/context-menu/context-menu.demo.ts
+++ b/src/app/context-menu/context-menu.demo.ts
@@ -4,7 +4,7 @@ import {
   ViewChild,
   ChangeDetectionStrategy
 } from '@angular/core';
-import { SohoTextAreaComponent } from 'ids-enterprise-ng';
+import { SohoTextAreaComponent, SohoContextMenuDirective } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'app-content-menu-demo',
@@ -14,6 +14,7 @@ import { SohoTextAreaComponent } from 'ids-enterprise-ng';
 export class ContextMenuDemoComponent implements OnInit {
 
   @ViewChild(SohoTextAreaComponent, { static: true }) textarea: SohoTextAreaComponent;
+  @ViewChild('menuOne') menuOneContextMenu: SohoContextMenuDirective;
 
   public normalText = `Input Example`;
   public modText = `Enabled Text Area Example`;
@@ -21,6 +22,7 @@ export class ContextMenuDemoComponent implements OnInit {
   public radioButtonLabel = `Radio Button Example`;
   public checkboxButtonLabel = `Check Box Example`;
   public richTextEditorLabel = `Rich Text Editor Example`;
+  public manualCloseLabel = `Close Context Menu Manually`;
 
   public contextEntries: Array<ContextMenuEntries>;
 
@@ -42,48 +44,48 @@ export class ContextMenuDemoComponent implements OnInit {
     const entries: Array<ContextMenuEntries> = [];
 
     entries.push({
-      displayString       : 'Cutx',
-      disabled : false,
+      displayString: 'Cutx',
+      disabled: false,
       shortcut: '⌘+X'
     });
 
     entries.push({
-      displayString       : 'Copy',
-      disabled : false,
+      displayString: 'Copy',
+      disabled: false,
       shortcut: '⌘+C'
     });
 
     entries.push({
-      displayString       : 'Paste',
-      disabled : false,
+      displayString: 'Paste',
+      disabled: false,
       shortcut: '⌘+V'
     });
 
     entries.push({
-      displayString       : 'Name and project range',
-      id     : 'range',
-      disabled : false
+      displayString: 'Name and project range',
+      id: 'range',
+      disabled: false
     });
 
     entries.push({
-      displayString       : 'Insert comment',
-      disabled : true
+      displayString: 'Insert comment',
+      disabled: true
     });
 
     entries.push({
-      displayString       : 'Insert note',
-      disabled : false
+      displayString: 'Insert note',
+      disabled: false
     });
 
     entries.push({
-      displayString       : 'Clear notes',
-      disabled : true
+      displayString: 'Clear notes',
+      disabled: true
     });
 
     entries.push({
-      displayString       : 'Google',
-      url     : 'http://www.google.com',
-      disabled : false
+      displayString: 'Google',
+      url: 'http://www.google.com',
+      disabled: false
     });
 
     return entries;
@@ -93,7 +95,7 @@ export class ContextMenuDemoComponent implements OnInit {
     console.log('CheckboxDemoComponent.onUpdated');
   }
 
-  constructor() {}
+  constructor() { }
   ngOnInit() {
     this.contextEntries = this.buildContextMenu();
   }
@@ -112,6 +114,12 @@ export class ContextMenuDemoComponent implements OnInit {
 
   onOpen() {
     console.log('onOpen');
+  }
+
+  onOpenManually(e: SohoContextMenuEvent): void {
+    setTimeout(() => {
+      this.menuOneContextMenu.close();
+    }, 2000)
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This allows the Context Menu to be closed manually/programmatically. 

**Related github/jira issue (required)**:
Closes #798

**Steps necessary to review your pull request (required)**:

- Pull this branch, build, and run the demo app
- Go to http://localhost:4200/ids-enterprise-ng-demo/context-menu
- Scroll to bottom and right click on "This context menu will close after 2 seconds"
- Context menu closes after 2 seconds.
