### PR TITLE
Enabling cypress e2e in github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,3 +48,6 @@ jobs:
 
     - name: Run tests
       run: npm run test
+
+    - name: Run e2e tests
+      run: npm run test:e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,9 @@ jobs:
     - name: Cache multiple paths
       uses: actions/cache@v2
       with:
-        path: node_modules
+        path: |
+          ~/.cache/Cypress
+          node_modules
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
     - name: Setup timezone


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This enables ep-ng e2e test to also be checked from our github workflow.

**Related github/jira issue (required)**:
NA

**Steps necessary to review your pull request (required)**:
Builds should pass with cypress tests 
