### PR TITLE
1107 - Add missing searchfield function and improve typings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 10.4.0 Fixes
 
 - `[Lookup]` Added autocomplete in lookup. ([#1087](https://github.com/infor-design/enterprise/issues/1087))
+- `[SearchField]` Added method for getting category data and improved typings for searchfield cateegories. ([#1107](https://github.com/infor-design/enterprise-ng/issues/1107))
 
 ## v10.3.0
 

--- a/projects/ids-enterprise-ng/src/lib/searchfield/soho-searchfield.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/searchfield/soho-searchfield.component.ts
@@ -127,6 +127,13 @@ export class SohoSearchFieldComponent implements AfterViewInit, OnDestroy {
     });
   }
 
+  /** Gets the categories as data. Passing true will return only the selected category data.*/
+  getCategoryData(onlySelected: boolean): SohoSearchFieldCategory[] | undefined {
+    return this.ngZone.runOutsideAngular(() => {
+      return this.searchfield?.getCategoryData(onlySelected);
+    });
+  }
+  
   /**  Gets a complete list of categories in jQuery-collection form. */
   getSelectedCategories(): any {
     return this.ngZone.runOutsideAngular(() => {

--- a/projects/ids-enterprise-ng/src/lib/searchfield/soho-searchfield.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/searchfield/soho-searchfield.component.ts
@@ -32,7 +32,7 @@ export class SohoSearchFieldComponent implements AfterViewInit, OnDestroy {
     this.options.allResultsCallback = value;
   }
   /** Displays a dropdown containing categories that can be used to filter results. */
-  @Input() set categories(value: Object[]) {
+  @Input() set categories(value: SohoSearchFieldCategoryType[]) {
     this.options.categories = value;
   }
 

--- a/projects/ids-enterprise-typings/lib/searchfield/soho-searchfield.d.ts
+++ b/projects/ids-enterprise-typings/lib/searchfield/soho-searchfield.d.ts
@@ -60,7 +60,7 @@ interface SohoSearchFieldStatic {
   element: JQuery;
 
   /** If this component resides within a toolbar, this returns `true` */
-  toolbarParent?: boolean | undefined;
+  toolbarParent?: boolean;
 
   /** Destructor. */
   destroy(): void;

--- a/projects/ids-enterprise-typings/lib/searchfield/soho-searchfield.d.ts
+++ b/projects/ids-enterprise-typings/lib/searchfield/soho-searchfield.d.ts
@@ -44,6 +44,9 @@ interface SohoSearchFieldStatic {
   /**  Gets a complete list of categories in jQuery-collection form. */
   getCategories(): any;
 
+  /** Gets the currently selected categories as data */
+  getCategoryData(onlySelected: boolean): SohoSearchFieldCategory[];
+
   /**  Gets a complete list of categories in jQuery-collection form. */
   getSelectedCategories(): any;
 
@@ -67,6 +70,16 @@ interface SohoSearchFieldStatic {
 
   /** Updated */
   updated(settings?: SohoSearchFieldOptions): void;
+}
+
+/**
+ * Search field category.
+ */
+interface SohoSearchFieldCategory {
+    checked: boolean;
+    name: string;
+    id?: string | number;
+    value?: string | number;
 }
 
 /**

--- a/projects/ids-enterprise-typings/lib/searchfield/soho-searchfield.d.ts
+++ b/projects/ids-enterprise-typings/lib/searchfield/soho-searchfield.d.ts
@@ -16,7 +16,7 @@ interface SohoSearchFieldOptions extends SohoAutoCompleteOptions {
   showAllResults?: boolean;
 
   /** Displays a dropdown containing categories that can be used to filter results. */
-  categories?: Object[];
+  categories?: SohoSearchFieldCategoryType[];
 
   /** If true, creates a multiselectable Categories list. */
   categoryMultiselect?: boolean;
@@ -81,6 +81,9 @@ interface SohoSearchFieldCategory {
     id?: string | number;
     value?: string | number;
 }
+
+/** Search field category type */
+type SohoSearchFieldCategoryType = SohoSearchFieldCategory | string;
 
 /**
  * Type safe SearchField event object.

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -189,6 +189,7 @@ import { RadarDemoComponent } from './radar/radar.demo';
 import { RadioButtonDemoComponent } from './radiobutton/radiobutton.demo';
 import { RatingDemoComponent } from './rating/rating.demo';
 import { SearchFieldDemoComponent } from './searchfield/searchfield.demo';
+import { SearchFieldCategoryDemoComponent } from './searchfield/searchfield-category.demo';
 import { SearchFieldClearDemoComponent } from './searchfield/searchfield-clear.demo';
 import { SliderDemoComponent } from './slider/slider.demo';
 import { SohoHeaderDynamicDemoComponent } from './header/header-dynamic.demo';
@@ -431,6 +432,7 @@ import { DropdownMultiselectAttributesDemoComponent } from './dropdown/dropdown-
     RadioButtonDemoComponent,
     RatingDemoComponent,
     SearchFieldDemoComponent,
+    SearchFieldCategoryDemoComponent,
     SearchFieldClearDemoComponent,
     SliderDemoComponent,
     SohoHeaderDynamicDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -147,6 +147,7 @@ import { RadarDemoComponent } from './radar/radar.demo';
 import { RadioButtonDemoComponent } from './radiobutton/radiobutton.demo';
 import { RatingDemoComponent } from './rating/rating.demo';
 import { SearchFieldDemoComponent } from './searchfield/searchfield.demo';
+import { SearchFieldCategoryDemoComponent } from './searchfield/searchfield-category.demo';
 import { SearchFieldClearDemoComponent } from './searchfield/searchfield-clear.demo';
 import { SliderDemoComponent } from './slider/slider.demo';
 import { SparklineDemoComponent } from './sparkline/sparkline.demo';
@@ -369,6 +370,7 @@ export const routes: Routes = [
   { path: 'radiobutton', component: RadioButtonDemoComponent },
   { path: 'rating', component: RatingDemoComponent },
   { path: 'searchfield', component: SearchFieldDemoComponent },
+  { path: 'searchfield-category', component: SearchFieldCategoryDemoComponent },
   { path: 'searchfield-clear', component: SearchFieldClearDemoComponent },
   { path: 'slider', component: SliderDemoComponent },
   { path: 'sparkline', component: SparklineDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -225,6 +225,7 @@
   <div class="accordion-header"><a href="javascript:void(0);"><span>S</span></a></div>
   <div class="accordion-pane">
     <div class="accordion-header list-item"><a [routerLink]="['searchfield']"><span>Search Field</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['searchfield-category']"><span>Search Field - Category</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['searchfield-clear']"><span>Search Field - Clear</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['slider']"><span>Slider</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['sparkline']"><span>Sparkline Chart</span></a></div>

--- a/src/app/searchfield/searchfield-category.demo.html
+++ b/src/app/searchfield/searchfield-category.demo.html
@@ -1,0 +1,17 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+    <label for="searchfield" class="audible">Search</label>
+    <input soho-searchfield
+       id="searchfield"
+       name="searchfield"
+       class="searchfield"
+       [options]="searchfieldOptions"
+       [(ngModel)]="model.searchValue"
+       (selected)="onCategorySelected()"/>
+  </div>
+
+  <div class="twelve columns">
+    <p>Selected categories: {{ selectedCategories | json }}</p>
+    <p>Search value: {{ model.searchValue }} </p>
+  </div>
+</div>

--- a/src/app/searchfield/searchfield-category.demo.ts
+++ b/src/app/searchfield/searchfield-category.demo.ts
@@ -1,0 +1,49 @@
+
+import {
+  Component,
+  ViewChild,
+} from '@angular/core';
+
+import { SohoSearchFieldComponent } from 'ids-enterprise-ng';
+import { AfterViewInit } from '@angular/core';
+
+@Component({
+  selector: 'app-searchfield-category-demo',
+  templateUrl: 'searchfield-category.demo.html'
+})
+export class SearchFieldCategoryDemoComponent implements AfterViewInit {
+  @ViewChild(SohoSearchFieldComponent, { static: true })
+  private searchfield!: SohoSearchFieldComponent;
+
+  /**
+   * Bindable Model value for getting what was typed in the search box.
+   */
+  public model = {
+    searchValue: ''
+  };
+
+  public selectedCategories: SohoSearchFieldCategory[] = [];
+
+  /**
+   * The set of options we link to in this example.
+   */
+  searchfieldOptions: SohoSearchFieldOptions = {
+    filterMode: 'contains',
+    // categories: [{ name: 'Books', checked: true }, 'Movies', 'TV Shows', 'Video Games'],
+    categoryMultiselect: true,
+    showCategoryText: true,
+    clearable: false,
+  };
+  
+  ngAfterViewInit(): void {
+    this.setSelectedCategories();
+  }
+  
+  onCategorySelected(): void {
+    this.setSelectedCategories();
+  }
+
+  setSelectedCategories(): void {
+    this.selectedCategories = this.searchfield.getCategoryData(true) || [];
+  }
+}

--- a/src/app/searchfield/searchfield-category.demo.ts
+++ b/src/app/searchfield/searchfield-category.demo.ts
@@ -5,13 +5,12 @@ import {
 } from '@angular/core';
 
 import { SohoSearchFieldComponent } from 'ids-enterprise-ng';
-import { AfterViewInit } from '@angular/core';
 
 @Component({
   selector: 'app-searchfield-category-demo',
   templateUrl: 'searchfield-category.demo.html'
 })
-export class SearchFieldCategoryDemoComponent implements AfterViewInit {
+export class SearchFieldCategoryDemoComponent  {
   @ViewChild(SohoSearchFieldComponent, { static: true })
   private searchfield!: SohoSearchFieldComponent;
 
@@ -29,21 +28,13 @@ export class SearchFieldCategoryDemoComponent implements AfterViewInit {
    */
   searchfieldOptions: SohoSearchFieldOptions = {
     filterMode: 'contains',
-    // categories: [{ name: 'Books', checked: true }, 'Movies', 'TV Shows', 'Video Games'],
+    categories: [{ name: 'Books', checked: false }, 'Movies', 'TV Shows', 'Video Games'],
     categoryMultiselect: true,
     showCategoryText: true,
     clearable: false,
   };
   
-  ngAfterViewInit(): void {
-    this.setSelectedCategories();
-  }
-  
   onCategorySelected(): void {
-    this.setSelectedCategories();
-  }
-
-  setSelectedCategories(): void {
     this.selectedCategories = this.searchfield.getCategoryData(true) || [];
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adding `getCategoryData()` to the api facilitates getting the actual categories. There is already a `getSelectedCategories()` but that one returns a list of jQuery items, which then makes it cumbersome to work with.

Also, to facilitate working with the categories, a `SohoSearchFieldCategory` interface (which corresponds to what you'd get back from the `getCategoryData()`)  was created, as well as a `SohoSearchFieldCategoryType` which is a what you can pass to the `searchfieldOptions.categories`, which is an array of strings and/or `SohoSearchFieldCategory` items. Previously this was typed to `categories: Object[];`.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-ng/issues/1107

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the build for typings and lib
- Run the demo app
- Navigate to: http://localhost:4200/ids-enterprise-ng-demo/searchfield-category
- When selecting any categories, these should be seen in the ui.