### PR TITLE
1109 - Add 'cleared' event emitter for searchfield

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 10.4.0 Fixes
 
 - `[Lookup]` Added autocomplete in lookup. ([#1087](https://github.com/infor-design/enterprise/issues/1087))
+- `[Searchfield]` Added `cleared` EventEmitter. ([#1109](https://github.com/infor-design/enterprise-ng/issues/1109))
 
 ## v10.3.0
 

--- a/projects/ids-enterprise-ng/src/lib/searchfield/soho-searchfield.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/searchfield/soho-searchfield.component.ts
@@ -78,6 +78,7 @@ export class SohoSearchFieldComponent implements AfterViewInit, OnDestroy {
   // ------------------------------------------------------------
 
   @Output() selected: EventEmitter<Object[]> = new EventEmitter<Object[]>();
+  @Output() cleared: EventEmitter<Object[]> = new EventEmitter<Object[]>();
 
   @HostBinding('class.searchfield') get isSearchField() {
     return true;
@@ -104,16 +105,23 @@ export class SohoSearchFieldComponent implements AfterViewInit, OnDestroy {
      * Bind to jQueryElement's events
      */
     this.jQueryElement.on('selected', (...args) => this.selected.emit(args));
+    this.jQueryElement.on('cleared', (...args) => this.ngZone.run(() => this.cleared.emit(args)));
 
     this.searchfield = this.jQueryElement.data('searchfield');
   }
 
   ngOnDestroy() {
     // Necessary clean up step (add additional here)
-    if (this.searchfield) {
-      this.searchfield.destroy();
-      this.searchfield = null;
-    }
+    this.ngZone.runOutsideAngular(() => {
+      if (this.jQueryElement) {
+        // clean up attached events.
+        this.jQueryElement.off();
+      }
+      if (this.searchfield) {
+        this.searchfield.destroy();
+        this.searchfield = null;
+      }
+    });
   }
 
   clear(): void {

--- a/src/app/searchfield/searchfield-clear.demo.html
+++ b/src/app/searchfield/searchfield-clear.demo.html
@@ -8,6 +8,7 @@
        [clearable]="true"
        [options]="searchfieldOptions"
        [(ngModel)]="model.searchValue"
-       (change)="onChange($event)"/>
+       (change)="onChange($event)"
+       (cleared)="onClear($event)"/>
   </div>
 </div>

--- a/src/app/searchfield/searchfield-clear.demo.ts
+++ b/src/app/searchfield/searchfield-clear.demo.ts
@@ -46,6 +46,10 @@ export class SearchFieldClearDemoComponent implements AfterViewInit, OnInit {
     console.log('Search Changed', event.type);
   }
 
+  onClear(event: unknown) {
+    console.log('Search cleared', event);
+  }
+
   objectBasedData(): Observable<Array<object>> {
     return of([
       { value: '1', label: 'Atlanta' },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adding a `cleared` event that emits whenever the clear button is clicked or the `clear()` method from the API is called allows other actions that can be done when a field is cleared. 

**Related github/jira issue (required)**:
Fixes #1109 

**Steps necessary to review your pull request (required)**:

1. Pull branch and do the `npm run build` command.
2. Run the demo app then navigate to http://localhost:4200/ids-enterprise-ng-demo/searchfield-clear.
3. Type something in the search field so that the clear (x) button appears.
4. Click the x button to clear the field.
5. Clear event should fire (check console log).

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
