### PR TITLE
#955 stepprocess: feature to call selectStep when isSelected is set to true on one of the SohoStepListItemComponent

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
@@ -77,7 +77,7 @@ export class SohoStepListItemComponent {
 
   @HostBinding('class.is-selected') @Input() set isSelected(isSelected: boolean) {
     if (isSelected) {
-      let stepLink = $(this.element.nativeElement).children('a.js-step-link');
+      const stepLink = $(this.element.nativeElement).children('a.js-step-link');
       this.sohoStepProcessComponent.stepprocess?.selectStep(stepLink);
     }
   }

--- a/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
@@ -82,6 +82,8 @@ export class SohoStepListItemComponent {
     }
   }
 
+  @Input() stepId?: string;
+
   constructor(@Host() private sohoStepProcessComponent: SohoStepProcessComponent, private element: ElementRef) { }
 }
 

--- a/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
@@ -75,20 +75,15 @@ export class SohoStepListItemComponent {
     return true;
   }
 
+  @HostBinding('class.is-selected') _isSelected = false;
+
   @Input() set isSelected(isSelected: boolean) {
+    this._isSelected = isSelected;
     if (isSelected) {
       const stepLink = $(this.element.nativeElement).children('a.js-step-link');
       this.sohoStepProcessComponent.stepprocess?.selectStep(stepLink);
     }
-    this._isSelected = isSelected;
   }
-
-  get isSelected() {
-    return this._isSelected;
-  }
-
-  @HostBinding('class.is-selected') _isSelected: boolean = false;
-
 
   constructor(@Host() private sohoStepProcessComponent: SohoStepProcessComponent, private element: ElementRef) { }
 }

--- a/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
@@ -75,14 +75,20 @@ export class SohoStepListItemComponent {
     return true;
   }
 
-  @HostBinding('class.is-selected') @Input() set isSelected(isSelected: boolean) {
+  @Input() set isSelected(isSelected: boolean) {
     if (isSelected) {
       const stepLink = $(this.element.nativeElement).children('a.js-step-link');
       this.sohoStepProcessComponent.stepprocess?.selectStep(stepLink);
     }
+    this._isSelected = isSelected;
   }
 
-  @Input() stepId?: string;
+  get isSelected() {
+    return this._isSelected;
+  }
+
+  @HostBinding('class.is-selected') _isSelected: boolean = false;
+
 
   constructor(@Host() private sohoStepProcessComponent: SohoStepProcessComponent, private element: ElementRef) { }
 }

--- a/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/stepprocess/soho-stepprocess.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  Host,
   HostBinding,
   Input,
   OnDestroy,
@@ -73,7 +74,15 @@ export class SohoStepListItemComponent {
   @HostBinding('class.js-step') get jsStep() {
     return true;
   }
-  @HostBinding('class.is-selected') @Input() isSelected = false;
+
+  @HostBinding('class.is-selected') @Input() set isSelected(isSelected: boolean) {
+    if (isSelected) {
+      let stepLink = $(this.element.nativeElement).children('a.js-step-link');
+      this.sohoStepProcessComponent.stepprocess?.selectStep(stepLink);
+    }
+  }
+
+  constructor(@Host() private sohoStepProcessComponent: SohoStepProcessComponent, private element: ElementRef) { }
 }
 
 /**************************************************************
@@ -219,7 +228,7 @@ export class SohoStepProcessComponent implements AfterViewInit, OnDestroy {
   private jQueryElement?: JQuery;
 
   // Reference to the soho stepprocess control api.
-  private stepprocess?: SohoStepProcessStatic;
+  public stepprocess?: SohoStepProcessStatic;
 
   // The internal stepsOptions object used to construct the stepproces control
   private stepProcessOptions: SohoStepProcessOptions = {};

--- a/projects/ids-enterprise-typings/lib/stepprocess/soho-stepprocess.d.ts
+++ b/projects/ids-enterprise-typings/lib/stepprocess/soho-stepprocess.d.ts
@@ -45,6 +45,12 @@ interface SohoStepProcessStatic {
   getSelectedStep(): JQuery;
 
   /**
+   * go to a specific step
+   * @param stepLink jquery object of the step anchor
+   */
+  selectStep(stepLink: JQuery): void;
+
+  /**
    * Destructor,
    */
   destroy(): void;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,5 @@
-﻿import { BrowserModule } from '@angular/platform-browser';
+﻿import { StepProcessAutoStepChangeComponent } from './stepprocess/stepprocess-auto-step-change.demo';
+import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import {
   CommonModule
@@ -414,6 +415,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     StepProcessBtnDisableDemoComponent,
     StepProcessDataDrivenDemoComponent,
     StepProcessVetoableDemoComponent,
+    StepProcessAutoStepChangeComponent,
     SwapListDemoComponent,
     SwapListDynamicDemoComponent,
     SwapListFullAccessDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,5 @@
-﻿import { ModuleWithProviders } from '@angular/core';
+﻿import { StepProcessAutoStepChangeComponent } from './stepprocess/stepprocess-auto-step-change.demo';
+import { ModuleWithProviders } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { AboutDemoComponent } from './about/about.demo';
@@ -349,6 +350,7 @@ export const routes: Routes = [
   { path: 'step-process-btn-disble', component: StepProcessBtnDisableDemoComponent },
   { path: 'step-data-driven', component: StepProcessDataDrivenDemoComponent },
   { path: 'step-process-vetoable', component: StepProcessVetoableDemoComponent },
+  { path: 'step-process-auto-step-change', component: StepProcessAutoStepChangeComponent },
   { path: 'swaplist', component: SwapListDemoComponent },
   { path: 'swaplist-dynamic', component: SwapListDynamicDemoComponent },
   { path: 'swaplist-full-access', component: SwapListFullAccessDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -222,6 +222,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['step-process-btn-disble']"><span>Step Process - Disable Buttons</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['step-data-driven']"><span>Step Process - Data Driven</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['step-process-vetoable']"><span>Step Process - Vetoable</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['step-process-auto-step-change']"><span>Step Process - Auto Step Change</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['swaplist']"><span>Swap List - Basic</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['swaplist-dynamic']"><span>Swap List - Dynamic</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['swaplist-full-access']"><span>Swap List - Full Access</span></a></div>

--- a/src/app/stepprocess/stepprocess-auto-step-change.demo.html
+++ b/src/app/stepprocess/stepprocess-auto-step-change.demo.html
@@ -8,21 +8,21 @@
 
     <ng-template ngFor let-step [ngForOf]="steps">
 
-      <li soho-step-list-item *ngIf="step.content">
+      <li soho-step-list-item stepId="{{step.id}}" *ngIf="step.content">
         <a soho-step-list-item-anchor stepId="{{step.id}}">
           <svg soho-icon icon="{{step.icon}}" alert="true"></svg>
           <span soho-step-list-item-title>{{step.title}}</span>
         </a>
       </li>
 
-      <li soho-step-list-item *ngIf="!step.content">
+      <li soho-step-list-item stepId="{{step.id}}" *ngIf="!step.content">
         <a soho-step-list-item-anchor stepId="{{step.id}}" *ngIf="step.substeps">
           <svg soho-icon icon="{{step.icon}}" alert="true"></svg>
           <span soho-step-list-item-title>{{step.title}}</span>
           <svg soho-icon icon="caret-down" class="icon-tree"></svg>
         </a>
         <ul soho-substep-list *ngIf="step.substeps">
-          <li soho-step-list-item *ngFor="let substep of step.substeps">
+          <li soho-step-list-item stepId="{{substep.id}}" *ngFor="let substep of step.substeps">
             <a soho-step-list-item-anchor stepId="{{substep.id}}">
               <svg soho-icon icon="{{substep.icon}}"></svg>
               <span soho-step-list-item-title>{{substep.title}}</span>
@@ -52,5 +52,27 @@
         </div>
       </div>
     </div>
-  </div>
+
+      <p>
+        <button soho-button (click)="selectPanel('step1')">Toggle step1</button>
+      </p>
+      <p>
+        <button soho-button (click)="selectPanel('step1Sub1')">Select step1Sub1</button>
+      </p>
+      <p>
+        <button soho-button (click)="selectPanel('step1Sub2')">Select step1Sub2</button>
+      </p>
+      <p>
+        <button soho-button (click)="selectPanel('step2')">Select step2</button>
+      </p>
+      <p>
+        <button soho-button (click)="selectPanel('step3')">Toggle step3</button>
+      </p>
+      <p>
+        <button soho-button (click)="selectPanel('step3Sub1')">Select step3Sub1</button>
+      </p>
+      <p>
+        <button soho-button (click)="selectPanel('step3Sub2')">step3Sub2</button>
+      </p>
+    </div>
 </div>

--- a/src/app/stepprocess/stepprocess-auto-step-change.demo.html
+++ b/src/app/stepprocess/stepprocess-auto-step-change.demo.html
@@ -1,0 +1,56 @@
+<div soho-stepprocess>
+
+  <div soho-step-list-title>
+    These are the steps
+  </div>
+
+  <ul soho-step-list>
+
+    <ng-template ngFor let-step [ngForOf]="steps">
+
+      <li soho-step-list-item *ngIf="step.content">
+        <a soho-step-list-item-anchor stepId="{{step.id}}">
+          <svg soho-icon icon="{{step.icon}}" alert="true"></svg>
+          <span soho-step-list-item-title>{{step.title}}</span>
+        </a>
+      </li>
+
+      <li soho-step-list-item *ngIf="!step.content">
+        <a soho-step-list-item-anchor stepId="{{step.id}}" *ngIf="step.substeps">
+          <svg soho-icon icon="{{step.icon}}" alert="true"></svg>
+          <span soho-step-list-item-title>{{step.title}}</span>
+          <svg soho-icon icon="caret-down" class="icon-tree"></svg>
+        </a>
+        <ul soho-substep-list *ngIf="step.substeps">
+          <li soho-step-list-item *ngFor="let substep of step.substeps">
+            <a soho-step-list-item-anchor stepId="{{substep.id}}">
+              <svg soho-icon icon="{{substep.icon}}"></svg>
+              <span soho-step-list-item-title>{{substep.title}}</span>
+            </a>
+          </li>
+        </ul>
+      </li>
+
+    </ng-template>
+
+  </ul>
+
+  <div soho-step-content-title>
+    Step Process
+    <small>Page X of XX</small>
+  </div>
+
+  <div soho-step-content>
+    <div *ngFor="let step of steps">
+      <div soho-step-content-panel *ngIf="step.content" stepId="{{step.id}}">
+        <p *ngIf="step.content">{{step.content}}</p>
+        <p *ngIf="!step.content">Step Content for title {{step.title}}</p>
+      </div>
+      <div *ngIf="step.substeps">
+        <div soho-step-content-panel *ngFor="let substep of step.substeps" stepId="{{substep.id}}">
+          <p>{{substep.content}}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/stepprocess/stepprocess-auto-step-change.demo.html
+++ b/src/app/stepprocess/stepprocess-auto-step-change.demo.html
@@ -8,21 +8,21 @@
 
     <ng-template ngFor let-step [ngForOf]="steps">
 
-      <li soho-step-list-item stepId="{{step.id}}" *ngIf="step.content">
+      <li soho-step-list-item  *ngIf="step.content" [isSelected]="step.id === selectedPanelId">
         <a soho-step-list-item-anchor stepId="{{step.id}}">
           <svg soho-icon icon="{{step.icon}}" alert="true"></svg>
           <span soho-step-list-item-title>{{step.title}}</span>
         </a>
       </li>
 
-      <li soho-step-list-item stepId="{{step.id}}" *ngIf="!step.content">
+      <li soho-step-list-item *ngIf="!step.content" [isSelected]="step.id === selectedPanelId">
         <a soho-step-list-item-anchor stepId="{{step.id}}" *ngIf="step.substeps">
           <svg soho-icon icon="{{step.icon}}" alert="true"></svg>
           <span soho-step-list-item-title>{{step.title}}</span>
           <svg soho-icon icon="caret-down" class="icon-tree"></svg>
         </a>
-        <ul soho-substep-list *ngIf="step.substeps">
-          <li soho-step-list-item stepId="{{substep.id}}" *ngFor="let substep of step.substeps">
+        <ul soho-substep-list *ngIf="step.substeps" >
+          <li soho-step-list-item [isSelected]="substep.id === selectedPanelId" *ngFor="let substep of step.substeps">
             <a soho-step-list-item-anchor stepId="{{substep.id}}">
               <svg soho-icon icon="{{substep.icon}}"></svg>
               <span soho-step-list-item-title>{{substep.title}}</span>
@@ -52,27 +52,19 @@
         </div>
       </div>
     </div>
-
+    <div>
       <p>
-        <button soho-button (click)="selectPanel('step1')">Toggle step1</button>
-      </p>
-      <p>
-        <button soho-button (click)="selectPanel('step1Sub1')">Select step1Sub1</button>
-      </p>
-      <p>
-        <button soho-button (click)="selectPanel('step1Sub2')">Select step1Sub2</button>
-      </p>
-      <p>
-        <button soho-button (click)="selectPanel('step2')">Select step2</button>
-      </p>
-      <p>
-        <button soho-button (click)="selectPanel('step3')">Toggle step3</button>
-      </p>
-      <p>
-        <button soho-button (click)="selectPanel('step3Sub1')">Select step3Sub1</button>
-      </p>
-      <p>
-        <button soho-button (click)="selectPanel('step3Sub2')">step3Sub2</button>
+        <button soho-button (click)="selectPanel('step1')">Select Step 1</button> <br>
+        <button soho-button (click)="selectPanel('step1Sub1')">Select Step 1 Sub 1</button><br>
+        <button soho-button (click)="selectPanel('step1Sub2')">Select Step 1 Sub 2</button><br>
+        <button soho-button (click)="selectPanel('step2')">Select Step 2</button><br>
+        <button soho-button (click)="selectPanel('step3')">Select Step 3</button><br>
+        <button soho-button (click)="selectPanel('step3Sub1')">Select Step 3 Sub 1</button><br>
+        <button soho-button (click)="selectPanel('step3Sub2')">Select Step 3 Sub 2</button><br>
+        <button soho-button (click)="selectPanel('step4')">Select Step 4</button><br>
       </p>
     </div>
+  </div>
+
+
 </div>

--- a/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
+++ b/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
@@ -8,7 +8,7 @@ import { SohoStepListItemComponent } from 'ids-enterprise-ng';
   selector: 'app-stepprocess-auto-step-change-demo',
   templateUrl: 'stepprocess-auto-step-change.demo.html'
 })
-export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit {
+export class StepProcessAutoStepChangeComponent implements OnInit {
 
   public selectedPanelId?: string;
 
@@ -19,7 +19,6 @@ export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit
     content?: string,
     substeps?: Array<{ id: string, title: string, icon: string, content: string }>
   }>;
-  constructor() { }
 
   ngOnInit() {
     this.steps = [
@@ -46,8 +45,6 @@ export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit
   selectPanel(id: string) {
     this.selectedPanelId = id;
   }
-
-  ngAfterViewInit() { }
 
   stepChange(_event: Event) {
     console.log('StepProcessAutoStepChangeComponent.stepChange');

--- a/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
+++ b/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
@@ -10,7 +10,9 @@ import { SohoStepListItemComponent } from 'ids-enterprise-ng';
 })
 export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit {
 
-  @ViewChildren(SohoStepListItemComponent) stepListItems?: QueryList<SohoStepListItemComponent>;
+  public selectedPanelId: string = "";
+
+  @ViewChildren(SohoStepListItemComponent) stepListItems!: QueryList<SohoStepListItemComponent>;
 
   public steps?: Array<{
     id: string,
@@ -36,70 +38,23 @@ export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit
         substeps: [
           { id: 'step3Sub1', title: 'Step 3 Sub 1', icon: 'empty-circle', content: 'Step 3 Sub 1 content' }, // eslint-disable-line
           { id: 'step3Sub2', title: 'Step 3 Sub 2', icon: 'error', content: 'Step 3 Sub 2 content' }, // eslint-disable-line
-          { id: 'step3Sub3', title: 'Step 3 Sub 3', icon: 'success', content: 'Step 3 Sub 3 content' }, // eslint-disable-line
         ]
-      }, // eslint-disable-line
-      { id: 'step4', title: 'Step 4', icon: 'empty-circle', content: 'Step 4 content' }, // eslint-disable-line
-      {
-        id: 'step5', title: 'Step 5', icon: 'half-empty-circle',
-        substeps: [
-          { id: 'step5Sub1', title: 'Step 5 Sub 1', icon: 'success', content: 'Step 5 Sub 1 content' }, // eslint-disable-line
-          { id: 'step5Sub2', title: 'Step 5 Sub 2', icon: 'empty-circle', content: 'Step 5 Sub 2 content' }, // eslint-disable-line
-          { id: 'step5Sub3', title: 'Step 5 Sub 3', icon: 'error', content: 'Step 5 Sub 3 content' }, // eslint-disable-line
-          { id: 'step5Sub4', title: 'Step 5 Sub 4', icon: 'empty-circle', content: 'Step 5 Sub 4 content' }, // eslint-disable-line
-          { id: 'step5Sub5', title: 'Step 5 Sub 5', icon: 'empty-circle', content: 'Step 5 Sub 5 content' }, // eslint-disable-line
-          { id: 'step5Sub6', title: 'Step 5 Sub 6', icon: 'error', content: 'Step 5 Sub 6 content' }, // eslint-disable-line
-        ]
-      }, // eslint-disable-line
-      { id: 'step6', title: 'Step 6', icon: 'empty-circle', content: 'Step 6 content' }, // eslint-disable-line
-      { id: 'step7', title: 'Step 7', icon: 'error', content: 'Step 7 content' }, // eslint-disable-line
-      { id: 'step8', title: 'Step 8', icon: 'success', content: 'Step 8 content' }, // eslint-disable-line
-      { id: 'step9', title: 'Step 9', icon: 'success', content: 'Step 9 content' }, // eslint-disable-line
-    ];
+      }
+    ]
   }
 
-  ngAfterViewInit() {
 
-    setTimeout(() => {
-      if (this.stepListItems) {
-        const stepListItemsLength = this.stepListItems.toArray().length;
-        const stepNo = Math.floor(Math.random() * stepListItemsLength);
-        this.stepListItems.toArray()[stepNo].isSelected = true;
-        console.log(stepNo);
-        console.log('step changed');
-      }
-    }, 5000);
-    setTimeout(() => {
-      if (this.stepListItems) {
-        const stepListItemsLength = this.stepListItems.toArray().length;
-        const stepNo = Math.floor(Math.random() * stepListItemsLength);
-        this.stepListItems.toArray()[stepNo].isSelected = true;
-        console.log(stepNo);
-        console.log('step changed');
-      }
-    }, 7000);
-    setTimeout(() => {
-      if (this.stepListItems) {
-        const stepListItemsLength = this.stepListItems.toArray().length;
-        const stepNo = Math.floor(Math.random() * stepListItemsLength);
-        this.stepListItems.toArray()[stepNo].isSelected = true;
-        console.log(stepNo);
-        console.log('step changed');
-      }
-    }, 9000);
-    setTimeout(() => {
-      if (this.stepListItems) {
-        const stepListItemsLength = this.stepListItems.toArray().length;
-        const stepNo = Math.floor(Math.random() * stepListItemsLength);
-        this.stepListItems.toArray()[stepNo].isSelected = true;
-        console.log(stepNo);
-        console.log('step changed');
-      }
-    }, 11000);
-
+  selectPanel(id: string) {
+    console.log(id);
+    const selectedItem = this.stepListItems.find((item) => item.stepId == id);
+    if (selectedItem) {
+      selectedItem.isSelected = true;
+    }
   }
+
+  ngAfterViewInit() { }
 
   stepChange(_event: Event) {
-    console.log('stepProcessDataDrivenDemoComponent.stepChange');
+    console.log('StepProcessAutoStepChangeComponent.stepChange');
   }
 }

--- a/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
+++ b/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
@@ -1,0 +1,105 @@
+import {
+  Component,
+  OnInit, AfterViewInit, ViewChild, ViewChildren, QueryList
+} from '@angular/core';
+import { SohoStepListItemComponent } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-stepprocess-auto-step-change-demo',
+  templateUrl: 'stepprocess-auto-step-change.demo.html'
+})
+export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit {
+
+  @ViewChildren(SohoStepListItemComponent) stepListItems?: QueryList<SohoStepListItemComponent>;
+
+  public steps?: Array<{
+    id: string,
+    title: string,
+    icon: string,
+    content?: string,
+    substeps?: Array<{ id: string, title: string, icon: string, content: string }>
+  }>;
+  constructor() { }
+
+  ngOnInit() {
+    this.steps = [
+      {
+        id: 'step1', title: 'Step 1', icon: 'error',
+        substeps: [
+          { id: 'step1Sub1', title: 'Step 1 Sub 1', icon: 'empty-circle', content: 'Step 1 Sub 1 content' }, // eslint-disable-line
+          { id: 'step1Sub2', title: 'Step 1 Sub 2', icon: 'empty-circle', content: 'Step 1 Sub 2 content' }, // eslint-disable-line
+        ]
+      }, // eslint-disable-line
+      { id: 'step2', title: 'Step 2', icon: 'success', content: 'Step 2 content' }, // eslint-disable-line
+      {
+        id: 'step3', title: 'Step 3', icon: 'empty-circle',
+        substeps: [
+          { id: 'step3Sub1', title: 'Step 3 Sub 1', icon: 'empty-circle', content: 'Step 3 Sub 1 content' }, // eslint-disable-line
+          { id: 'step3Sub2', title: 'Step 3 Sub 2', icon: 'error', content: 'Step 3 Sub 2 content' }, // eslint-disable-line
+          { id: 'step3Sub3', title: 'Step 3 Sub 3', icon: 'success', content: 'Step 3 Sub 3 content' }, // eslint-disable-line
+        ]
+      }, // eslint-disable-line
+      { id: 'step4', title: 'Step 4', icon: 'empty-circle', content: 'Step 4 content' }, // eslint-disable-line
+      {
+        id: 'step5', title: 'Step 5', icon: 'half-empty-circle',
+        substeps: [
+          { id: 'step5Sub1', title: 'Step 5 Sub 1', icon: 'success', content: 'Step 5 Sub 1 content' }, // eslint-disable-line
+          { id: 'step5Sub2', title: 'Step 5 Sub 2', icon: 'empty-circle', content: 'Step 5 Sub 2 content' }, // eslint-disable-line
+          { id: 'step5Sub3', title: 'Step 5 Sub 3', icon: 'error', content: 'Step 5 Sub 3 content' }, // eslint-disable-line
+          { id: 'step5Sub4', title: 'Step 5 Sub 4', icon: 'empty-circle', content: 'Step 5 Sub 4 content' }, // eslint-disable-line
+          { id: 'step5Sub5', title: 'Step 5 Sub 5', icon: 'empty-circle', content: 'Step 5 Sub 5 content' }, // eslint-disable-line
+          { id: 'step5Sub6', title: 'Step 5 Sub 6', icon: 'error', content: 'Step 5 Sub 6 content' }, // eslint-disable-line
+        ]
+      }, // eslint-disable-line
+      { id: 'step6', title: 'Step 6', icon: 'empty-circle', content: 'Step 6 content' }, // eslint-disable-line
+      { id: 'step7', title: 'Step 7', icon: 'error', content: 'Step 7 content' }, // eslint-disable-line
+      { id: 'step8', title: 'Step 8', icon: 'success', content: 'Step 8 content' }, // eslint-disable-line
+      { id: 'step9', title: 'Step 9', icon: 'success', content: 'Step 9 content' }, // eslint-disable-line
+    ];
+  }
+
+  ngAfterViewInit() {
+
+    setTimeout(() => {
+      if (this.stepListItems) {
+        const stepListItemsLength = this.stepListItems.toArray().length;
+        const stepNo = Math.floor(Math.random() * stepListItemsLength);
+        this.stepListItems.toArray()[stepNo].isSelected = true;
+        console.log(stepNo);
+        console.log('step changed');
+      }
+    }, 5000);
+    setTimeout(() => {
+      if (this.stepListItems) {
+        const stepListItemsLength = this.stepListItems.toArray().length;
+        const stepNo = Math.floor(Math.random() * stepListItemsLength);
+        this.stepListItems.toArray()[stepNo].isSelected = true;
+        console.log(stepNo);
+        console.log('step changed');
+      }
+    }, 7000);
+    setTimeout(() => {
+      if (this.stepListItems) {
+        const stepListItemsLength = this.stepListItems.toArray().length;
+        const stepNo = Math.floor(Math.random() * stepListItemsLength);
+        this.stepListItems.toArray()[stepNo].isSelected = true;
+        console.log(stepNo);
+        console.log('step changed');
+      }
+    }, 9000);
+    setTimeout(() => {
+      if (this.stepListItems) {
+        const stepListItemsLength = this.stepListItems.toArray().length;
+        const stepNo = Math.floor(Math.random() * stepListItemsLength);
+        this.stepListItems.toArray()[stepNo].isSelected = true;
+        console.log(stepNo);
+        console.log('step changed');
+      }
+    }, 11000);
+
+  }
+
+  stepChange(_event: Event) {
+    console.log('stepProcessDataDrivenDemoComponent.stepChange');
+  }
+}

--- a/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
+++ b/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
@@ -12,8 +12,6 @@ export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit
 
   public selectedPanelId?: string;
 
-  @ViewChildren(SohoStepListItemComponent) stepListItems!: QueryList<SohoStepListItemComponent>;
-
   public steps?: Array<{
     id: string,
     title: string,
@@ -39,17 +37,14 @@ export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit
           { id: 'step3Sub1', title: 'Step 3 Sub 1', icon: 'empty-circle', content: 'Step 3 Sub 1 content' }, // eslint-disable-line
           { id: 'step3Sub2', title: 'Step 3 Sub 2', icon: 'error', content: 'Step 3 Sub 2 content' }, // eslint-disable-line
         ]
-      }
+      },
+      { id: 'step4', title: 'Step 4', icon: 'success', content: 'Step 4 content' }
     ]
   }
 
 
   selectPanel(id: string) {
-    console.log(id);
-    const selectedItem = this.stepListItems.find((item) => item.stepId === id);
-    if (selectedItem) {
-      selectedItem.isSelected = true;
-    }
+    this.selectedPanelId = id;
   }
 
   ngAfterViewInit() { }

--- a/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
+++ b/src/app/stepprocess/stepprocess-auto-step-change.demo.ts
@@ -10,7 +10,7 @@ import { SohoStepListItemComponent } from 'ids-enterprise-ng';
 })
 export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit {
 
-  public selectedPanelId: string = "";
+  public selectedPanelId?: string;
 
   @ViewChildren(SohoStepListItemComponent) stepListItems!: QueryList<SohoStepListItemComponent>;
 
@@ -46,7 +46,7 @@ export class StepProcessAutoStepChangeComponent implements OnInit, AfterViewInit
 
   selectPanel(id: string) {
     console.log(id);
-    const selectedItem = this.stepListItems.find((item) => item.stepId == id);
+    const selectedItem = this.stepListItems.find((item) => item.stepId === id);
     if (selectedItem) {
       selectedItem.isSelected = true;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

We cannot navigate to another panel via code, in this PR, we can just update the stepListItemComponent of that particular panel to true, and it will call selectStep to navigate and display that particular panel into view. 

**Related github/jira issue (required)**:

- Closes #955 
- https://jira.lawson.com/browse/LMCLIENT-32916

**Steps necessary to review your pull request (required)**:

- pull the code from a fork: https://github.com/JBismonte/enterprise-ng, build and run the demo app.
- go to http://localhost:4200/ids-enterprise-ng-demo/step-process-auto-step-change
- click any buttons, it should navigate to the correct panel.

See screen recording:

https://user-images.githubusercontent.com/29673378/102778777-25b6e800-43ce-11eb-8334-5a5fadb60231.mp4



note: 
- when you set the isSelected to true in a panel that is a folder, it will toggle the folder to either open or close.

<!-- 
Other:
Here is the recording.
[step process test with 955.zip](https://github.com/infor-design/enterprise-ng/files/5701437/step.process.test.with.955.zip)
here are the files i modified to test
[stepprocess.zip](https://github.com/infor-design/enterprise-ng/files/5701442/stepprocess.zip)

tested also other scenarios that uses the stepprocess component.



Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass on Travis
-->
