### PR TITLE
1035 - Added Automation Attributes on Autocomplete

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 10.4.0 Fixes
 
+- `[Autocomplete]` Added automation attributes in Autocomplete. ([#1035](https://github.com/infor-design/enterprise/issues/1035))
 - `[Lookup]` Added autocomplete in lookup. ([#1087](https://github.com/infor-design/enterprise/issues/1087))
 - `[Searchfield]` Added `cleared` EventEmitter. ([#1109](https://github.com/infor-design/enterprise-ng/issues/1109))
 - `[SearchField]` Added method for getting category data and improved typings for searchfield cateegories. ([#1107](https://github.com/infor-design/enterprise-ng/issues/1107))

--- a/projects/ids-enterprise-ng/src/lib/autocomplete/soho-autocomplete.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/autocomplete/soho-autocomplete.component.ts
@@ -73,6 +73,15 @@ export class SohoAutoCompleteComponent extends BaseControlValueAccessor<string> 
     this.options.autoSelectFirstItem = autoSelectFirstItem;
   }
 
+  @Input()
+  public set attributes(attributes: Array<Object> | Object | undefined) {
+    this.options.attributes = attributes;
+  }
+
+  public get attributes(): Array<Object> | Object | undefined {
+    return this.options.attributes;
+  }
+
   /**
    * Available Soho Template events as Output (EventEmitters passing the event)
    * Should match the Soho event names for the component

--- a/projects/ids-enterprise-typings/lib/autocomplete/soho-autocomplete.d.ts
+++ b/projects/ids-enterprise-typings/lib/autocomplete/soho-autocomplete.d.ts
@@ -35,6 +35,9 @@ interface SohoAutoCompleteOptions {
 
   /** Selects first item menu */
   autoSelectFirstItem?: boolean;
+
+  /** Add extra attributes like id's to the component **/
+  attributes?: Array<Object> | Object;
 }
 
 type SohoAutoCompleteSource = Object[] | string | Object | SohoAutoCompleteSourceFunction;

--- a/src/app/autocomplete/autocomplete.demo.html
+++ b/src/app/autocomplete/autocomplete.demo.html
@@ -2,7 +2,7 @@
   <div class="twelve columns">
     <div class="field">
       <label for="autocomplete-default">Set source as string, update from cities to states</label>
-      <input id="autocomplete-default" soho-autocomplete soho-mask [sohoPattern]="'********************'" [attr.data-autocomplete]="url" type="text"  (selected)="onSelected($event)">
+      <input id="autocomplete-default" soho-autocomplete soho-mask [sohoPattern]="'********************'" [attributes]="extraAttributes.attributes" [attr.data-autocomplete]="url" type="text"  (selected)="onSelected($event)">
     </div>
     <div class="field">
       <label for="autocomplete-source">Set source as a function</label>

--- a/src/app/autocomplete/autocomplete.demo.ts
+++ b/src/app/autocomplete/autocomplete.demo.ts
@@ -78,6 +78,15 @@ export class AutocompleteDemoComponent implements AfterViewInit {
   public selected: any;
   options?: SohoAutoCompleteOptions;
 
+  public extraAttributes = {
+    attributes : [
+      {
+        name: 'data-automation-id',
+        value: 'my-custom-1'
+      }
+    ]
+  };
+
   constructor(private changeDetectorRef: ChangeDetectorRef) { }
 
   ngAfterViewInit() {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will add automation id attributes on options in autocomplete.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1035

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/autocomplete
- Open `Developer Console`
- See the Automation IDs

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

