### PR TITLE
1024 - Fix switching datepicker mode wasn't setting the range object in options correctly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Charts]` Added double click event to all chart types. `DV` ([#3229](https://github.com/infor-design/enterprise/pull/3229))
 - `[Popupmenu]` Add example demonstrating shared Popupmenus working after one is destroyed. ([#987](https://github.com/infor-design/enterprise-ng/issues/987)) `EPC`
+- `[DatePicker]` Fixed issue when switching mode back to range wouldn't clear out the range in the options object. ([#1024](https://github.com/infor-design/enterprise-ng/issues/1024)) `MHH`
 
 ## v9.3.2
 

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -146,6 +146,10 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<any> imple
         this._options.range = {};
         this._options.range.useRange = true;
       }
+    } else {
+      if (this._options.range) {
+        this._options.range.useRange = false;
+      }
     }
     if (this.datepicker) {
       this.markForRefresh();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Sets the datepicker options correctly when switching back from range mode.

**Related github/jira issue (required)**:
Closes #1024 

**Steps necessary to review your pull request (required)**:
1. Pull in my code change
2. In the angular demo app, go to F -> Field Filter
3. Scroll down to Date With Range, and set the filter field to In Range.
4. Open the picker and validate it is now in range mode
4. Set the filter field to Equals
5. Open the date picker and see that the picker is now in single select mode.

