### PR TITLE
1023 - Fix lookup hostlistener for disabled attribute

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 9.5.0 Fixes
 
 - `[Misc]` Placeholder..... `P` ([#3229](https://github.com/infor-design/enterprise/pull/3229))
+- `[Lookup]` Fixed issue where setting `[isDisabled]="false"` would add the disabled attribute anyway. ([#1023](https://github.com/infor-design/enterprise-ng/issues/1023))
 
 ## v9.4.0
 

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
@@ -349,9 +349,12 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
     return true;
   }
 
-  @HostBinding('attr.disabled')
-  @Input()
-  isDisabled: boolean | undefined = undefined;
+  @HostBinding('attr.disabled') get isDisabledAttr() {
+    return this.isDisabled || undefined;
+  }
+
+  @Input() isDisabled: boolean | undefined = undefined;
+
 
   /**
    * Local variables

--- a/src/app/lookup/lookup.demo.html
+++ b/src/app/lookup/lookup.demo.html
@@ -30,7 +30,6 @@
             name="product_single_exists" />
         </div>
       </div>
-
     </div>
     <div class="row">
       <div class="six columns">
@@ -275,7 +274,6 @@
             field="productId"
             name="product_custom_match" />
         </div>
-
         <div class="field">
           <label soho-label for="product_async">Products (Async Results) Multi Select</label>
           <input soho-lookup
@@ -305,7 +303,6 @@
             field="productId"
             name="product_async_multi"/>
         </div>
-
         <div class="field">
           <label soho-label for="dataset-input">Using Dataset Inputs</label>
           <input soho-lookup
@@ -318,8 +315,23 @@
             [dataset]="templates" 
           />
         </div>
-
+        <div class="field">
+          <label soho-label for="toggle-disabled">Toggle isDisabled</label>
+          <input soho-lookup
+            [isDisabled]="isDisabled"
+            [(ngModel)]="model.single"
+            [columns]="columns_product"
+            [dataset]="data_product"
+            field="productId"
+            title="Products"
+            name="toggle-disabled" />
+          <button soho-button="primary"
+            [style.margin-left.px]="10"
+            (click)="isDisabled = !isDisabled">
+            {{ isDisabled ? 'Enable' : 'Disable'}}
+          </button>
         </div>
       </div>
     </div>
+  </div>
 </form>

--- a/src/app/lookup/lookup.demo.ts
+++ b/src/app/lookup/lookup.demo.ts
@@ -26,6 +26,7 @@ export class LookupDemoComponent implements OnInit {
   @ViewChild('templateId', { static: true }) sohoLookupComponent?: SohoLookupComponent;
   @ViewChild('toggleButtons', { static: true }) sohoLookupRef?: SohoLookupComponent;
 
+  public isDisabled = false;
   public columns_product?: SohoDataGridColumn[];
   public columns_multi?: SohoDataGridColumn[];
   public entityIds?: string;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adding a getter for the hostlistener for `attr.disabled`. Solves issue where  setting `[isDisabled]="false"` would still add the disabled attribute on the element.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-ng/issues/1023

**Steps necessary to review your pull request (required)**:

* Review trivial change to hostlistener
* Check added example with button to enable/disable lookup based on isDisabled input
  * http://localhost:4200/ids-enterprise-ng-demo/lookup
<img width="559" alt="Screenshot 2021-04-07 at 21 55 42" src="https://user-images.githubusercontent.com/73601152/113926053-03fe3700-97ec-11eb-93fc-6076a7ae6833.png">
