### PR TITLE
1061 message service message undefined

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### 10.2.0 Fixes
 
-- `[General]` Temporary Placeholder
 - `[Multiselect]` Added an example showing automation id attributes on options in multiselect. ([#1005](https://github.com/infor-design/enterprise-ng/issues/1005))
 - `[SohoMessageService]` Removed `undefined` return type from messages method. ([#1061](https://github.com/infor-design/enterprise-ng/issues/1061))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `[General]` Temporary Placeholder
 - `[Multiselect]` Added an example showing automation id attributes on options in multiselect. ([#1005](https://github.com/infor-design/enterprise-ng/issues/1005))
-- `[MessageDialog]` Removed `undefined` return type from messages method. ([#1061](https://github.com/infor-design/enterprise-ng/issues/1061))
+- `[SohoMessageService]` Removed `undefined` return type from messages method. ([#1061](https://github.com/infor-design/enterprise-ng/issues/1061))
 
 ### 10.2.0 Features
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[General]` Temporary Placeholder
 - `[Multiselect]` Added an example showing automation id attributes on options in multiselect. ([#1005](https://github.com/infor-design/enterprise-ng/issues/1005))
+- `[MessageDialog]` Removed `undefined` return type from messages method. ([#1061](https://github.com/infor-design/enterprise-ng/issues/1061))
 
 ### 10.2.0 Features
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -51,10 +51,10 @@ export NODE_OPTIONS="--max-old-space-size=8192"
 
 #### Angular 10 & 11
 
-When updating (and depending on your dependencies) the update *may* not complete, and this is often because one of the referenced packages has a dependency on an older version of TypeScript.  If this is the case, install TypeScript 3.9.x first, as follows:
+When updating (and depending on your dependencies) the update *may* not complete, and this is often because one of the referenced packages has a dependency on an older version of TypeScript.  If this is the case, install [TypeScript](https://github.com/infor-design/enterprise-ng/blob/main/package.json#L109) first, as follows:
 
 ```sh
-npm i typescript@4.0.4
+npm i typescript@<version>
 ```
 
 ### Install typings as a seperate package

--- a/projects/ids-enterprise-ng/src/lib/message/soho-message.service.ts
+++ b/projects/ids-enterprise-ng/src/lib/message/soho-message.service.ts
@@ -24,7 +24,7 @@ export class SohoMessageService {
    *
    * @return the message reference.
    */
-  message(options?: SohoMessageOptions): SohoMessageRef | undefined {
+  message(options?: SohoMessageOptions): SohoMessageRef {
     return new SohoMessageRef().options(options);
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Removed `undefined` from `message` method on `SohoMessageService`.

**Related github/jira issue (required)**:

Closes #1061 

**Steps necessary to review your pull request (required)**:

```sh
git clone c:/git/github/infor-design/enterprise-ng.git
cd enterprise-ng
npm i
npm lint
npm run test
npm run build:prod
npm run start
```

Navigate to message tests.

To test new library, add a new component to ids-enterprise-ng-quickstart:

```sh
git clone c:/git/github/infor-design/enterprise-ng-quickstart.git
cd ids-enterprise-ng-quickstart
npm i
cd src
cd app
ng generate component content
```

Add `app-content` to `app.component.html`.

```html
<ids-layout-grid>
      <ids-text font-size="12" type="h1">New Web Components Work Too</ids-text>
      <app-content></app-content>
    </ids-layout-grid>
  </div>
```

Change `content.component.ts`:

```typescript
@Component({
  selector: 'app-content',
  template: `
  <ids-button id="test-button-primary" type="primary" (click)="onClick($event)">
    <span slot="text">Primary Button</span>
  </ids-button>./content.component.html
  `
})
export class ContentComponent {
  constructor(private messageService: SohoMessageService) { }
  onClick(e: Event) {
    const buttons: SohoModalButton[] = [];

    this.messageService.message()
      .buttons(buttons)
      .open();
  }
}
```

There should be no errors.

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
