### PR TITLE
1048 - CAP title in modalSettings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 10.2.0 Fixes
 
+- `[ContextualActionPanel]` Fixed missing title prop in modalSettings, and `beforeclose` event emit. ([#1048](https://github.com/infor-design/enterprise-ng/issues/1048)) `EA`
 - `[Multiselect]` Added an example showing automation id attributes on options in multiselect. ([#1005](https://github.com/infor-design/enterprise-ng/issues/1005))
 - `[SohoMessageService]` Removed `undefined` return type from messages method. ([#1061](https://github.com/infor-design/enterprise-ng/issues/1061))
 - `[SohoDatePicker]` Fixed datepicker format when assigned via angular form control. ([#1072](https://github.com/infor-design/enterprise-ng/issues/1072))

--- a/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
@@ -60,15 +60,6 @@ export class SohoContextualActionPanelRef<T> {
     return null;
   }
 
-  /**
-   * The buttonset API for the CAP dialog.
-   *
-   * @returns the buttonset API for the modal dialog, if initialised.
-   */
-  public get buttonsetAPI(): SohoButtonsetStatic | undefined {
-    return this.contextualactionpanel ? this.contextualactionpanel.buttonsetAPI : undefined;
-  }
-
   // -------------------------------------------
   // Default options block
   // -------------------------------------------

--- a/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
@@ -26,6 +26,9 @@ export class SohoContextualActionPanelRef<T> {
   /** Event fired when the panel is closed. */
   private close$: Subject<any> = new Subject();
 
+  /** Event fired before closing the panel */
+  private beforeClose$: Subject<any> = new Subject();
+
   /** Event fired after closing the panel. */
   private afterClose$: Subject<any> = new Subject();
 
@@ -57,6 +60,15 @@ export class SohoContextualActionPanelRef<T> {
     return null;
   }
 
+  /**
+   * The buttonset API for the CAP dialog.
+   *
+   * @returns the buttonset API for the modal dialog, if initialised.
+   */
+  public get buttonsetAPI(): SohoButtonsetStatic | undefined {
+    return this.contextualactionpanel ? this.contextualactionpanel.buttonsetAPI : undefined;
+  }
+
   // -------------------------------------------
   // Default options block
   // -------------------------------------------
@@ -69,6 +81,8 @@ export class SohoContextualActionPanelRef<T> {
     initializeContent: true, // initialize content before opening
     title: 'Contextual Action Panel',
     modalSettings: {
+      title: undefined,
+      buttons: [],
       centerTitle: false,
       showCloseBtn: false,
       trigger: 'immediate',
@@ -309,6 +323,9 @@ export class SohoContextualActionPanelRef<T> {
     (this.contextualactionpanel as any).panel?.on('afteropen.contextualactionpanel', ((event: any) => {
       this.onAfterOpen(event);
     }));
+    (this.contextualactionpanel as any).panel?.on('beforeclose.contextualactionpanel', ((event: any) => {
+      this.onBeforeClose(event);
+    }));
 
     return this;
   }
@@ -356,6 +373,19 @@ export class SohoContextualActionPanelRef<T> {
    */
   afterOpen(eventFn: Function): SohoContextualActionPanelRef<T> | null {
     this.afterOpen$.pipe(takeUntil(this.destroyed$)).subscribe((f: any) => {
+      eventFn(f, this);
+    });
+    return this;
+  }
+
+  /**
+   * Before Closed Event.
+   * This event is fired before closing the panel.
+   * 
+   * @param eventFn - the function to invoke when the panel before closing.
+   */
+  beforeClose(eventFn: Function): SohoContextualActionPanelRef<T> | null {
+    this.beforeClose$.pipe(takeUntil(this.destroyed$)).subscribe((f: any) => {
       eventFn(f, this);
     });
     return this;
@@ -457,6 +487,15 @@ export class SohoContextualActionPanelRef<T> {
       this.destroyed$.complete();
     });
 
+  }
+
+  /**
+   * Handles the 'beforeclose' event.
+   * 
+   * @param event - full event object.
+   */
+  private onBeforeClose(event: any) {
+    this.beforeClose$.next(event);
   }
 }
 /**

--- a/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
+++ b/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
@@ -49,7 +49,7 @@ interface SohoContextualActionPanelOptions {
   centerTitle?: boolean;
 }
 
-interface SohoContextualActionPanelButton  {
+interface SohoContextualActionPanelButton {
   /** An optional identifier for the button. */
   id?: string;
 
@@ -99,6 +99,11 @@ type SohoContextualActionPanelButtonClickFunction = (
  * Only public members are exposed on this interface.
  */
 interface SohoContextualActionPanelStatic {
+  /**
+   * API for interacting with the buttons on the dialog.
+   */
+  buttonsetAPI: SohoButtonsetStatic;
+
   /** Existing configuration settings. */
   settings: SohoContextualActionPanelOptions;
 

--- a/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
+++ b/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
@@ -99,11 +99,6 @@ type SohoContextualActionPanelButtonClickFunction = (
  * Only public members are exposed on this interface.
  */
 interface SohoContextualActionPanelStatic {
-  /**
-   * API for interacting with the buttons on the dialog.
-   */
-  buttonsetAPI: SohoButtonsetStatic;
-
   /** Existing configuration settings. */
   settings: SohoContextualActionPanelOptions;
 

--- a/src/app/contextual-action-panel/contextual-action-panel.component.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.component.ts
@@ -79,7 +79,7 @@ export class ContextualActionPanelComponent {
     this.panelService
       // @ts-ignore
       .contextualactionpanel(NestedContextualActionPanelComponent, (this.placeholder as any))
-      .modalSettings({ buttons, title: 'Nested CAP' })
+      .modalSettings({ buttons, title: 'Nested CAP using modalSettings' })
       .open()
       .initializeContent(true);
   }

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -68,8 +68,6 @@ export class ContextualActionPanelDemoComponent {
       return;
     }
 
-    console.log(this.panelService?.contextualactionpanel(ContextualActionPanelComponent, this.placeholder))
-
     this.panelRef = (this.panelService as any).contextualactionpanel(ContextualActionPanelComponent, this.placeholder)
       .modalSettings({ buttons, title: this.title })
       .open()

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -80,6 +80,9 @@ export class ContextualActionPanelDemoComponent {
       .afterOpen(() => {
         console.log('After Open Fires');
       })
+      .beforeClose(() => {
+        console.log('Before close fires');
+      })
       .closed(() => {
         console.log('Closed Fires');
       })

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -30,7 +30,7 @@ export class ContextualActionPanelDemoComponent {
    */
   public panelRef?: SohoContextualActionPanelRef<any> | null;
   public closeResult?: string;
-  public title = 'Contextual Action Panel';
+  public title = 'Title using modalSettings title';
 
   /**
    * Constructor.
@@ -67,6 +67,8 @@ export class ContextualActionPanelDemoComponent {
     if (!this.panelService || !this.placeholder) {
       return;
     }
+
+    console.log(this.panelService?.contextualactionpanel(ContextualActionPanelComponent, this.placeholder))
 
     this.panelRef = (this.panelService as any).contextualactionpanel(ContextualActionPanelComponent, this.placeholder)
       .modalSettings({ buttons, title: this.title })

--- a/src/app/modal-dialog/modal-dialog.demo.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.ts
@@ -81,8 +81,6 @@ export class ModalDialogDemoComponent {
         return true;
       })
       .open();
-
-    console.log(dialogRef.buttonsetAPI)
   }
 
   openNested() {

--- a/src/app/modal-dialog/modal-dialog.demo.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.ts
@@ -81,6 +81,8 @@ export class ModalDialogDemoComponent {
         return true;
       })
       .open();
+
+    console.log(dialogRef.buttonsetAPI)
   }
 
   openNested() {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the missing title prop in `modalSettings`, adds `beforeclose` event emitter.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

Closes https://github.com/infor-design/enterprise-ng/issues/1048
Related PR in EP - https://github.com/infor-design/enterprise/pull/5414

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Get the `dist` build EP of https://github.com/infor-design/enterprise/pull/5414
- Then link or change the enterprise dependency in node_modules
- Run the following command,
```powershell
npm run build
npm run start
```
- Go to http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- Open `Panel` button trigger
- The title should be `Title using modalSettings title`. Check the implementation in code. It should use the `.modalSettings()`
- Click `Switch to another CAP`
- Title should be `Nested CAP using modalSettings`. Check also the implementation.
- Close the CAP. `beforeclose` event should fire after closing. Check the log.

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
