### PR TITLE
Rating: Expose the readonly and enable methods

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,11 @@
     - Replace `tslint` with `eslint`.
 - `[General]` Enabled strict compiling in the library and demos. This allows you to enable it as well when compiling. If you do you can do this in the tsconfig in your project like [this](https://github.com/infor-design/enterprise-ng/pull/939/files#diff-b5f32afdd9e8c14b02c570db855022a30aeb595e3dd1c3a71c187d685c0a2860R7). Then you may need to update your code to add more types and protections from null.  ([#755](https://github.com/infor-design/enterprise/issues/755)) `TJM`
 
+## v8.2.4
+
+### 8.2.4 Fixes
+- `[Rating]` Exposed the readonly and enable methods. This allows the component to be toggled between read only and editable. ([#958](https://github.com/infor-design/enterprise-ng/issues/958)) `MHH`
+
 ## v8.2.3
 
 ### 8.2.3 Fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 ## v8.2.4
 
 ### 8.2.4 Fixes
+
 - `[Rating]` Exposed the readonly and enable methods. This allows the component to be toggled between read only and editable. ([#958](https://github.com/infor-design/enterprise-ng/issues/958)) `MHH`
 
 ## v8.2.3

--- a/projects/ids-enterprise-ng/src/lib/rating/soho-rating.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/rating/soho-rating.component.ts
@@ -38,4 +38,18 @@ export class SohoRatingComponent implements AfterViewInit, OnDestroy {
       this.rating = null;
     }
   }
+
+  /** Make control read only **/
+  public readonly(): void {
+    if (this.rating) {
+      this.rating.readonly();
+    }
+  }
+
+  /** Enable the control **/
+  public enable(): void {
+    if (this.rating) {
+      this.rating.enable();
+    }
+  }
 }

--- a/projects/ids-enterprise-ng/src/lib/rating/soho-rating.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/rating/soho-rating.spec.ts
@@ -29,7 +29,7 @@ describe('Soho Rating Unit Tests', () => {
 });
 
 @Component({
-  template: `<div soho-rating>`
+  template: `<div soho-rating></div>`
 })
 class SohoRatingTestComponent {
   @ViewChild(SohoRatingComponent) rating?: SohoRatingComponent;
@@ -39,6 +39,7 @@ describe('Soho Rating Chart Render', () => {
   let fixture: ComponentFixture<SohoRatingTestComponent>;
   let de: DebugElement;
   let el: HTMLElement;
+  let component: SohoRatingComponent | undefined;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -50,10 +51,21 @@ describe('Soho Rating Chart Render', () => {
 
     de = fixture.debugElement;
     el = de.query(By.css('[soho-rating]')).nativeElement;
+    component = fixture.componentInstance.rating;
   });
 
   it('Check HTML content', () => {
     expect(el.hasAttribute('soho-rating')).toBeTruthy('soho-rating');
+  });
+
+  it ('Check readonly/enable', () => {
+    if (component) {
+      component.readonly();
+      expect(el.classList.contains('is-readonly')).toBeTruthy();
+
+      component.enable();
+      expect(el.classList.contains('is-readonly')).toBeFalsy();
+    }
   });
 
 });

--- a/src/app/rating/rating.demo.html
+++ b/src/app/rating/rating.demo.html
@@ -1,7 +1,7 @@
 <div class="row top-padding">
   <div class="twelve columns">
     <div class="field">
-      <div soho-rating>
+      <div #sohoRating soho-rating>
         <fieldset>
           <legend class="audible">Rate Your Experience</legend>
           <input type="radio" class="is-filled" name="rating-id1" id="one-star-id1">
@@ -46,5 +46,7 @@
         </fieldset>
       </div>
     </div>
+    <button soho-button (click)="readonly()">Make Read Only</button>
+    <button soho-button (click)="enable()">Enable</button>
   </div>
 </div>

--- a/src/app/rating/rating.demo.ts
+++ b/src/app/rating/rating.demo.ts
@@ -1,14 +1,24 @@
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import { SohoRatingComponent } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'app-rating-demo',
   templateUrl: 'rating.demo.html'
 })
-export class RatingDemoComponent implements OnInit {
+export class RatingDemoComponent implements AfterViewInit {
+  @ViewChild('sohoRating') rating!:SohoRatingComponent;
 
-  constructor() {
+  ngAfterViewInit() { }
+
+  public readonly(): void {
+    if (this.rating) {
+      this.rating.readonly();
+    }
   }
 
-  ngOnInit() {
+  public enable(): void {
+    if (this.rating) {
+      this.rating.enable();
+    }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Exposed the readonly and enable methods that were in the interface for the component. This was needed to be able to toggle the readonly status of the component in angular.

**Related github/jira issue (required)**:
"Closes #958 "

**Steps necessary to review your pull request (required)**:
1. Pull and build the code
2. Navigate to the Rating page
3. Click the 'Make Read Only" button
4. See that you can no longer modify the rating control
5. Click the "Enable" button
6. See that you can modify the rating control again

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
