### PR TITLE
Adding lazy loading for SohoContextMenu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[General]` Added missing types from 4.35 and 4.36 `TJM`
 - `[General]` Fixed a bug expanding and collapsing nested datagrid rows ([#967](https://github.com/infor-design/enterprise-ng/issues/967)) `TJM`
 - `[General]` Added missing attributes setting to fileupload ([#966](https://github.com/infor-design/enterprise-ng/issues/966)) `TJM`
+- `[Context Menu]` Added lazy loading for the directive. ([#974](https://github.com/infor-design/enterprise-ng/issues/974)) `MHH`
 
 ## v9.1.0
 

--- a/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.directive.ts
@@ -243,9 +243,18 @@ export class SohoContextMenuDirective implements AfterViewInit, OnDestroy {
     return (this.options as any).beforeOpen;
   }
 
+  /** beforeOpen - ajax callback for open event */
+  @Input() lazyLoad = false;
+
   constructor(private element: ElementRef, private ngZone: NgZone) { }
 
   ngAfterViewInit() {
+    if (!this.lazyLoad) {
+      this.init();
+    }
+  }
+
+  private init() {
     this.ngZone.runOutsideAngular(() => {
       this.jQueryElement = jQuery(this.element.nativeElement);
       this.jQueryElement.popupmenu(this.options);
@@ -299,5 +308,12 @@ export class SohoContextMenuDirective implements AfterViewInit, OnDestroy {
         this.contextMenu = null;
       }
     });
+  }
+
+  public initializeComponent() {
+    if (this.lazyLoad) {
+      this.options.trigger = 'immediate';
+      this.init();
+    }
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -58,6 +58,7 @@ import { CodeBlockDemoComponent } from './code-block/code-block.demo';
 import { CompletionChartDemoComponent } from './completion-chart/completion-chart.demo';
 import { ContextMenuDemoComponent } from './context-menu/context-menu.demo';
 import { ContextMenuToggleDemoComponent } from './context-menu/context-menu-toggle.demo';
+import { ContextMenuLazyLoadDemoComponent } from './context-menu/context-menu-lazy-load.demo';
 import { ContextualActionPanelDemoModule } from './contextual-action-panel/contextual-action-panel.demo.module';
 import { DataGridBreadcrumbDemoComponent } from './datagrid/datagrid-breadcrumb.demo';
 import {
@@ -299,6 +300,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     CompletionChartDemoComponent,
     ContextMenuDemoComponent,
     ContextMenuToggleDemoComponent,
+    ContextMenuLazyLoadDemoComponent,
     DataGridBreadcrumbDemoComponent,
     DataGridCardDemoComponent,
     DataGridAngularEditorDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -42,6 +42,7 @@ import { ColumnGroupedXaxisTwolineDemoComponent } from './column-grouped/column-
 import { ColumnStackedDemoComponent } from './column-stacked/column-stacked.demo';
 import { CompletionChartDemoComponent } from './completion-chart/completion-chart.demo';
 import { ContextMenuDemoComponent } from './context-menu/context-menu.demo';
+import { ContextMenuLazyLoadDemoComponent } from './context-menu/context-menu-lazy-load.demo';
 import { ContextMenuToggleDemoComponent } from './context-menu/context-menu-toggle.demo';
 import { ContextualActionPanelDemoComponent } from './contextual-action-panel/contextual-action-panel.demo';
 import { DataGridAngularEditorDemoComponent } from './datagrid/datagrid-angular-editor.demo';
@@ -243,6 +244,7 @@ export const routes: Routes = [
   { path: 'column-stacked', component: ColumnStackedDemoComponent },
   { path: 'completion-chart', component: CompletionChartDemoComponent },
   { path: 'context-menu', component: ContextMenuDemoComponent },
+  { path: 'context-menu-lazy-load', component: ContextMenuLazyLoadDemoComponent },
   { path: 'context-menu-toggle', component: ContextMenuToggleDemoComponent },
   { path: 'contextual-action-panel', component: ContextualActionPanelDemoComponent },
   { path: 'datagrid-breadcrumb', component: DataGridBreadcrumbDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -57,6 +57,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['column-stacked']"><span>Column Chart-Stacked</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['completion-chart']"><span>Completion Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['context-menu']"><span>Context Menu</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['context-menu-lazy-load']"><span>Context Menu (lazy load)</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['context-menu-toggle']"><span>Context Menu (toggle)</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['contextual-action-panel']"><span>Contextual Action Panel</span></a></div>
   </div>

--- a/src/app/context-menu/context-menu-lazy-load.demo.html
+++ b/src/app/context-menu/context-menu-lazy-load.demo.html
@@ -1,0 +1,35 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Soho Context Menu Lazy Load</h2>
+    <p>
+      Example for lazy loading a context menu.<br>
+      To test: <br>
+      1. On load of the page, open the developers tools. See that there are only two div.popupmenu-wrapper. <br>
+      2. With the developers tools still open, click the button next to the text field <br>
+      3. See that a new div.popupmenu-wrapper has been added, and that a context menu has appeared on the screen
+    </p>
+  </div>
+</div>
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <!-- Input text field example. No soho components used-->
+    <div class="field">
+      <label id="label1" soho-label for="field1" >{{normalText}}</label>
+      <input id="field1" name="field1" />
+      <button
+          soho-context-menu [lazyLoad]="true" [attachToBody]="true" menu="action-popupmenu"
+          soho-button="icon" icon="more" class="context-menu-button"
+          (click)="onContextClick()"></button>
+    </div>
+
+    <!-- Context menu used in all examples (except the menu button)-->
+    <ul soho-popupmenu id="action-popupmenu">
+      <li soho-popupmenu-item *ngFor="let menuEntry of contextEntries" [isDisabled]="menuEntry.disabled">
+        <a soho-popupmenu-label *ngIf="!menuEntry.url" menuId="{{menuEntry.id}}">{{menuEntry.displayString}}<span class="shortcut-text">{{menuEntry.shortcut}}</span></a>
+        <a soho-popupmenu-label *ngIf="menuEntry.url" menuUrl="{{menuEntry.url}}">{{menuEntry.displayString}}<span class="shortcut-text">{{menuEntry.shortcut}}</span></a>
+      </li>
+    </ul>
+
+  </div>
+</div>

--- a/src/app/context-menu/context-menu-lazy-load.demo.ts
+++ b/src/app/context-menu/context-menu-lazy-load.demo.ts
@@ -1,0 +1,134 @@
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  ChangeDetectionStrategy, AfterViewInit
+} from '@angular/core';
+import { SohoContextMenuDirective } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-content-menu-lazy-load-demo',
+  templateUrl: 'context-menu-lazy-load.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [`.context-menu-button {
+    transform: rotate(90deg);
+    border-radius: 1px;
+    height: 18px;
+    display: inline-block;
+    min-height: 0;
+    min-width: 0;
+    border: 0;
+    margin-left: -9px;
+    margin-top: 8px;
+  }`]
+})
+export class ContextMenuLazyLoadDemoComponent implements OnInit, AfterViewInit {
+
+  @ViewChild(SohoContextMenuDirective, {static: true}) contextMenu?: SohoContextMenuDirective;
+
+  public normalText = `Input Example`;
+
+  public contextEntries: Array<ContextMenuEntries> = [];
+
+  public textModel = {
+    disableText: `This text area is disabled, so should show the browser context menu and not the same context menu as the other components`,// tslint:disable-line
+    modifiableText: `This text is modifiable`,
+  };
+
+  private buildContextMenu(): Array<ContextMenuEntries> {
+    const entries: Array<ContextMenuEntries> = [];
+
+    entries.push({
+      displayString: 'Cutx',
+      disabled: false,
+      shortcut: '⌘+X'
+    });
+
+    entries.push({
+      displayString: 'Copy',
+      disabled: false,
+      shortcut: '⌘+C'
+    });
+
+    entries.push({
+      displayString: 'Paste',
+      disabled: false,
+      shortcut: '⌘+V'
+    });
+
+    entries.push({
+      displayString: 'Name and project range',
+      id: 'range',
+      disabled: false
+    });
+
+    entries.push({
+      displayString: 'Insert comment',
+      disabled: true
+    });
+
+    entries.push({
+      displayString: 'Insert note',
+      disabled: false
+    });
+
+    entries.push({
+      displayString: 'Clear notes',
+      disabled: true
+    });
+
+    entries.push({
+      displayString: 'Google',
+      url: 'http://www.google.com',
+      disabled: false
+    });
+
+    return entries;
+  }
+
+  onUpdated() {
+    console.log('CheckboxDemoComponent.onUpdated');
+  }
+
+  constructor() { }
+  ngOnInit() {
+    this.contextEntries = this.buildContextMenu();
+  }
+
+  ngAfterViewInit() {
+    console.log('here');
+    if (this.contextMenu) {
+      console.log('context menu exists');
+    }
+  }
+
+  onSelected() {
+    console.log('onSelected');
+  }
+
+  onBeforeOpen() {
+    console.log('onBeforeOpen');
+  }
+
+  onClose() {
+    console.log('onClose');
+  }
+
+  onOpen() {
+    console.log('onOpen');
+  }
+
+  onContextClick() {
+    if (this.contextMenu) {
+      this.contextMenu.initializeComponent();
+    }
+  }
+}
+
+export interface ContextMenuEntries {
+  displayString: string;
+  id?: string;
+  url?: string;
+  disabled?: boolean;
+  shortcut?: string;
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adding lazy loading to SohoContextMenuDirective, so the user can choose when to initialize the ids-enterprise control. This will allow for some performance improvement for implementers.

**Related github/jira issue (required)**:
 "Closes #974 "

**Steps necessary to review your pull request (required)**:
Pull the code and navigate to the new Context Menu (lazy load) page. Follow the steps on that page to test.

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
