### PR TITLE
996 - SohoContextMenu fixing lazy initialize events

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## v9.3.0
+
+## v9.3.0 Fixes
+
+- `[Context Menu]` Fixed a bug causing events to be subscribed to multiple times. ([#996](https://github.com/infor-design/enterprise-ng)) `MHH`
+
 ## v9.2.0
 
 ### 9.2.0 Fixes

--- a/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/context-menu/soho-context-menu.directive.ts
@@ -313,6 +313,11 @@ export class SohoContextMenuDirective implements AfterViewInit, OnDestroy {
   public initializeComponent() {
     if (this.lazyLoad) {
       this.options.trigger = 'immediate';
+      // Remove all existing events before re-initializing, or the events will keep getting listened
+      // to (so on first click, listened to once. On second click, listened to twice).
+      if (this.jQueryElement) {
+        this.jQueryElement.off();
+      }
       this.init();
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixing events for lazily loaded context menus

**Related github/jira issue (required)**:
Closes #996 

**Steps necessary to review your pull request (required)**:
1. Go to the demo app, navigate to C -> Context Menu (lazy load)
2. Open the debug window, open the source file for soho-context-menu.directive and set a break point at line 265.
3. Open the context menu ... and click the Insert Note option
4. See that the break point is hit, and when you continue code execution it doesn't stop again.
5. Open the context menu and click the Insert Note option again
6. See that the breakpoint is hit, and when you continue code execution, it doesn't stop again

