### PR TITLE
Add 'get' for attributes to SohoBusyIndicatorDirective

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/busyindicator/soho-busyindicator.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/busyindicator/soho-busyindicator.directive.ts
@@ -156,6 +156,16 @@ export class SohoBusyIndicatorDirective implements AfterViewInit, AfterViewCheck
   }
 
   /**
+   * To get the attributes of the busy indicator. Useful for things like getting an indicator based on an Id.
+   */
+  public get attributes(): Object | Array<Object> {
+    if (this.busyindicator) {
+      return this.options.attributes ? this.options.attributes : [];
+    }
+    return [];
+  }
+
+  /**
    * Constructor.
    *
    * @param elementRef - the element matching the component's selector.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds the ability to reference a SohoBusyIndicatorDirective's custom attributes.
This allows you to identify a BusyIndicator based on the attribute, instead of f.x index.

It's already possible to do: `busyIndicator.attributes` but this will always return undefined, as there is no **get** method for it.

**Related github/jira issue (required)**:
#1038 

**Steps necessary to review your pull request (required)**:
Build the project

Code used to check if it works

**test.component.ts**
```Typescript
@ViewChildren(SohoBusyIndicatorDirective)
  busyIndicators?: QueryList<SohoBusyIndicatorDirective>;

if (this.busyIndicators) {
      this.busyIndicators.forEach((indicator) => {
        console.log(indicator.attributes);
      });
    }
``` 

**test.component.html**
```HTML
<div class="row">
  <div class="one-half column" [attributes]="{ id: 'test' }" soho-busyindicator [displayDelay]="0">
    <p>Test</p>
  </div>
  
  <div class="one-half column" soho-busyindicator [displayDelay]="0">
    <p>Test 2</p>
  </div>
</div>
```
