### PR TITLE
Added moreButtonId input to soho-toolbar-flex-more-button to be place…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### 8.2.5 Fixes
 
+- `[Toolbar Flex]` Added moreButtonId input to soho-toolbar-flex-more-button to be placed on the inner button element. `EPC` ([#963](https://github.com/infor-design/enterprise-ng/issues/963))
+
+## v8.2.5
+
+### 8.2.5 Fixes
+
 - `[General]` Added patched EP version 4.35.4.
 
 ## v8.2.4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 8.2.5 Fixes
 
-- `[Toolbar Flex]` Added moreButtonId input to soho-toolbar-flex-more-button to be placed on the inner button element. `EPC` ([#963](https://github.com/infor-design/enterprise-ng/issues/963))
+- `[Toolbar Flex]` Added moreButtonId input to soho-toolbar-flex-more-button to be placed on the inner button element. `PWP` ([#963](https://github.com/infor-design/enterprise-ng/issues/963))
 
 ## v8.2.5
 

--- a/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
@@ -174,14 +174,20 @@ export class SohoToolbarFlexSearchFieldComponent implements AfterViewChecked, Af
  */
 @Component({
   selector: 'soho-toolbar-flex-more-button', // tslint:disable-line
-  template: `<button class="btn-actions" [ngClass]="{'page-changer': isPageChanger}"
-                     type="button" [attr.disabled]="isDisabled ? 'disabled' : null">
-    <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-      <use href="#icon-more"></use>
-    </svg>
-    <span class="audible">More Actions</span>
-  </button>
-  <ng-content></ng-content>`,
+    template:
+      `<button
+        class="btn-actions"
+        type="button"
+        [ngClass]="{'page-changer': isPageChanger}"
+        [attr.id]="moreButtonId"
+        [attr.disabled]="isDisabled ? 'disabled' : null"
+      >
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-more"></use>
+        </svg>
+        <span class="audible">More Actions</span>
+      </button>
+      <ng-content></ng-content>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SohoToolbarFlexMoreButtonComponent {
@@ -189,7 +195,11 @@ export class SohoToolbarFlexMoreButtonComponent {
   @HostBinding('class.toolbar-section') isToolbarSection = true;
   @Input() isPageChanger = false;
   @Input() isDisabled = false;
+  @Input() moreButtonId: string;
+
+  /** @deprecated doesn't seem to be used **/
   @Input() ajaxBeforeFunction: Function;
+  /** @deprecated doesn't seem to be used **/
   @Input() menuId: string;
 }
 

--- a/src/app/toolbar-flex/toolbar-flex-basic.demo.html
+++ b/src/app/toolbar-flex/toolbar-flex-basic.demo.html
@@ -38,7 +38,7 @@
         <input soho-toolbar-flex-searchfield (cleared)="onCleared($event)" (change)="onChange($event)" placeholder="Search Here" [clearable]="true" [collapsible]="true"/>
       </soho-toolbar-flex-section>
 
-      <soho-toolbar-flex-more-button>
+      <soho-toolbar-flex-more-button [moreButtonId]="moreButtonId">
         <ul class="popupmenu">
           <li><a href="#">Pre-defined Item #1</a></li>
           <li><a href="#">Pre-defined Item #2</a></li>

--- a/src/app/toolbar-flex/toolbar-flex-basic.demo.ts
+++ b/src/app/toolbar-flex/toolbar-flex-basic.demo.ts
@@ -15,6 +15,8 @@ export class ToolbarFlexBasicDemoComponent {
     alert(data);
   }
 
+  public moreButtonId = 'my-more-button';
+
   public onSubmit() {
     console.log('submit');
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Need an id on the more button for a toolbar that doesn't use the attributes api. 
This solves the need to have a unique id for the more button element in a toolbar.

Closes #963 

**Steps necessary to review your pull request (required)**:
Run toolbar-flex-basic demo and look at the first ... more button id.
