### PR TITLE
1069 - Fix enabling lookup elements when initially disabled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 10.2.0 Fixes
 
-- `[Lookup]` Fixed a bug where the enabling the lookup doesn't work when the component is initially disabled. ([#1069](https://github.com/infor-design/enterprise-ng/issues/1069)) `EA`
+- `[Lookup]` Fixed a bug where the enabling the lookup doesn't work when the component is initially disabled. In order to do this we changed the examples to use `[attr.disabled]` instead of an `isDisabled` input to be more consistent. Suggest using this but kept `isDisabled` for compatibility. ([#1069](https://github.com/infor-design/enterprise-ng/issues/1069)) `EA`
 - `[Multiselect]` Added an example showing automation id attributes on options in multiselect. ([#1005](https://github.com/infor-design/enterprise-ng/issues/1005))
 - `[SohoMessageService]` Removed `undefined` return type from messages method. ([#1061](https://github.com/infor-design/enterprise-ng/issues/1061))
 - `[SohoDatePicker]` Fixed datepicker format when assigned via angular form control. ([#1072](https://github.com/infor-design/enterprise-ng/issues/1072))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 10.2.0 Fixes
 
+- `[Lookup]` Fixed a bug where the enabling the lookup doesn't work when the component is initially disabled. ([#1069](https://github.com/infor-design/enterprise-ng/issues/1069)) `EA`
 - `[Multiselect]` Added an example showing automation id attributes on options in multiselect. ([#1005](https://github.com/infor-design/enterprise-ng/issues/1005))
 - `[SohoMessageService]` Removed `undefined` return type from messages method. ([#1061](https://github.com/infor-design/enterprise-ng/issues/1061))
 - `[SohoDatePicker]` Fixed datepicker format when assigned via angular form control. ([#1072](https://github.com/infor-design/enterprise-ng/issues/1072))

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -42,7 +42,7 @@ For proper tree shaking you may need:
 
 See <https://angular.io/guide/creating-libraries>, and search for Transitioning libraries to partial-Ivy format.
 
-Also on Mac OS i had to run this in the command line as the new NG 12 builds are more intensive.
+Also on Mac OS I had to run this in the command line as the new NG 12 builds are more intensive.
 
 ```sh
 # For angular 12 to build

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
@@ -380,7 +380,7 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
   /** Initial dataset */
   private _dataset?: Object[];
 
-  constructor(private element: ElementRef, private ngZone: NgZone) {
+  constructor(private element: ElementRef<HTMLInputElement>, private ngZone: NgZone) {
     super();
   }
 
@@ -519,7 +519,7 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
     }
 
     // enabling all elements of lookup when component is initially disabled
-    if (!this.isDisabled) {
+    if (!this.isDisabled && !this.element.nativeElement.getAttribute('disabled')) {
       this.enable();
     }
   }

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
@@ -431,14 +431,6 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
       this.jQueryElement.on('input', () => this.ngZone.run(() => this.inputEvt.emit(undefined)));
       this.jQueryElement.on('close', () => this.ngZone.run(() => this.close.emit(undefined)));
 
-      // this.jQueryElement.on('click', () => {
-      //   this.ngZone.runOutsideAngular(() => {
-      //     if (!this.isDisabled) {
-      //       this.enable();
-      //     }
-      //   });
-      // });
-
       this.lookup = this.jQueryElement.data('lookup');
 
       if (this.internalValue) {

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
@@ -431,6 +431,14 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
       this.jQueryElement.on('input', () => this.ngZone.run(() => this.inputEvt.emit(undefined)));
       this.jQueryElement.on('close', () => this.ngZone.run(() => this.close.emit(undefined)));
 
+      // this.jQueryElement.on('click', () => {
+      //   this.ngZone.runOutsideAngular(() => {
+      //     if (!this.isDisabled) {
+      //       this.enable();
+      //     }
+      //   });
+      // });
+
       this.lookup = this.jQueryElement.data('lookup');
 
       if (this.internalValue) {
@@ -516,6 +524,11 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
     if (this.updateRequired) {
       this.updated();
       this.updateRequired = false;
+    }
+
+    // enabling all elements of lookup when component is initially disabled
+    if (!this.isDisabled) {
+      this.enable();
     }
   }
 

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
@@ -719,8 +719,14 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
    * This function is called when the control status changes to or from "DISABLED".
    * Depending on the value, it will enable or disable the appropriate DOM element.
    */
-  setDisabledState(isDisabled: boolean): void {
-    this.disabled = isDisabled;
+  setDisabledState(isDisabled: boolean | undefined): void {
+    // Update the jQuery widget with the requested disabled state.
+    this.disabled = isDisabled ? true : undefined;
+    if (isDisabled) {
+      this.lookup?.element.attr('disabled', 'true');
+    } else {
+      this.lookup?.element.removeAttr('disabled');
+    }
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
@@ -575,6 +575,9 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
       if (this._isDisabled !== null && this._isDisabled !== undefined) {
         this.disabled = this._isDisabled;
       }
+      if (this._isReadOnly !== null && this._isReadOnly !== undefined) {
+        this.readonly = this._isReadOnly;
+      }
     }
     if (this.updateRequired) {
       this.updated();

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.spec.ts
@@ -249,7 +249,9 @@ describe('SohoLookupComponent on ReactiveForm', () => {
   });
 
   it('is readonly after call to readonly().', () => {
-    component.lookup?.readonly();
+    if (component.lookup) {
+      component.lookup.readonly = true;
+    }
     expect(el.hasAttribute('readonly')).toBeTruthy('readonly');
   });
 

--- a/src/app/lookup/lookup.demo.html
+++ b/src/app/lookup/lookup.demo.html
@@ -362,7 +362,10 @@
         <button soho-button
         (click)="isDisabled = !isDisabled">
         {{ isDisabled ? 'Enable' : 'Disable'}}
-      </button>
+        </button>
+        <button soho-button
+        (click)="toggleDisabled()">Toggle Disabled (Method)
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/lookup/lookup.demo.html
+++ b/src/app/lookup/lookup.demo.html
@@ -316,6 +316,28 @@
           />
         </div>
         <div class="field">
+          <label soho-label for="toggle-disabled">Toggle [attr.disabled]</label>
+          <input soho-lookup
+            [attr.disabled]="isDisabled ? '' : null"
+            [(ngModel)]="model.single"
+            [columns]="columns_product"
+            [dataset]="data_product"
+            field="productId"
+            title="Products"
+            name="toggle-disabled" />
+        </div>
+        <div class="field">
+          <label soho-label for="toggle-disabled">Toggle [attr.disabled] (Inverse)</label>
+          <input soho-lookup
+            [attr.disabled]="!isDisabled ? '' : null"
+            [(ngModel)]="model.single"
+            [columns]="columns_product"
+            [dataset]="data_product"
+            field="productId"
+            title="Products"
+            name="toggle--inverse" />
+        </div>
+        <div class="field">
           <label soho-label for="toggle-disabled">Toggle isDisabled</label>
           <input soho-lookup
             [isDisabled]="isDisabled"
@@ -324,13 +346,12 @@
             [dataset]="data_product"
             field="productId"
             title="Products"
-            name="toggle-disabled" />
-          <button soho-button="primary"
-            [style.margin-left.px]="10"
-            (click)="isDisabled = !isDisabled">
-            {{ isDisabled ? 'Enable' : 'Disable'}}
-          </button>
+            name="toggle-isdisabled" />
         </div>
+        <button soho-button
+        (click)="isDisabled = !isDisabled">
+        {{ isDisabled ? 'Enable' : 'Disable'}}
+      </button>
       </div>
     </div>
   </div>

--- a/src/app/lookup/lookup.demo.html
+++ b/src/app/lookup/lookup.demo.html
@@ -316,6 +316,17 @@
           />
         </div>
         <div class="field">
+          <label soho-label for="readonly">Readonly [attr.readonly]</label>
+          <input soho-lookup
+            [attr.readonly]="isDisabled"
+            [(ngModel)]="model.single"
+            [columns]="columns_product"
+            [dataset]="data_product"
+            field="productId"
+            title="Products"
+            name="readonly" />
+        </div>
+        <div class="field">
           <label soho-label for="toggle-disabled">Toggle [attr.disabled]</label>
           <input soho-lookup
             [attr.disabled]="isDisabled ? '' : null"
@@ -327,7 +338,7 @@
             name="toggle-disabled" />
         </div>
         <div class="field">
-          <label soho-label for="toggle-disabled">Toggle [attr.disabled] (Inverse)</label>
+          <label soho-label for="toggle-inverse">Toggle [attr.disabled] (Inverse)</label>
           <input soho-lookup
             [attr.disabled]="!isDisabled ? '' : null"
             [(ngModel)]="model.single"
@@ -335,10 +346,10 @@
             [dataset]="data_product"
             field="productId"
             title="Products"
-            name="toggle--inverse" />
+            name="toggle-inverse" />
         </div>
         <div class="field">
-          <label soho-label for="toggle-disabled">Toggle isDisabled</label>
+          <label soho-label for="toggle-isdisabled">Toggle isDisabled</label>
           <input soho-lookup
             [isDisabled]="isDisabled"
             [(ngModel)]="model.single"

--- a/src/app/lookup/lookup.demo.ts
+++ b/src/app/lookup/lookup.demo.ts
@@ -289,4 +289,14 @@ export class LookupDemoComponent implements OnInit {
   onBeforeOpen(event: any) {
     console.log('lookup.onbeforeopen', event);
   }
+
+  toggleDisabled() {
+    console.log('lookup.toggleDisabled', event);
+    const exampleComp = (this.sohoLookupComponent as any);
+    if (exampleComp.disabled) {
+      (this.sohoLookupComponent as any).enable();
+    } else {
+      (this.sohoLookupComponent as any).disable();
+    }
+  }
 }

--- a/src/app/lookup/lookup.demo.ts
+++ b/src/app/lookup/lookup.demo.ts
@@ -26,7 +26,7 @@ export class LookupDemoComponent implements OnInit {
   @ViewChild('templateId', { static: true }) sohoLookupComponent?: SohoLookupComponent;
   @ViewChild('toggleButtons', { static: true }) sohoLookupRef?: SohoLookupComponent;
 
-  public isDisabled = false;
+  public isDisabled = true;
   public columns_product?: SohoDataGridColumn[];
   public columns_multi?: SohoDataGridColumn[];
   public entityIds?: string;

--- a/src/app/timepicker/timepicker.demo.html
+++ b/src/app/timepicker/timepicker.demo.html
@@ -22,7 +22,11 @@
           </div>
           <div class="field">
             <label for="disable" class="label">Disable</label>
-            <input soho-timepicker name="disable" [disabled]="true" timeFormat="h:mm a" mode="standard" [(ngModel)]="model.hhmm" (change)="onChange($event)"/>
+            <input soho-timepicker name="disable" [attr.disabled]="disabled ? '' : null" timeFormat="h:mm a" mode="standard" [(ngModel)]="model.hhmm" (change)="onChange($event)"/>
+          </div>
+          <div class="field">
+            <label for="disable" class="label">Disable (Inverse)</label>
+            <input soho-timepicker name="disable" [attr.disabled]="!disabled ? '' : null" timeFormat="h:mm a" mode="standard" [(ngModel)]="model.hhmm" (change)="onChange($event)"/>
           </div>
         </div>
       </div>

--- a/src/app/timepicker/timepicker.demo.ts
+++ b/src/app/timepicker/timepicker.demo.ts
@@ -22,6 +22,7 @@ export class TimePickerDemoComponent implements OnInit {
   public showModel = false;
   public timepickerDisabled = false;
   public timepickerReadOnly = false;
+  public disabled = true;
 
   constructor() { }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the enabling of lookup elements (lookup input field and button icon trigger) when the component is initially disabled.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise-ng/issues/1069

**Steps necessary to review your pull request (required)**:
- Pull this branch

```powershell
npm run build
npm run start
```
- Go to http://localhost:4200/ids-enterprise-ng-demo/lookup
- Find the label `Toggle isDisabled`, and click `Enable`
- It should enable the input field, and the trigger button
- Click the trigger button to check if it's working
- Click `Disable`, and it should disable the component

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
