### PR TITLE
Closes #1014

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - `[Placeholder]` Remove me.... ([#1001](https://github.com/infor-design/enterprise-ng/issues/1001)) `TJM`
 
+## v9.3.2
+
+### 9.3.2 Fixes
+
+- `[Modal]` Update modal close method API and use force as default to proceed modal closing even when tooltip is open. `NBCP` ([#1014](https://github.com/infor-design/enterprise-ng/issues/1014))
+
 ## v9.3.1
 
 ### 9.3.1 Fixes

--- a/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
@@ -501,7 +501,7 @@ export class SohoModalDialogRef<T> {
   close(dialogResult?: any): SohoModalDialogRef<T> {
     this.dialogResult = dialogResult;
     if (this.modal) {
-      this.ngZone.runOutsideAngular(() => this.modal?.close());
+      this.ngZone.runOutsideAngular(() => this.modal?.close(false, false, true));
     }
     return this;
   }

--- a/projects/ids-enterprise-typings/lib/modal-dialog/soho-modal-dialog.d.ts
+++ b/projects/ids-enterprise-typings/lib/modal-dialog/soho-modal-dialog.d.ts
@@ -182,8 +182,10 @@ interface SohoModalStatic {
    * Close the modal dialog.
    *
    * @param destroy - destroy the html elements.
+   * @param noRefresh - if true, prevents the ModalManager from refreshing state when the close is complete.
+   * @param force - if true, forces the modal closed and ignores open subcomponents/visibility.
    */
-  close(destroy?: boolean): void;
+  close(destroy?: boolean, noRefresh?: boolean, force?: boolean): void;
 
   /**
    * Releases all resources managed by the modal.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This updates the SohoModalStatic interface to accept enterprise's close parameters and defaults force parameter into true. This ensures the modal closes when modal.close() is called even when there is a open tooltip.

**Related github/jira issue (required)**:
closes #1014

**Steps necessary to review your pull request (required)**:
Visual inspect, this change is trivial

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
