### PR TITLE
fix(splitter): assign correct value for `splitter` property

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Added missing beforepaging and afterpaging events. ([#5493](https://github.com/infor-design/enterprise/issues/5493))
 - `[Lookup]` Fixed an issue where selection for server side and paging was not working. ([#986](https://github.com/infor-design/enterprise-ng/issues/986))
 - `[Searchfield]`Added missing category functions. ([#1079](https://github.com/infor-design/enterprise-ng/issues/1079))
+- `[Splitter]` assign correct value for `splitter` property. ([#1099](https://github.com/infor-design/enterprise-ng/issues/1099))
 - `[Tag]` Fixed an issue where before tag remove was not called. ([#1063](https://github.com/infor-design/enterprise-ng/issues/1063))
 - `[Tree]`Added missing badge types. ([#1079](https://github.com/infor-design/enterprise-ng/issues/1079))
 

--- a/projects/ids-enterprise-ng/src/lib/splitter/soho-splitter.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/splitter/soho-splitter.component.ts
@@ -137,7 +137,7 @@ export class SohoSplitterComponent implements AfterViewInit, OnDestroy {
     // Once the control is initialised, extract the control
     // plug-in from the element.  The element name is
     // defined by the plug-in, but in this case it is 'splitter'.
-    this.splitter = this.jQueryElement.data('data');
+    this.splitter = this.jQueryElement.data('splitter');
 
     // Initialise any event handlers.
     this.jQueryElement

--- a/projects/ids-enterprise-ng/src/lib/splitter/soho-splitter.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/splitter/soho-splitter.spec.ts
@@ -1,0 +1,51 @@
+import { Component, DebugElement, ViewChild } from '@angular/core';
+import { SohoSplitterComponent } from './soho-splitter.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SohoSplitterModule } from './soho-splitter.module';
+
+@Component({
+  template: `
+    <soho-splitter [isSplitterRight]="true" [collapseButton]="true" [save]="false">
+      <div class="panel-header"></div>
+    </soho-splitter>
+    `
+})
+
+class SohoSplitterRightTestComponent {
+  @ViewChild(SohoSplitterComponent) splitter?: SohoSplitterComponent | null;
+}
+
+describe('Soho Right Splitter Render', () => {
+  let splitter: SohoSplitterComponent;
+  let comp: SohoSplitterRightTestComponent;
+  let fixture: ComponentFixture<SohoSplitterRightTestComponent>;
+  let de: DebugElement;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SohoSplitterRightTestComponent],
+      imports: [SohoSplitterModule]
+    });
+
+    fixture = TestBed.createComponent(SohoSplitterRightTestComponent);
+    comp = fixture.componentInstance;
+
+    de = fixture.debugElement;
+    el = de.query(By.css('soho-splitter')).nativeElement;
+
+    fixture.detectChanges();
+    splitter = (comp.splitter as any);
+  });
+
+  it('Check splitter element', () => {
+    fixture.detectChanges();
+    expect(el.nodeName).toEqual('SOHO-SPLITTER');
+    expect(Object.values(el.classList)).toEqual(['splitter', 'splitter-right']);
+    expect((splitter as any).options.collapseButton).toEqual(true);
+    expect((splitter as any).options.save).toEqual(false);
+    expect((splitter as any).splitter.settings.collapseButton).toEqual(true);
+    expect((splitter as any).splitter.settings.save).toEqual(false);
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

At the moment, https://github.com/infor-design/enterprise-ng/blob/main/projects/ids-enterprise-ng/src/lib/splitter/soho-splitter.component.ts#L140 gives result as `undefined`. Looking at the other components, it should be `data('splitter')`.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1098

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
Added unit tests to confirm `splitter` is not `undefined`
