### PR TITLE
getValue returns string or Date object.

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -386,7 +386,17 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<any> imple
     this.datepicker?.setValue(value, true);
   }
 
-  public getValue(): Date {
+  public getValue(asDate: boolean = false): string | Date {
+    if (asDate) {
+      const calendar = Soho.Locale.calendar();
+      const dateFormat = this._options.dateFormat || calendar.dateFormat.short;
+      const timeFormat = this._options.timeFormat || calendar.timeFormat;
+      let format = dateFormat;
+      if (this._options.showTime) {
+        format += 'T' + timeFormat;
+      }
+      return Soho.Locale.parseDate(this.internalValue, format);
+    }
     return this.internalValue;
   }
 

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
@@ -381,4 +381,78 @@ describe('Soho Datepicker Unit Tests', () => {
       });
     });
   }));
+
+  it('Check getting value for en-US', waitForAsync(() => {
+    spyOn(comp, 'onChange');
+
+    const date = new Date('1978-11-11T12:00:00Z');
+    const dateWithoutTime = getDateWithoutTime(date);
+
+    expect(Soho.Locale.currentLocale.name).toEqual('en-US');
+    comp.datepicker?.setValue(date);
+
+    fixture.detectChanges();
+
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(Soho.Locale.currentLocale.name).toEqual('en-US');
+      expect(comp.onChange).toHaveBeenCalled();
+      expect(['11/11/1978', '1978-11-11']).toContain(comp.datepicker?.getValue() as any);
+      expect(dateWithoutTime).toEqual(comp.datepicker?.getValue(true) as any);
+    });
+  }));
+
+  it('Check getting value for different date format', waitForAsync(() => {
+    comp.dateFormat = 'dd:MM:yyyy';
+    fixture.detectChanges();
+
+    spyOn(comp, 'onChange');
+
+    const date = new Date('1978-11-11T12:00:00Z');
+    const dateWithoutTime = getDateWithoutTime(date);
+
+    expect(Soho.Locale.currentLocale.name).toEqual('en-US');
+    comp.datepicker?.setValue(date);
+
+    fixture.detectChanges();
+
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(Soho.Locale.currentLocale.name).toEqual('en-US');
+      expect(comp.onChange).toHaveBeenCalled();
+      expect('11:11:1978').toBe(comp.datepicker?.getValue() as any);
+      expect(dateWithoutTime).toEqual(comp.datepicker?.getValue(true) as any);
+    });
+  }));
+
+  it('Check getting value with time', waitForAsync(() => {
+    comp.showTime = true;
+    fixture.detectChanges();
+
+    spyOn(comp, 'onChange');
+
+    const date = new Date('1978-11-11T06:00:00Z');
+    const dateWithoutTime = getDateWithoutTime(date);
+
+    expect(Soho.Locale.currentLocale.name).toEqual('en-US');
+    comp.datepicker?.setValue(date);
+
+    fixture.detectChanges();
+
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(Soho.Locale.currentLocale.name).toEqual('en-US');
+      expect(comp.onChange).toHaveBeenCalled();
+      expect('11/11/1978 12:00 AM').toBe(comp.datepicker?.getValue() as any);
+      expect(dateWithoutTime).toEqual(comp.datepicker?.getValue(true) as any);
+    });
+  }));
+
+  function getDateWithoutTime(date: Date): Date {
+    const dateWithoutTime = date;
+    dateWithoutTime.setHours(0);
+    dateWithoutTime.setMinutes(0);
+    dateWithoutTime.setSeconds(0);
+    return dateWithoutTime;
+  }
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The DatePicker component now returns the selected date as string or Date object.

**Related github/jira issue (required)**:
Fixes #1016

**Steps necessary to review your pull request (required)**:
- getValue method was changed according the discussion in issue
- 3 additional automated tests check the new behavior
- for test 'Check getting value with time' one remark: setting a date with 6 o'clock results in 12 o'clock. 
