### PR TITLE
3229 - Add double click event to all chart types

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 9.4.0 Fixes
 
+- `[Charts]` Added double click event to all chart types. `DV` ([#3229](https://github.com/infor-design/enterprise/pull/3229))
 - `[Popupmenu]` Add example demonstrating shared Popupmenus working after one is destroyed. ([#987](https://github.com/infor-design/enterprise-ng/issues/987)) `EPC`
 
 ## v9.3.1

--- a/projects/ids-enterprise-ng/src/lib/bar/soho-bar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/bar/soho-bar.component.ts
@@ -226,6 +226,7 @@ export class SohoBarComponent implements AfterViewInit, AfterViewChecked, OnDest
   @Output() selected: EventEmitter<SohoBarSelectEvent> = new EventEmitter<SohoBarSelectEvent>();
   @Output() unselected: EventEmitter<SohoBarSelectEvent> = new EventEmitter<SohoBarSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  // eslint-disable-next-line @angular-eslint/no-output-native, @angular-eslint/no-output-rename
   @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
   /**
    * @todo replace override of native attribute

--- a/projects/ids-enterprise-ng/src/lib/bar/soho-bar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/bar/soho-bar.component.ts
@@ -226,6 +226,7 @@ export class SohoBarComponent implements AfterViewInit, AfterViewChecked, OnDest
   @Output() selected: EventEmitter<SohoBarSelectEvent> = new EventEmitter<SohoBarSelectEvent>();
   @Output() unselected: EventEmitter<SohoBarSelectEvent> = new EventEmitter<SohoBarSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
   /**
    * @todo replace override of native attribute
    */
@@ -258,6 +259,8 @@ export class SohoBarComponent implements AfterViewInit, AfterViewChecked, OnDest
         this.ngZone.run(() => this.rendered.emit(args)));
       this.jQueryElement.on('contextmenu', (...args) =>
         this.ngZone.run(() => this.contextmenu?.emit(args)));
+      this.jQueryElement.on('dblclick', (_e: any, args: Object) =>
+        this.ngZone.run(() => this.dblclick.emit(args)));
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/bullet/soho-bullet.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/bullet/soho-bullet.component.ts
@@ -57,7 +57,9 @@ export class SohoBulletComponent implements AfterViewInit, AfterViewChecked, OnD
     }
   }
 
+  @Output() selected: EventEmitter<SohoLineSelectEvent> = new EventEmitter<SohoLineSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**
    * @todo replace override of native attribute
@@ -83,10 +85,14 @@ export class SohoBulletComponent implements AfterViewInit, AfterViewChecked, OnD
       this.bullet = this.jQueryElement.data('bullet');
 
       // Setup the events
+      this.jQueryElement.on('selected', (_e: any, args: SohoLineSelectEvent) =>
+        this.ngZone.run(() => this.selected.emit(args)));
       this.jQueryElement.on('rendered', (...args) =>
         this.ngZone.run(() => this.rendered.emit(args)));
       this.jQueryElement.on('contextmenu', (...args) =>
         this.ngZone.run(() => this.contextmenu?.emit(args)));
+      this.jQueryElement.on('dblclick', (_e: any, args: Object) =>
+        this.ngZone.run(() => this.dblclick.emit(args)));
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/bullet/soho-bullet.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/bullet/soho-bullet.component.ts
@@ -59,6 +59,7 @@ export class SohoBulletComponent implements AfterViewInit, AfterViewChecked, OnD
 
   @Output() selected: EventEmitter<SohoLineSelectEvent> = new EventEmitter<SohoLineSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  // eslint-disable-next-line @angular-eslint/no-output-native, @angular-eslint/no-output-rename
   @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/column/soho-column.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/column/soho-column.component.ts
@@ -171,6 +171,7 @@ export class SohoColumnComponent implements AfterViewInit, AfterViewChecked, OnD
   @Output() selected: EventEmitter<SohoColumnSelectEvent> = new EventEmitter<SohoColumnSelectEvent>();
   @Output() unselected: EventEmitter<SohoColumnSelectEvent> = new EventEmitter<SohoColumnSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**
    * @todo replace override of native attribute
@@ -204,6 +205,8 @@ export class SohoColumnComponent implements AfterViewInit, AfterViewChecked, OnD
         this.ngZone.run(() => this.rendered.emit(args)));
       this.jQueryElement.on('contextmenu', (...args) =>
         this.ngZone.run(() => this.contextmenu?.emit(args)));
+      this.jQueryElement.on('dblclick', (_e: any, args: Object) =>
+        this.ngZone.run(() => this.dblclick.emit(args)));
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/column/soho-column.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/column/soho-column.component.ts
@@ -171,6 +171,7 @@ export class SohoColumnComponent implements AfterViewInit, AfterViewChecked, OnD
   @Output() selected: EventEmitter<SohoColumnSelectEvent> = new EventEmitter<SohoColumnSelectEvent>();
   @Output() unselected: EventEmitter<SohoColumnSelectEvent> = new EventEmitter<SohoColumnSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  // eslint-disable-next-line @angular-eslint/no-output-native, @angular-eslint/no-output-rename
   @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/column/soho-column.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/column/soho-column.spec.ts
@@ -171,18 +171,23 @@ describe('Soho Column Unit Tests', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('check public functions', () => {
+  it('check public functions', (done) => {
     comp.dataset = columnData;
     comp.type = 'column';
     fixture.detectChanges();
 
     comp.toggleSelected({ index: 1 });
 
-    const firstElem = (comp.getSelected() as any)[0];
-    expect(firstElem.data.name).toEqual(columnData[0].data[1].name);
+    setTimeout(() => {
+      const firstElem = (comp.getSelected() as any)[0];
+      expect(firstElem.data.name).toEqual(columnData[0].data[1].name);
+      comp.setSelected({ index: 2 });
 
-    comp.setSelected({ index: 2 });
-    expect((comp as any).getSelected()[0].data.name).toEqual(columnData[0].data[2].name);
+      setTimeout(() => {
+        expect((comp as any).getSelected()[0].data.name).toEqual(columnData[0].data[2].name);
+        done();
+      }, 201);
+    }, 201);
   });
 });
 

--- a/projects/ids-enterprise-ng/src/lib/line/soho-line.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/line/soho-line.component.ts
@@ -156,6 +156,7 @@ export class SohoLineComponent implements AfterViewInit, AfterViewChecked, OnDes
   @Output() selected: EventEmitter<SohoLineSelectEvent> = new EventEmitter<SohoLineSelectEvent>();
   @Output() unselected: EventEmitter<SohoLineSelectEvent> = new EventEmitter<SohoLineSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**
    * @todo replace override of native attribute
@@ -191,6 +192,8 @@ export class SohoLineComponent implements AfterViewInit, AfterViewChecked, OnDes
         this.ngZone.run(() => this.rendered.emit(args)));
       this.jQueryElement.on('contextmenu', (...args) =>
         this.ngZone.run(() => this.contextmenu?.emit(args)));
+      this.jQueryElement.on('dblclick', (_e: any, args: Object) =>
+        this.ngZone.run(() => this.dblclick.emit(args)));
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/line/soho-line.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/line/soho-line.component.ts
@@ -156,6 +156,7 @@ export class SohoLineComponent implements AfterViewInit, AfterViewChecked, OnDes
   @Output() selected: EventEmitter<SohoLineSelectEvent> = new EventEmitter<SohoLineSelectEvent>();
   @Output() unselected: EventEmitter<SohoLineSelectEvent> = new EventEmitter<SohoLineSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  // eslint-disable-next-line @angular-eslint/no-output-native, @angular-eslint/no-output-rename
   @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/pie/soho-pie.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/pie/soho-pie.component.ts
@@ -171,6 +171,7 @@ export class SohoPieComponent implements AfterViewInit, AfterViewChecked, OnDest
   @Output() selected: EventEmitter<SohoPieSelectEvent> = new EventEmitter<SohoPieSelectEvent>();
   @Output() unselected: EventEmitter<SohoPieSelectEvent> = new EventEmitter<SohoPieSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**
    * @todo remove override of native element
@@ -206,6 +207,8 @@ export class SohoPieComponent implements AfterViewInit, AfterViewChecked, OnDest
         this.ngZone.run(() => this.rendered.emit(args)));
       this.jQueryElement.on('contextmenu', (...args) =>
         this.ngZone.run(() => this.contextmenu?.emit(args)));
+      this.jQueryElement.on('dblclick', (_e: any, args: Object) =>
+        this.ngZone.run(() => this.dblclick.emit(args)));
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/pie/soho-pie.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/pie/soho-pie.component.ts
@@ -171,6 +171,7 @@ export class SohoPieComponent implements AfterViewInit, AfterViewChecked, OnDest
   @Output() selected: EventEmitter<SohoPieSelectEvent> = new EventEmitter<SohoPieSelectEvent>();
   @Output() unselected: EventEmitter<SohoPieSelectEvent> = new EventEmitter<SohoPieSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  // eslint-disable-next-line @angular-eslint/no-output-native, @angular-eslint/no-output-rename
   @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/pie/soho-pie.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/pie/soho-pie.spec.ts
@@ -151,16 +151,20 @@ describe('Soho Pie Unit Tests', () => {
     expect(pieUpdatedSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('check public functions', () => {
+  it('check public functions', (done) => {
     comp.dataset = pieData;
     fixture.detectChanges();
 
     comp.toggleSelected({ index: 1 });
 
-    expect((comp.getSelected() as any)[0].index).toEqual(1);
-
-    comp.setSelected({ index: 2 });
-    expect((comp.getSelected() as any)[0].index).toEqual(2);
+    setTimeout(() => {
+      expect((comp.getSelected() as any)[0].index).toEqual(1);
+      comp.setSelected({ index: 2 });
+      setTimeout(() => {
+        expect((comp.getSelected() as any)[0].index).toEqual(2);
+        done();
+      }, 201);
+    }, 201);
   });
 
   // xit('set data', () => {

--- a/projects/ids-enterprise-ng/src/lib/radar/soho-radar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/radar/soho-radar.component.ts
@@ -252,6 +252,7 @@ export class SohoRadarComponent implements AfterViewInit, AfterViewChecked, OnDe
   @Output() selected: EventEmitter<SohoRadarSelectEvent> = new EventEmitter<SohoRadarSelectEvent>();
   @Output() unselected: EventEmitter<SohoRadarSelectEvent> = new EventEmitter<SohoRadarSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  // eslint-disable-next-line @angular-eslint/no-output-native, @angular-eslint/no-output-rename
   @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/radar/soho-radar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/radar/soho-radar.component.ts
@@ -252,6 +252,7 @@ export class SohoRadarComponent implements AfterViewInit, AfterViewChecked, OnDe
   @Output() selected: EventEmitter<SohoRadarSelectEvent> = new EventEmitter<SohoRadarSelectEvent>();
   @Output() unselected: EventEmitter<SohoRadarSelectEvent> = new EventEmitter<SohoRadarSelectEvent>();
   @Output() rendered: EventEmitter<Object> = new EventEmitter<Object>();
+  @Output() dblclick: EventEmitter<Object> = new EventEmitter<Object>();
 
   /**
    * @todo remove override of native elements
@@ -286,6 +287,8 @@ export class SohoRadarComponent implements AfterViewInit, AfterViewChecked, OnDe
         this.ngZone.run(() => this.rendered.emit(args)));
       this.jQueryElement.on('contextmenu', (...args) =>
         this.ngZone.run(() => this.contextmenu?.emit(args)));
+      this.jQueryElement.on('dblclick', (_e: any, args: Object) =>
+        this.ngZone.run(() => this.dblclick.emit(args)));
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/radar/soho-radar.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/radar/soho-radar.spec.ts
@@ -190,15 +190,20 @@ describe('Soho Radar Unit Tests', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('check public functions', () => {
+  it('check public functions', (done) => {
     comp.dataset = radarData;
     fixture.detectChanges();
-
     comp.toggleSelected({ index: 1 });
-    expect((comp as any).getSelected().index).toEqual(1);
 
-    comp.setSelected({ index: 2 });
-    expect((comp as any).getSelected().index).toEqual(2);
+    setTimeout(() => {
+      expect((comp as any).getSelected().index).toEqual(1);
+      comp.setSelected({ index: 2 });
+
+      setTimeout(() => {
+        expect((comp as any).getSelected().index).toEqual(2);
+        done();
+      }, 201);
+    }, 201);
   });
 });
 

--- a/src/app/area/area.demo.html
+++ b/src/app/area/area.demo.html
@@ -6,6 +6,8 @@
       </div>
       <div class="widget-content">
         <div soho-line
+          (selected)="onSelected($event)"
+          (dblclick)="onDblclick($event)"
           [dataset]="areaData"
           [isArea]="true">
         </div>

--- a/src/app/area/area.demo.ts
+++ b/src/app/area/area.demo.ts
@@ -68,11 +68,14 @@ export class AreaDemoComponent implements OnInit {
     this.sohoLineComponent?.toggleSelected(sohoLineSelected);
   }
 
-  onSelected (_e: any) {
-    console.log('selected', _e);
+  onSelected (args: any) {
+    console.log('selected', args);
   }
 
-  onDblclick (_e: any) {
-    console.log('double clicked', _e);
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
   }
 }

--- a/src/app/area/area.demo.ts
+++ b/src/app/area/area.demo.ts
@@ -67,4 +67,12 @@ export class AreaDemoComponent implements OnInit {
     const sohoLineSelected: SohoLineSelected = this.selection;
     this.sohoLineComponent?.toggleSelected(sohoLineSelected);
   }
+
+  onSelected (_e: any) {
+    console.log('selected', _e);
+  }
+
+  onDblclick (_e: any) {
+    console.log('double clicked', _e);
+  }
 }

--- a/src/app/bar-grouped/bar-grouped.demo.html
+++ b/src/app/bar-grouped/bar-grouped.demo.html
@@ -6,6 +6,8 @@
       </div>
       <div class="widget-content">
         <div soho-bar
+          (selected)="onSelected($event)"
+          (dblclick)="onDblclick($event)"
           [dataset]="barGroupedData"
           [type]="barType">
         </div>

--- a/src/app/bar-grouped/bar-grouped.demo.ts
+++ b/src/app/bar-grouped/bar-grouped.demo.ts
@@ -68,4 +68,15 @@ export class BarGroupedDemoComponent implements OnInit {
     const SohoBarSelected: SohoBarSelected = this.selection;
     this.sohoBarComponent?.toggleSelected(SohoBarSelected);
   }
+
+  onSelected (args: any) {
+    console.log('selected', args);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
+  }
 }

--- a/src/app/bar-stacked/bar-stacked.demo.html
+++ b/src/app/bar-stacked/bar-stacked.demo.html
@@ -6,6 +6,8 @@
         </div>
         <div class="widget-content">
           <div soho-bar
+            (selected)="onSelected($event)"
+            (dblclick)="onDblclick($event)"
             [dataset]="barStackedData"
             [type]="barType">
           </div>

--- a/src/app/bar-stacked/bar-stacked.demo.ts
+++ b/src/app/bar-stacked/bar-stacked.demo.ts
@@ -59,4 +59,15 @@ export class BarStackedDemoComponent implements OnInit {
     const SohoBarSelected: SohoBarSelected = this.selection;
     this.sohoBarComponent?.toggleSelected(SohoBarSelected);
   }
+
+  onSelected (args: any) {
+    console.log('selected', args);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
+  }
 }

--- a/src/app/bar/bar.demo.html
+++ b/src/app/bar/bar.demo.html
@@ -8,6 +8,8 @@
         <div soho-bar
           [dataset]="barData"
           [type]="barType"
+          (selected)="onSelected($event)"
+          (dblclick)="onDblclick($event)"
           (rendered)="onRendered($event)"
           (contextmenu)="onContextMenu($event)">
         </div>

--- a/src/app/bar/bar.demo.ts
+++ b/src/app/bar/bar.demo.ts
@@ -55,4 +55,15 @@ export class BarDemoComponent implements OnInit {
   onContextMenu(args: any) {
     console.log('onContextMenu', args);
   }
+
+  onSelected (args: any) {
+    console.log('selected', args);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
+  }
 }

--- a/src/app/bubble/bubble.demo.html
+++ b/src/app/bubble/bubble.demo.html
@@ -6,6 +6,8 @@
       </div>
       <div class="widget-content">
         <div soho-line
+          (selected)="onSelected($event)"
+          (dblclick)="onDblclick($event)"
           [dataset]="bubbleData"
           [isBubble]="true">
         </div>

--- a/src/app/bubble/bubble.demo.ts
+++ b/src/app/bubble/bubble.demo.ts
@@ -119,4 +119,15 @@ export class BubbleDemoComponent implements OnInit {
     const sohoLineSelected: SohoLineSelected = this.selection;
     this.sohoLineComponent?.toggleSelected(sohoLineSelected);
   }
+
+  onSelected (args: any) {
+    console.log('selected', args);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
+  }
 }

--- a/src/app/bullet/bullet.demo.html
+++ b/src/app/bullet/bullet.demo.html
@@ -1,10 +1,14 @@
 <div class="row top-padding">
   <div class="full column center">
     <div soho-bullet
+      (selected)="onSelected($event)"
+      (dblclick)="onDblclick($event)"
       [dataset]="bulletData1"
       (rendered)="onRendered($event)">
     </div>
     <div soho-bullet
+      (selected)="onSelected($event)"
+      (dblclick)="onDblclick($event)"
       [dataset]="bulletData2"
       (rendered)="onRendered($event)">
     </div>

--- a/src/app/bullet/bullet.demo.ts
+++ b/src/app/bullet/bullet.demo.ts
@@ -46,4 +46,14 @@ export class BulletDemoComponent implements OnInit {
     console.log('Soho Radar: onRender', event);
   }
 
+  onSelected (args: any) {
+    console.log('selected', args);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
+  }
 }

--- a/src/app/column-grouped/column-grouped.demo.html
+++ b/src/app/column-grouped/column-grouped.demo.html
@@ -6,6 +6,8 @@
       </div>
       <div class="widget-content">
         <div soho-column
+          (selected)="onSelected($event)"
+          (dblclick)="onDblclick($event)"
           [dataset]="columnGroupedData"
           [type]="columnType">
         </div>

--- a/src/app/column-grouped/column-grouped.demo.ts
+++ b/src/app/column-grouped/column-grouped.demo.ts
@@ -79,4 +79,15 @@ export class ColumnGroupedDemoComponent implements OnInit {
     const SohoColumnSelected: SohoColumnSelected = this.selection;
     this.sohoColumnComponent?.toggleSelected(SohoColumnSelected);
   }
+
+  onSelected (args: any) {
+    console.log('selected', args);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
+  }
 }

--- a/src/app/column-stacked/column-stacked.demo.html
+++ b/src/app/column-stacked/column-stacked.demo.html
@@ -6,6 +6,8 @@
       </div>
       <div class="widget-content">
         <div soho-column
+          (selected)="onSelected($event)"
+          (dblclick)="onDblclick($event)"
           [dataset]="columnStackedData"
           [type]="columnType">
         </div>

--- a/src/app/column-stacked/column-stacked.demo.ts
+++ b/src/app/column-stacked/column-stacked.demo.ts
@@ -115,4 +115,15 @@ export class ColumnStackedDemoComponent implements OnInit {
     const SohoColumnSelected: SohoColumnSelected = this.selection;
     this.sohoColumnComponent?.toggleSelected(SohoColumnSelected);
   }
+
+  onSelected (args: any) {
+    console.log('selected', args);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
+  }
 }

--- a/src/app/column/column.demo.html
+++ b/src/app/column/column.demo.html
@@ -6,6 +6,8 @@
       </div>
       <div class="widget-content">
         <div soho-column
+          (selected)="onSelected($event)"
+          (dblclick)="onDblclick($event)"
           [dataset]="columnData"
           [type]="columnType">
         </div>

--- a/src/app/column/column.demo.ts
+++ b/src/app/column/column.demo.ts
@@ -72,4 +72,15 @@ export class ColumnDemoComponent implements OnInit {
     const SohoColumnSelected: SohoColumnSelected = this.selection;
     this.sohoColumnComponent?.toggleSelected(SohoColumnSelected);
   }
+
+  onSelected (args: any) {
+    console.log('selected', args);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
+  }
 }

--- a/src/app/donut/donut.demo.html
+++ b/src/app/donut/donut.demo.html
@@ -10,6 +10,7 @@
           [isDonut]="true"
           (selected)="onSelected($event)"
           (deselected)="onDeselected($event)"
+          (dblclick)="onDblclick($event)"
           (rendered)="onRendered($event)">
         </div>
       </div>

--- a/src/app/donut/donut.demo.ts
+++ b/src/app/donut/donut.demo.ts
@@ -48,6 +48,13 @@ export class DonutDemoComponent implements OnInit {
     console.log('Soho Donut: Deselected', event);
   }
 
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('Soho Donut: double clicked', args);
+    }
+  }
+
   setChartSelection() {
     const sohoPieSelected: SohoPieSelected = this.selection;
     this.sohoPieComponent?.setSelected(sohoPieSelected);

--- a/src/app/line/line.demo.html
+++ b/src/app/line/line.demo.html
@@ -6,6 +6,8 @@
       </div>
       <div class="widget-content">
         <div soho-line
+          (selected)="onSelected($event)"
+          (dblclick)="onDblclick($event)"
           [dataset]="lineData"
           [xAxis]="xAxis">
         </div>

--- a/src/app/line/line.demo.ts
+++ b/src/app/line/line.demo.ts
@@ -80,4 +80,15 @@ export class LineDemoComponent implements OnInit {
     const sohoLineSelected: SohoLineSelected = this.selection;
     this.sohoLineComponent?.toggleSelected(sohoLineSelected);
   }
+
+  onSelected (args: any) {
+    console.log('selected', args);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('double clicked', args);
+    }
+  }
 }

--- a/src/app/pie/pie.demo.html
+++ b/src/app/pie/pie.demo.html
@@ -9,6 +9,7 @@
           [dataset]="pieData"
           (selected)="onSelected($event)"
           (deselected)="onDeselected($event)"
+          (dblclick)="onDblclick($event)"
           (rendered)="onRendered($event)">
         </div>
       </div>

--- a/src/app/pie/pie.demo.ts
+++ b/src/app/pie/pie.demo.ts
@@ -53,15 +53,22 @@ export class PieDemoComponent implements OnInit {
   ngOnInit() {}
 
   onRendered(event: Event) {
-    console.log('Soho Radar: onRender', event);
+    console.log('Soho Pie: onRender', event);
   }
 
   onSelected(event: Event) {
-    console.log('Soho Radar: Selected', event);
+    console.log('Soho Pie: Selected', event);
   }
 
   onDeselected(event: Event) {
-    console.log('Soho Radar: Deselected', event);
+    console.log('Soho Pie: Deselected', event);
+  }
+
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('Soho Pie: double clicked', args);
+    }
   }
 
   setChartSelection() {

--- a/src/app/radar/radar.demo.html
+++ b/src/app/radar/radar.demo.html
@@ -10,6 +10,7 @@
             [showAxisLabels]="false"
             (selected)="onSelected($event)"
             (deselected)="onDeselected($event)"
+            (dblclick)="onDblclick($event)"
             (rendered)="onRendered($event)"
             (radar)="onRadar($event)">
           </div>

--- a/src/app/radar/radar.demo.ts
+++ b/src/app/radar/radar.demo.ts
@@ -79,6 +79,13 @@ export class RadarDemoComponent implements OnInit {
     console.log('Soho Radar: Deselected', event);
   }
 
+  onDblclick (args: any) {
+    // Use only when `dblclick` is firing on our component
+    if (!args.target) {
+     console.log('Soho Radar: double clicked', args);
+    }
+  }
+
   update() {
     this.radarData = [{
       data: [


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added double click event to all chart types.

**Related github/jira issue (required)**:
Closes infor-design/enterprise#3229

**Steps necessary to review your pull request (required)**:
- After ([PR 4975](https://github.com/infor-design/enterprise/pull/4975)) merged
- Pull and build this branch
- Navigate to:
- http://localhost:4200/ids-enterprise-ng-demo/area
- http://localhost:4200/ids-enterprise-ng-demo/bar
- http://localhost:4200/ids-enterprise-ng-demo/bar-grouped
- http://localhost:4200/ids-enterprise-ng-demo/bar-stacked
- http://localhost:4200/ids-enterprise-ng-demo/bubble
- http://localhost:4200/ids-enterprise-ng-demo/bullet
- http://localhost:4200/ids-enterprise-ng-demo/column
- http://localhost:4200/ids-enterprise-ng-demo/column-grouped
- http://localhost:4200/ids-enterprise-ng-demo/column-stacked
- http://localhost:4200/ids-enterprise-ng-demo/donut
- http://localhost:4200/ids-enterprise-ng-demo/line
- http://localhost:4200/ids-enterprise-ng-demo/pie
- http://localhost:4200/ids-enterprise-ng-demo/radar
- Open developer tools
- Single or Double click on each chart
- See logs in console for single and double clicked event

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
