### PR TITLE
926 - Fix support for span tags inside of Breadcrumb items, change examples

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[General]` Added EP version 4.34.2 with Big Sur fixes `TJM`
 - `[FileUploadAdvanced]` Fixed an issue where abort method was not working properly to remove the file block when upload fails. ([#938](https://github.com/infor-design/enterprise-ng/issues/938))
+- `[Breadcrumb]` Enable support for using `span` instead of `a` inside Breadcrumb List Items.  Also added demos of CSS-only and changing content on both JS-powered and CSS-only breadcrumbs. `EPC` ([#926](https://github.com/infor-design/enterprise-ng/issues/926))
 
 ## v8.1.1
 

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.html
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.html
@@ -1,3 +1,1 @@
-<ol aria-label="breadcrumb">
-  <ng-content></ng-content>
-</ol>
+<ng-content></ng-content>

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  HostBinding,
   Input,
   NgZone,
   OnDestroy,
@@ -26,6 +27,8 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
   private options: SohoBreadcrumbOptions = {
     style: 'default'
   };
+
+  @HostBinding('class.breadcrumb') get isBreadcrumb() { return true; }
 
   /** Allow Breadcrumb Definition by Input */
   @Input()
@@ -220,4 +223,13 @@ export class SohoBreadcrumbComponent implements AfterViewInit, OnDestroy, OnInit
       this.breadcrumbAPI.destroy();
     });
   }
+}
+
+@Component({
+  selector: '[soho-breadcrumb-list]', // tslint:disable-line
+  template: `<ng-content></ng-content>`,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SohoBreadcrumbListComponent {
+  @HostBinding('class.breadcrumb-list') get isBreadcrumbList() { return true; }
 }

--- a/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/breadcrumb/soho-breadcrumb.module.ts
@@ -1,17 +1,19 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { SohoBreadcrumbComponent } from './soho-breadcrumb.component';
+import { SohoBreadcrumbComponent, SohoBreadcrumbListComponent } from './soho-breadcrumb.component';
 
 @NgModule({
   imports: [
     CommonModule
   ],
   declarations: [
-    SohoBreadcrumbComponent
+    SohoBreadcrumbComponent,
+    SohoBreadcrumbListComponent
   ],
   exports: [
-    SohoBreadcrumbComponent
+    SohoBreadcrumbComponent,
+    SohoBreadcrumbListComponent
   ]
 })
 
-export class SohoBreadcrumbModule {}
+export class SohoBreadcrumbModule { }

--- a/projects/ids-enterprise-typings/lib/breadcrumb/soho-breadcrumb.d.ts
+++ b/projects/ids-enterprise-typings/lib/breadcrumb/soho-breadcrumb.d.ts
@@ -16,7 +16,7 @@ type SohoBreadcrumbOptionsStyle = 'default' | 'alternate';
  * with a mixed argument, which can be an IDS Breadcrumb Item API,
  * a breadcrumb item's anchor, or a number representing the current index of a breadcrumb item within the list.
  */
-type SohoBreadcrumbRef = SohoBreadcrumbItemStatic | HTMLAnchorElement | Number;
+type SohoBreadcrumbRef = SohoBreadcrumbItemStatic | HTMLLIElement | HTMLAnchorElement | Number;
 
 /**
  * Function prototype for the IDS Breadcrumb Item's optional `callback` property.
@@ -146,11 +146,11 @@ interface SohoBreadcrumbStatic {
 /**
  * IDS Enterprise Breadcrumb Target Object
  * Some internal methods in the IDS Enterprise API return this Object, which
- * contains references to the Breadcrumb Item's anchor, API, and index within the
+ * contains references to the Breadcrumb Item's list item, API, and index within the
  * Breadcrumb list.
  */
 interface SohoBreadcrumbTargetObject {
-  a?: HTMLAnchorElement;
+  li?: HTMLLIElement;
   api?: SohoBreadcrumbItemStatic;
   index?: Number;
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,8 @@ import { BlockGridMultiSelectionDemoComponent } from './blockgrid/blockgrid-mult
 import { BlockGridSingleSelectionDemoComponent } from './blockgrid/blockgrid-single-selection.demo';
 import { BlockGridPagingDemoComponent } from './blockgrid/blockgrid-paging.demo';
 import { BreadcrumbDemoComponent } from './breadcrumb/breadcrumb.demo';
+import { BreadcrumbChangeContentsDemoComponent } from './breadcrumb/breadcrumb-change-contents.demo';
+import { BreadcrumbCssOnlyDemoComponent } from './breadcrumb/breadcrumb-css-only.demo';
 import { BreadcrumbGauntletDemoComponent } from './breadcrumb/breadcrumb-gauntlet.demo';
 import { BubbleDemoComponent } from './bubble/bubble.demo';
 import { BulletDemoComponent } from './bullet/bullet.demo';
@@ -266,6 +268,8 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     BlockGridSingleSelectionDemoComponent,
     BlockGridPagingDemoComponent,
     BreadcrumbDemoComponent,
+    BreadcrumbChangeContentsDemoComponent,
+    BreadcrumbCssOnlyDemoComponent,
     BreadcrumbGauntletDemoComponent,
     BubbleDemoComponent,
     BulletDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -17,6 +17,8 @@ import { BlockGridMultiSelectionDemoComponent } from './blockgrid/blockgrid-mult
 import { BlockGridSingleSelectionDemoComponent } from './blockgrid/blockgrid-single-selection.demo';
 import { BlockGridPagingDemoComponent } from './blockgrid/blockgrid-paging.demo';
 import { BreadcrumbDemoComponent } from './breadcrumb/breadcrumb.demo';
+import { BreadcrumbChangeContentsDemoComponent } from './breadcrumb/breadcrumb-change-contents.demo';
+import { BreadcrumbCssOnlyDemoComponent } from './breadcrumb/breadcrumb-css-only.demo';
 import { BreadcrumbGauntletDemoComponent } from './breadcrumb/breadcrumb-gauntlet.demo';
 import { BubbleDemoComponent } from './bubble/bubble.demo';
 import { BulletDemoComponent } from './bullet/bullet.demo';
@@ -210,6 +212,8 @@ export const routes: Routes = [
   { path: 'bar-grouped', component: BarGroupedDemoComponent },
   { path: 'bar-stacked', component: BarStackedDemoComponent },
   { path: 'breadcrumb', component: BreadcrumbDemoComponent },
+  { path: 'breadcrumb-change-contents', component: BreadcrumbChangeContentsDemoComponent },
+  { path: 'breadcrumb-css-only', component: BreadcrumbCssOnlyDemoComponent },
   { path: 'breadcrumb-gauntlet', component: BreadcrumbGauntletDemoComponent },
   { path: 'blockgrid-custom-content', component: BlockGridCustomContentDemoComponent },
   { path: 'blockgrid-mixed-selection', component: BlockGridMixedSelectionDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -28,6 +28,8 @@
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-paging']"><span>BlockGrid - Paging</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['blockgrid-single-selection']"><span>BlockGrid - Single Selection</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['breadcrumb']"><span>Breadcrumb</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['breadcrumb-change-contents']"><span>Breadcrumb - Change Contents</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['breadcrumb-css-only']"><span>Breadcrumb - CSS Only</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['breadcrumb-gauntlet']"><span>Breadcrumb Gauntlet</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['bubble']"><span>Bubble Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['bullet']"><span>Bullet Chart</span></a></div>

--- a/src/app/breadcrumb/breadcrumb-change-contents.demo.html
+++ b/src/app/breadcrumb/breadcrumb-change-contents.demo.html
@@ -1,0 +1,47 @@
+<div class="row top-padding">
+  <div class="six columns">
+    <p>This demonstrates how to update the contents of Breadcrumb items in two different scenarios.  The top breadcrumb item is updated via the Breadcrumb API, which is preferred if you are taking advantage of the IDS Enterprise Breadcrumb component API.  The bottom breadcrumb item is CSS-only, and is updated directly with string interpolation.</p>
+  </div>
+</div>
+
+<div class="row small-top-padding">
+  <div class="twelve columns">
+    <nav soho-breadcrumb class="breadcrumb">
+      <ol soho-breadcrumb-list class="breadcrumb-list">
+        <li>
+          <span>Top</span>
+        </li>
+        <li>
+          <span>Breadcrumb</span>
+        </li>
+        <li>
+          <span>{{someData}}</span>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</div>
+
+<div class="row small-top-padding">
+  <div class="twelve columns">
+    <nav class="breadcrumb">
+      <ol class="breadcrumb-list">
+        <li>
+          <span>Bottom</span>
+        </li>
+        <li>
+          <span>Breadcrumb</span>
+        </li>
+        <li>
+          <span>{{someData}}</span>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</div>
+
+<div class="row small-top-padding">
+  <div class="twelve columns">
+    <button soho-button (click)="increment()">Increment</button>
+  </div>
+</div>

--- a/src/app/breadcrumb/breadcrumb-change-contents.demo.ts
+++ b/src/app/breadcrumb/breadcrumb-change-contents.demo.ts
@@ -1,0 +1,36 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewChild
+} from '@angular/core';
+
+import { SohoBreadcrumbComponent } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-breadcrumb-demo',
+  templateUrl: 'breadcrumb-change-contents.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BreadcrumbChangeContentsDemoComponent {
+  private _i = 1;
+  @ViewChild(SohoBreadcrumbComponent, { static: true }) sohoBreadcrumbComponent: SohoBreadcrumbComponent;
+
+  /**
+   * Enables template-driven updating of the CSS-only breadcrumb chain.
+   */
+  public get someData() {
+    return this._i;
+  }
+
+  /**
+   * Targets the API-driven Breadcrumb Component on the page, and updates the contents
+   * of the last breadcrumb item in the chain.
+   */
+  public increment() {
+    const targetBreadcrumb = this.sohoBreadcrumbComponent.breadcrumbAPIs[2];
+
+    console.log(`Incrementing ${this._i++}`);
+    targetBreadcrumb.settings.content = `${this._i}`;
+    targetBreadcrumb.refresh();
+  }
+}

--- a/src/app/breadcrumb/breadcrumb-css-only.demo.html
+++ b/src/app/breadcrumb/breadcrumb-css-only.demo.html
@@ -1,0 +1,20 @@
+<div class="row small-top-padding">
+  <div class="twelve columns">
+    <nav class="breadcrumb">
+      <ol class="breadcrumb-list" aria-label="breadcrumb">
+        <li>
+          <a href="./#" id="home" data-automation-id="test-breadcrumb-home" class="hyperlink hide-focus">Home</a>
+        </li>
+        <li>
+          <a href="./#" id="second-item" data-automation-id="test-breadcrumb-second" class="hyperlink hide-focus">Second Item</a>
+        </li>
+        <li>
+          <a href="./#" id="third-item" data-automation-id="test-breadcrumb-third" class="hyperlink hide-focus">Third Item</a>
+        </li>
+        <li class="current">
+          <span>Fourth Item <span class="audible">Current</span></span>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</div>

--- a/src/app/breadcrumb/breadcrumb-css-only.demo.ts
+++ b/src/app/breadcrumb/breadcrumb-css-only.demo.ts
@@ -6,14 +6,11 @@ import {
 
 import { SohoBreadcrumbComponent } from 'ids-enterprise-ng';
 
-import { STANDARD_DATA } from './breadcrumb-demo-data';
-
 @Component({
   selector: 'app-breadcrumb-demo',
-  templateUrl: 'breadcrumb.demo.html',
+  templateUrl: 'breadcrumb-css-only.demo.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BreadcrumbDemoComponent {
+export class BreadcrumbCssOnlyDemoComponent {
   @ViewChild(SohoBreadcrumbComponent, { static: true }) sohoBreadcrumbComponent: SohoBreadcrumbComponent;
-  public breadcrumbs = STANDARD_DATA;
 }

--- a/src/app/breadcrumb/breadcrumb-demo-data.ts
+++ b/src/app/breadcrumb/breadcrumb-demo-data.ts
@@ -3,7 +3,6 @@ export const STANDARD_DATA = [
   {
     content: 'Home',
     id: 'test-breadcrumb-home',
-    href: '#'
   },
   {
     content: 'Second Item',
@@ -19,6 +18,5 @@ export const STANDARD_DATA = [
     content: 'Fourth Item',
     current: true,
     id: 'test-breadcrumb-fourth',
-    href: '#'
   }
 ];

--- a/src/app/breadcrumb/breadcrumb-gauntlet.demo.ts
+++ b/src/app/breadcrumb/breadcrumb-gauntlet.demo.ts
@@ -103,7 +103,7 @@ export class BreadcrumbGauntletDemoComponent {
     const self = this;
     if (this.demoForm.controls['callback'].value) {
       newSettings.callback = function testCallback (e) {
-        self.renderBreadcrumbConfig(e.target);
+        self.renderBreadcrumbConfig(e.currentTarget);
         const content = this.settings.content;
 
         // Trigger a toast message


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR builds on top of an IDS Enterprise change to the breadcrumb to help enable the support for `<span>` tags to be respected by the new Javascript-based Breadcrumb API.  This was incorrectly missing from the last implementation.

This PR also adds a modified version of @bthharper's samples from the original issue to demo:
- A CSS-only Breadcrumb component (supports template interpolation)
- An example of how to update the contents of both a CSS-only Breadcrumb Item (using templating) and a JS-driven one (using the exposed EP API). 

Additionally, some changes to the existing demos had to be made to support usage of the `<li>` instead of the `<a>` as the base for the `SohoBreadcrumbItemStatic` API.

**Related github/jira issue (required)**:
- Closes #926
- Related to infor-design/enterprise#4635

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp.  Make sure that either infor-design/enterprise#4635 is merged, or this project is linked to a build of it somehow.
- Open http://localhost:4200/ids-enterprise-ng-demo/breadcrumb-change-contents.  Clicking "Increment" should cause both items to update their contents.
- Open http://localhost:4200/ids-enterprise-ng-demo/breadcrumb-css-only - Everything should appear to render correctly
- Open http://localhost:4200/ids-enterprise-ng-demo/breadcrumb-gauntlet.  Try adding breadcrumbs with and without an href property. The ones with an href property will be rendered with a hyperlink -- the ones without will be rendered with a span tag. The coloration of these two things will be slightly different but the font size/alignment/padding should be roughly the same.
