### PR TITLE
938 - Fix abort method with soho fileupload advanced

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 8.1.2 Fixes
 
 - `[General]` Added EP version 4.34.2 with Big Sur fixes `TJM`
+- `[FileUploadAdvanced]` Fixed an issue where abort method was not working properly to remove the file block when upload fails. ([#938](https://github.com/infor-design/enterprise-ng/issues/938))
 
 ## v8.1.1
 

--- a/projects/ids-enterprise-typings/lib/fileupload-advanced/soho-fileupload-advanced.d.ts
+++ b/projects/ids-enterprise-typings/lib/fileupload-advanced/soho-fileupload-advanced.d.ts
@@ -22,7 +22,7 @@ interface SohoFileUploadAdvancedStatus {
 
   setProgress(percent: number);
 
-  setAbort(jqXHR: JQueryXHR);
+  setAbort(xhr?: any); // xml http request object
 
   /** The file being uploaded. */
   file: File;

--- a/src/app/fileupload-advanced/fileupload-advanced.demo.ts
+++ b/src/app/fileupload-advanced/fileupload-advanced.demo.ts
@@ -103,7 +103,11 @@ export class FileUploadAdvancedDemoComponent implements OnInit {
         console.error(`Backend returned code ${err.status}, body was: ${err.error}`);
         alert(`Backend returned code ${err.status}, body was: ${err.error}`);
       }
-      status.setCompleted();
+      status.setAbort({
+        abort: function() {
+          console.log('Abort action called');
+        }
+      });
     }
   );
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed abort method was not working properly to remove the file block when upload fails with soho fileupload advanced.

**Related github/jira issue (required)**:
Closes #938

**Steps necessary to review your pull request (required)**:
- After ([PR 4618](https://github.com/infor-design/enterprise/pull/4618)) merged
- Pull and build this branch
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/fileupload-advanced
- Open developer tools
- Use last field on the page labeled as: `Send Method`
- Upload a file
- Should get an alert, click `OK` on alert
- Should show error on console
- Click on `(x)` button on file block
- Should remove the file block, and see console should log

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
