### PR TITLE
Add shared Popupmenu sample

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 9.4.0 Fixes
 
-- `[Placeholder]` Remove me.... ([#1001](https://github.com/infor-design/enterprise-ng/issues/1001)) `TJM`
+- `[Popupmenu]` Add example demonstrating shared Popupmenus working after one is destroyed. ([#987](https://github.com/infor-design/enterprise-ng/issues/987)) `EPC`
 
 ## v9.3.1
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -56,6 +56,7 @@ import { CodeBlockComponent } from './code-block/code-block.component';
 import { CodeBlockDemoComponent } from './code-block/code-block.demo';
 import { CompletionChartDemoComponent } from './completion-chart/completion-chart.demo';
 import { ContextMenuDemoComponent } from './context-menu/context-menu.demo';
+import { ContextMenuSharedDemoComponent } from './context-menu/context-menu-shared.demo';
 import { ContextMenuToggleDemoComponent } from './context-menu/context-menu-toggle.demo';
 import { ContextMenuLazyLoadDemoComponent } from './context-menu/context-menu-lazy-load.demo';
 import { ContextualActionPanelDemoModule } from './contextual-action-panel/contextual-action-panel.demo.module';
@@ -298,6 +299,7 @@ import { ButtonsetDemoComponent } from './buttonset/buttonset.demo';
     CodeBlockEditorComponent,
     CompletionChartDemoComponent,
     ContextMenuDemoComponent,
+    ContextMenuSharedDemoComponent,
     ContextMenuToggleDemoComponent,
     ContextMenuLazyLoadDemoComponent,
     DataGridBreadcrumbDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -42,6 +42,7 @@ import { ColumnStackedDemoComponent } from './column-stacked/column-stacked.demo
 import { CompletionChartDemoComponent } from './completion-chart/completion-chart.demo';
 import { ContextMenuDemoComponent } from './context-menu/context-menu.demo';
 import { ContextMenuLazyLoadDemoComponent } from './context-menu/context-menu-lazy-load.demo';
+import { ContextMenuSharedDemoComponent } from './context-menu/context-menu-shared.demo';
 import { ContextMenuToggleDemoComponent } from './context-menu/context-menu-toggle.demo';
 import { ContextualActionPanelDemoComponent } from './contextual-action-panel/contextual-action-panel.demo';
 import { DataGridAngularEditorDemoComponent } from './datagrid/datagrid-angular-editor.demo';
@@ -244,6 +245,7 @@ export const routes: Routes = [
   { path: 'completion-chart', component: CompletionChartDemoComponent },
   { path: 'context-menu', component: ContextMenuDemoComponent },
   { path: 'context-menu-lazy-load', component: ContextMenuLazyLoadDemoComponent },
+  { path: 'context-menu-shared', component: ContextMenuSharedDemoComponent },
   { path: 'context-menu-toggle', component: ContextMenuToggleDemoComponent },
   { path: 'contextual-action-panel', component: ContextualActionPanelDemoComponent },
   { path: 'datagrid-breadcrumb', component: DataGridBreadcrumbDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -58,6 +58,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['completion-chart']"><span>Completion Chart</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['context-menu']"><span>Context Menu</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['context-menu-lazy-load']"><span>Context Menu (lazy load)</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['context-menu-shared']"><span>Context Menu (shared)</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['context-menu-toggle']"><span>Context Menu (toggle)</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['contextual-action-panel']"><span>Contextual Action Panel</span></a></div>
   </div>

--- a/src/app/context-menu/context-menu-shared.demo.html
+++ b/src/app/context-menu/context-menu-shared.demo.html
@@ -1,0 +1,36 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <!-- Controls -->
+    <div class="field">
+      <button soho-button="secondary" id="destroy-input-popup" (click)="destroyInputPopup()">Destroy Input Popup</button>
+      <button soho-button="secondary" id="destroy-textarea-popup" (click)="destroyTextAreaPopup()">Destroy TextArea Popup</button>
+    </div>
+
+    <!-- Input text field example. No soho components used-->
+    <div class="field">
+      <label id="label1" name="label1" soho-label for="field1">{{normalText}}</label>
+      <input id="field1" name="field1" soho-context-menu menu="action-popupmenu-2" value="Right Click Here"
+        (selected)="onSelected()" (beforeopen)="onBeforeOpen()" (close)="onClose()" (open)="onOpen()" />
+    </div>
+
+    <!-- Text area example. Soho-textarea component used-->
+    <div class="field">
+      <label soho-label for="textarea" id="label2" name="label2">{{modText}}</label>
+      <textarea soho-textarea id="textarea" name="textarea" [(ngModel)]="textModel.modifiableText" soho-context-menu
+        menu="action-popupmenu-2" (selected)="onSelected()" (beforeopen)="onBeforeOpen()" (close)="onClose()"
+        (open)="onOpen()"></textarea>
+    </div>
+
+    <!-- Context menu used in all examples (except the menu button)-->
+    <ul soho-popupmenu id="action-popupmenu-2">
+      <li soho-popupmenu-item *ngFor="let menuEntry of contextEntries" [isDisabled]="menuEntry.disabled">
+        <a soho-popupmenu-label *ngIf="!menuEntry.url" menuId="{{menuEntry.id}}">{{menuEntry.displayString}}<span
+            class="shortcut-text">{{menuEntry.shortcut}}</span></a>
+        <a soho-popupmenu-label *ngIf="menuEntry.url" menuUrl="{{menuEntry.url}}">{{menuEntry.displayString}}<span
+            class="shortcut-text">{{menuEntry.shortcut}}</span></a>
+      </li>
+    </ul>
+
+  </div>
+</div>

--- a/src/app/context-menu/context-menu-shared.demo.ts
+++ b/src/app/context-menu/context-menu-shared.demo.ts
@@ -1,0 +1,129 @@
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  ChangeDetectionStrategy
+} from '@angular/core';
+// @ts-ignore
+import { SohoTextAreaComponent, SohoContextMenuDirective } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-content-menu-shared-demo',
+  templateUrl: 'context-menu-shared.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ContextMenuSharedDemoComponent implements OnInit {
+
+  @ViewChild(SohoTextAreaComponent, { static: true }) textarea?: SohoTextAreaComponent;
+  @ViewChild('menuOne') menuOneContextMenu?: SohoContextMenuDirective;
+
+  public normalText = `Input Example`;
+  public modText = `Enabled Text Area Example`;
+  public manualCloseLabel = `Close Context Menu Manually`;
+
+  public contextEntries?: Array<ContextMenuEntries>;
+
+  public textModel = {
+    modifiableText: `This text is modifiable`,
+  };
+
+  private buildContextMenu(): Array<ContextMenuEntries> {
+    const entries: Array<ContextMenuEntries> = [];
+
+    entries.push({
+      displayString: 'Cut',
+      disabled: false,
+      shortcut: '⌘+X'
+    });
+
+    entries.push({
+      displayString: 'Copy',
+      disabled: false,
+      shortcut: '⌘+C'
+    });
+
+    entries.push({
+      displayString: 'Paste',
+      disabled: false,
+      shortcut: '⌘+V'
+    });
+
+    entries.push({
+      displayString: 'Name and project range',
+      id: 'range',
+      disabled: false
+    });
+
+    entries.push({
+      displayString: 'Insert comment',
+      disabled: true
+    });
+
+    entries.push({
+      displayString: 'Insert note',
+      disabled: false
+    });
+
+    entries.push({
+      displayString: 'Clear notes',
+      disabled: true
+    });
+
+    entries.push({
+      displayString: 'Google',
+      url: 'http://www.google.com',
+      disabled: false
+    });
+
+    return entries;
+  }
+
+  onUpdated() {
+    console.log('ContextMenuComponent.onUpdated');
+  }
+
+  constructor() { }
+  ngOnInit() {
+    this.contextEntries = this.buildContextMenu();
+  }
+
+  onSelected() {
+    console.log('onSelected');
+  }
+
+  onBeforeOpen() {
+    console.log('onBeforeOpen');
+  }
+
+  onClose() {
+    console.log('onClose');
+  }
+
+  onOpen() {
+    console.log('onOpen');
+  }
+
+  onOpenManually(_e: SohoContextMenuEvent): void {
+    setTimeout(() => {
+      this.menuOneContextMenu?.close();
+    }, 2000);
+  }
+
+  destroyInputPopup(): void {
+    $('#field1').data('popupmenu').destroy();
+    $('#field1').remove();
+  }
+
+  destroyTextAreaPopup(): void {
+    $('#textarea').data('popupmenu').destroy();
+    $('#textarea').remove();
+  }
+}
+
+export interface ContextMenuEntries {
+  displayString: string;
+  id?: string;
+  url?: string;
+  disabled?: boolean;
+  shortcut?: string;
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a demo for destroying Popupmenu trigger elements that share the same menu.  The issue is fixed in Enterprise, but we also need to demonstrate it working in the Angular components.

**Related github/jira issue (required)**:
Closes #987
Related to infor-design/enterprise#4985

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Before building, use `npm link` or a symbolic link to connect [this branch](https://github.com/infor-design/enterprise/tree/ng987-shared-popupmenu) of IDS Enterprise to this branch of NG.
- Build/run the demoapp and open http://localhost:4200/ids-enterprise-ng-demo/context-menu-shared
- Right click both the input field and the textarea and display their menus at least once
- Click the "Destroy Input Popup" button
- Right Click the Textarea and ensure the Popupmenu is displayed correctly.

@volante007