### PR TITLE
993 - append the doForce param in close api

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - `[Calendar]` Fixed dayLegend type in the calendar component. ([#1001](https://github.com/infor-design/enterprise-ng/issues/1001)) `TJM`
 - `[Context Menu]` Fixed a bug causing events to be subscribed to multiple times. ([#996](https://github.com/infor-design/enterprise-ng)) `MHH`
-- `[Contextual Action Panel]` Added an optional parameter to the CAP's close() API to support the same behavior as the jQuery. ([#993](https://github.com/infor-design/enterprise-ng/issues/993))
+- `[Contextual Action Panel]` Added an optional parameter to the CAP's close() API to support the same behavior as the jQuery. ([#993](https://github.com/infor-design/enterprise-ng/issues/993)) `EA`
 - `[DataGrid]` Added missing getActiveCell getter. ([#4781](https://github.com/infor-design/enterprise/issues/4781)) `TJM`
 - `[DataGrid]` Updated the datagrid context menu example to work with the keyboard ([#4781](https://github.com/infor-design/enterprise/issues/4781)) `TJM`
 - `[Message]` Fixed multiple events were firing. ([#953](https://github.com/infor-design/enterprise-ng/issues/953))

--- a/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
@@ -320,7 +320,7 @@ export class SohoContextualActionPanelRef<T> {
    * @param panelResult - optional result - passed back to the caller.
    * @param doForce - optional - forces the modal to close.
    */
-  close(doForce?: boolean, panelResult?: any): SohoContextualActionPanelRef<T> {
+  close(panelResult?: any, doForce?: boolean): SohoContextualActionPanelRef<T> {
     this.panelResult = panelResult;
     if (this.contextualactionpanel) {
       this.ngZone.runOutsideAngular(() => {

--- a/src/app/contextual-action-panel/contextual-action-panel-searchfield-flex.component.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel-searchfield-flex.component.ts
@@ -10,6 +10,6 @@ export class ContextualActionPanelSearchfieldFlexComponent {
   panel?: SohoContextualActionPanelRef<unknown>;
 
   close() {
-    this.panel?.close(true);
+    this.panel?.close(true, true);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Follow up fix for https://github.com/infor-design/enterprise-ng/issues/993. Making `doForce` param being appended.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

Closes https://github.com/infor-design/enterprise-ng/issues/993

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- Click `Panel with Searchfield in flex toolbar` button to trigger the CAP
- Click the dropdown `Menu` to open it
- Then close the modal
- It should close the modal immediately

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
