### PR TITLE
953 - Fix multiple events were firing with soho message

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Context Menu]` Fixed a bug causing events to be subscribed to multiple times. ([#996](https://github.com/infor-design/enterprise-ng)) `MHH`
 - `[DataGrid]` Added missing getActiveCell getter. ([#4781](https://github.com/infor-design/enterprise/issues/4781)) `TJM`
 - `[DataGrid]` Updated the datagrid context menu example to work with the keyboard ([#4781](https://github.com/infor-design/enterprise/issues/4781)) `TJM`
+- `[Message]` Fixed multiple events were firing. ([#953](https://github.com/infor-design/enterprise-ng/issues/953))
 
 ## v9.2.0
 

--- a/projects/ids-enterprise-ng/src/lib/message/soho-message.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/message/soho-message.ref.ts
@@ -194,13 +194,13 @@ export class SohoMessageRef {
     this._message = this.jQueryElement.data('modal');
 
     // Add listeners to control event (which are on the placeholder)
-    this._placeholder.on('open', ((event: any) => {
- this.onOpen(event);
-}));
+    this._placeholder.off('open').on('open', ((event: any) => {
+      this.onOpen(event);
+    }));
 
     // These are vetoable events.
-    this._placeholder.on('beforeopen', ((event: any) => this.onBeforeOpen(event)));
-    this._placeholder.on('beforeclose', ((event: any) => this.onBeforeClose(event)));
+    this._placeholder.off('beforeopen').on('beforeopen', ((event: any) => this.onBeforeOpen(event)));
+    this._placeholder.off('beforeclose').on('beforeclose', ((event: any) => this.onBeforeClose(event)));
 
     return this;
   }
@@ -241,8 +241,8 @@ export class SohoMessageRef {
    */
   opened(eventFn: Function): SohoMessageRef {
     this.open$.subscribe((f: any) => {
- eventFn(f, this);
-});
+      eventFn(f, this);
+    });
     return this;
   }
 

--- a/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
@@ -479,15 +479,15 @@ export class SohoModalDialogRef<T> {
     });
 
     // Add listeners to control events
-    this.jQueryElement?.on('close', ((event: any, isCancelled: boolean) => this.ngZone.run(() => this.onClose(event, isCancelled))));
-    this.jQueryElement?.on('afterclose', ((event: any) => this.ngZone.run(() => this.onAfterClose(event))));
-    this.jQueryElement?.on('open', ((event: any) => this.ngZone.run(() => this.onOpen(event))));
-    this.jQueryElement?.on('afteropen', ((event: any) => this.ngZone.run(() => this.onAfterOpen(event))));
+    this.jQueryElement?.off('close').on('close', ((event: any, isCancelled: boolean) => this.ngZone.run(() => this.onClose(event, isCancelled))));
+    this.jQueryElement?.off('afterclose').on('afterclose', ((event: any) => this.ngZone.run(() => this.onAfterClose(event))));
+    this.jQueryElement?.off('open').on('open', ((event: any) => this.ngZone.run(() => this.onOpen(event))));
+    this.jQueryElement?.off('afteropen').on('afteropen', ((event: any) => this.ngZone.run(() => this.onAfterOpen(event))));
 
     // These are vetoable events.
-    this.jQueryElement?.on('beforeopen', ((event: any) => this.ngZone.run(() => this.onBeforeOpen(event))));
-    this.jQueryElement?.on('beforeclose', ((event: any) => this.ngZone.run(() => this.onBeforeClose(event))));
-    this.jQueryElement?.on('beforedestroy', ((event: any) => this.ngZone.run(() => this.onBeforeDestroy(event))));
+    this.jQueryElement?.off('beforeopen').on('beforeopen', ((event: any) => this.ngZone.run(() => this.onBeforeOpen(event))));
+    this.jQueryElement?.off('beforeclose').on('beforeclose', ((event: any) => this.ngZone.run(() => this.onBeforeClose(event))));
+    this.jQueryElement?.off('beforedestroy').on('beforedestroy', ((event: any) => this.ngZone.run(() => this.onBeforeDestroy(event))));
 
     return this;
   }

--- a/src/app/message/message.demo.ts
+++ b/src/app/message/message.demo.ts
@@ -40,6 +40,14 @@ export class MessageDemoComponent {
       .message(`This application has experienced a system error due to the lack of internet access.
                 Please restart the application in order to proceed.`)
       .buttons(buttons)
+      .beforeOpen(() => {
+        console.log('before open');
+        return true;
+      })
+      .beforeClose(() => {
+        console.log('before close');
+        return true;
+      })
       .open();
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed multiple events were firing with Soho Message.

**Related github/jira issue (required)**:
Closes #953

**Steps necessary to review your pull request (required)**:
- Pull and build this branch
- Pull and build EP branch ([953-modal-multiple-events](https://github.com/infor-design/enterprise/tree/953-modal-multiple-events))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/message
- Open developer tools
- Click on button `Error Example`
- See in console
- Events `before open` and `before close` should fire event once

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
