### PR TITLE
915 - Add demo for working close button on About dialogs containing nested Modals

### DIFF
--- a/src/app/about/nested-about.demo.html
+++ b/src/app/about/nested-about.demo.html
@@ -1,0 +1,16 @@
+<div class="row top-padding">
+  <div class="six columns">
+    <p>
+      When a nested dialog is opened from inside the About dialog, it should be possible to close the About dialog using the "X" button. To test:
+    </p>
+    <ol style="padding-top: 20px;">
+        <li>1. Click "About" to open the dialog</li>
+        <li>2. Click "OPEN NESTED" inside the dialog to open a nested dialog.</li>
+        <li>3. Close the nested dialog</li>
+        <li>4. Try to close the About dialog.  It should close with no issues.</li>
+    </ol>
+  </div>
+</div>
+<div class="row top-padding">
+  <button soho-button="primary" (click)="openAbout()">About</button>
+</div>

--- a/src/app/about/nested-about.demo.ts
+++ b/src/app/about/nested-about.demo.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { SohoAboutService, SohoModalDialogService } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-nested-about',
+  templateUrl: './nested-about.demo.html'
+})
+export class AboutNestedDemoComponent {
+
+  constructor(private aboutService: SohoAboutService, private modalService: SohoModalDialogService) { }
+
+  openAbout() {
+    const content = `
+      <div style="text-align: center;">
+        <button class='hyperlink' type='button' id='nestedAboutDialogButton'>OPEN NESTED</button>
+      </div>`;
+    this.aboutService
+      .about()
+      .appName('AppName')
+      .productName('ProductName')
+      .version('1.0')
+      .content(content)
+      .open();
+
+    document.getElementById('nestedAboutDialogButton').onclick = () => {
+      this.modalService.message('').options({
+        id: 'nested',
+        content: 'This is a nested dialog',
+        showCloseBtn: true,
+        title: 'Nested Dialog',
+        triggerButton: '#nestedAboutDialogButton'
+      }).open();
+    };
+  }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { AppRoutingModule } from './app.routes';
 import { SohoComponentsModule } from 'ids-enterprise-ng';
 
 import { AboutDemoComponent } from './about/about.demo';
+import { AboutNestedDemoComponent } from './about/nested-about.demo';
 import { AlertDemoComponent } from './alert/alert.demo';
 import { ApplicationMenuDemoComponent } from './application-menu/application-menu.demo';
 import { ApplicationMenuLazyDemoComponent } from './application-menu/application-menu-lazy.demo';
@@ -246,6 +247,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
   declarations: [
     AppComponent,
     AboutDemoComponent,
+    AboutNestedDemoComponent,
     AlertDemoComponent,
     ApplicationMenuDemoComponent,
     ApplicationMenuLazyDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@
 import { Routes, RouterModule } from '@angular/router';
 
 import { AboutDemoComponent } from './about/about.demo';
+import { AboutNestedDemoComponent } from './about/nested-about.demo';
 import { AlertDemoComponent } from './alert/alert.demo';
 import { ApplicationMenuLazyDemoComponent } from './application-menu/application-menu-lazy.demo';
 import { AreaDemoComponent } from './area/area.demo';
@@ -196,6 +197,7 @@ import { DataGridSummaryRowDemoComponent } from './datagrid/datagrid-summary-row
 export const routes: Routes = [
   { path: '', redirectTo: '', pathMatch: 'full' }, // default
   { path: 'about', component: AboutDemoComponent },
+  { path: 'about-nested', component: AboutNestedDemoComponent },
   { path: 'accordion', loadChildren: () => import('./accordion/accordion-demo.module').then(m => m.AccordionDemoModule) },
   { path: 'alert', component: AlertDemoComponent },
   { path: 'application-lazy-menu', component: ApplicationMenuLazyDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -3,6 +3,7 @@
   <div class="accordion-header"><a href="javascript:void(0);"><span>A</span></a></div>
   <div class="accordion-pane">
     <div class="accordion-header list-item"><a [routerLink]="['about']"><span>About</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['about-nested']"><span>About (Nested)</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['accordion']"><span>Accordion</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['accordion/dynamic']"><span>Accordion Dynamic</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['accordion/panels']"><span>Accordion Panels</span></a></div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds sample code for an issue where the About dialog was unable to be closed by click, after a nested modal had previously been closed.  The actual fix for this exists in Enterprise -- this only adds @anhallbe's sample to the NG demos.

**Related github/jira issue (required)**:
- Closes #915
- Depends on infor-design/enterprise#4606

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp (ensure infor-design/enterprise#4606 is merged before building NG)
- Open http://localhost:4200/ids-enterprise-ng-demo/about-nested
- Click the "About" button
- Click the "OPEN NESTED" link inside the About dialog.
- Click the "X" button to close the nested Modal.
- Click the About dialog's "X" button.  It should close the About dialog as expected.
