### PR TITLE
993 - update close() api for CAP to force close

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `[Calendar]` Fixed dayLegend type in the calendar component. ([#1001](https://github.com/infor-design/enterprise-ng/issues/1001)) `TJM`
 - `[Context Menu]` Fixed a bug causing events to be subscribed to multiple times. ([#996](https://github.com/infor-design/enterprise-ng)) `MHH`
+- `[Contextual Action Panel]` Added an optional parameter to the CAP's close() API to support the same behavior as the jQuery. ([#993](https://github.com/infor-design/enterprise-ng/issues/993))
 - `[DataGrid]` Added missing getActiveCell getter. ([#4781](https://github.com/infor-design/enterprise/issues/4781)) `TJM`
 - `[DataGrid]` Updated the datagrid context menu example to work with the keyboard ([#4781](https://github.com/infor-design/enterprise/issues/4781)) `TJM`
 - `[Message]` Fixed multiple events were firing. ([#953](https://github.com/infor-design/enterprise-ng/issues/953))

--- a/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
@@ -314,16 +314,17 @@ export class SohoContextualActionPanelRef<T> {
   }
 
   /**
-   * Closes the panel panel, if open.  The panel is not closed
+   * Closes the panel, if open. The panel is not closed
    * fully until the 'afterClosed' event is fired.
    *
    * @param panelResult - optional result - passed back to the caller.
+   * @param doForce - optional - forces the modal to close.
    */
-  close(panelResult?: any): SohoContextualActionPanelRef<T> {
+  close(doForce?: boolean, panelResult?: any): SohoContextualActionPanelRef<T> {
     this.panelResult = panelResult;
     if (this.contextualactionpanel) {
       this.ngZone.runOutsideAngular(() => {
-        this.contextualactionpanel?.close();
+        this.contextualactionpanel?.close(doForce);
       });
     }
     return this;

--- a/src/app/contextual-action-panel/contextual-action-panel-searchfield-flex.component.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel-searchfield-flex.component.ts
@@ -10,6 +10,6 @@ export class ContextualActionPanelSearchfieldFlexComponent {
   panel?: SohoContextualActionPanelRef<unknown>;
 
   close() {
-    this.panel?.close();
+    this.panel?.close(true);
   }
 }

--- a/src/app/contextual-action-panel/contextual-action-panel-searchfield.component.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel-searchfield.component.ts
@@ -10,6 +10,6 @@ export class ContextualActionPanelSearchfieldComponent {
   panel?: SohoContextualActionPanelRef<unknown>;
 
   close() {
-    this.panel?.close();
+    this.panel?.close(true);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Update the close() API to behave the same way as the jQuery version of CAP. Added an optional param `doForce` to force the CAP to close.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise-ng/issues/993

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- Click `Panel with Searchfield in flex toolbar` button to trigger the CAP
- Click the dropdown `Menu` to open it
- Then close the modal
- It should close the modal immediately

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
