### PR TITLE
983 - Fix bug with readonly input

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,13 @@
 - `[Calendar]` Fixed some types and added some missing types ([#4781](https://github.com/infor-design/enterprise/issues/4781)) `TJM`
 - `[DataGrid]` Removed unused filterFormatter type ([#4781](https://github.com/infor-design/enterprise/issues/4781)) `TJM`
 - `[Rating]` Expose the val() method ([#981](https://github.com/infor-design/enterprise-ng/issues/981)) `MHH`
+- `[Slider/TimePicker/Datepicker]` The readonly input was not working correctly after adding strict types ([#983](https://github.com/infor-design/enterprise-ng/issues/983)) `TJM`
+
+## v9.1.4
+
+### 9.1.4 Fixes
+
+- `[Slider/TimePicker/Datepicker]` The readonly input was not working correctly after adding strict types ([#983](https://github.com/infor-design/enterprise-ng/issues/983)) `TJM`
 
 ## v9.1.3
 

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -449,10 +449,10 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<any> imple
   ngAfterViewChecked() {
     if (this.runUpdatedOnCheck) {
       // Ensure the enabled/disabled flags are set.
-      if (this.isDisabled !== null) {
+      if (this.isDisabled !== null && this.isDisabled !== undefined) {
         this.disabled = this.isDisabled;
       }
-      if (this.isReadOnly !== null) {
+      if (this.isReadOnly !== null && this.isReadOnly !== undefined) {
         this.readonly = this.isReadOnly;
       }
 

--- a/projects/ids-enterprise-ng/src/lib/timepicker/soho-timepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/timepicker/soho-timepicker.component.ts
@@ -270,10 +270,10 @@ export class SohoTimePickerComponent extends BaseControlValueAccessor<any> imple
   ngAfterViewChecked() {
     if (this.runUpdatedOnCheck) {
       // Ensure the enabled/disabled flags are set.
-      if (this.isDisabled !== null) {
+      if (this.isDisabled !== null && this.isDisabled !== undefined) {
         this.disabled = this.isDisabled;
       }
-      if (this.isReadOnly !== null) {
+      if (this.isReadOnly !== null && this.isReadOnly !== undefined) {
         this.readonly = this.isReadOnly;
       }
 

--- a/src/app/slider/slider.demo.ts
+++ b/src/app/slider/slider.demo.ts
@@ -35,7 +35,6 @@ export class SliderDemoComponent implements OnInit {
   }
 
   setReadonly() {
-    // TODO: Depends on SOHO-5012. Needs a readonly method for slider.
     this.slider.readonly = true;
     this.sliderReadOnly = this.slider.readonly;
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

On 3 components the readonly input broke after making the strict typing changes.

**Related github/jira issue (required)**:
Fixes #983 

**Steps necessary to review your pull request (required)**:
- check each of these pages:
http://localhost:4200/ids-enterprise-ng-demo/slider
http://localhost:4200/ids-enterprise-ng-demo/datepicker
http://localhost:4200/ids-enterprise-ng-demo/timepicker
- on the datepicker and timepicker pages should be a readonly input that is now readonly again
- on all three the buttons to toggle the states should work correctly
