### PR TITLE
1096 - Changed type definition of SohoDataGridDirtyCell

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - `[Datagrid]` The `getColumnIndex` function did not exist, so changed it to the working `columnIdxById` which does the same.
 - `[Datagrid]` Added missing beforepaging and afterpaging events. ([#5493](https://github.com/infor-design/enterprise/issues/5493))
+- `[Datagrid]` Changed type definition in row cell. ([#1096](https://github.com/infor-design/enterprise/issues/1096))
 - `[Lookup]` Fixed an issue where selection for server side and paging was not working. ([#986](https://github.com/infor-design/enterprise-ng/issues/986))
 - `[Searchfield]`Added missing category functions. ([#1079](https://github.com/infor-design/enterprise-ng/issues/1079))
 - `[Splitter]` assign correct value for `splitter` property. ([#1099](https://github.com/infor-design/enterprise-ng/issues/1099))

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -383,11 +383,19 @@ interface SohoDataGridModifiedRow {
 }
 
 interface SohoDataGridDirtyCell {
+  row: number;
+  col: number;
+  cellData: SohoCellData;
+}
+
+interface SohoCellData {
   value: any;
   coercedVal: any;
   escapedCoercedVal: any;
+  originalVal: any;
   cellNodeText: string;
   cell: number;
+  isDirty: boolean;
   column: SohoDataGridColumn;
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Changed type definition of SohoDataGridDirtyCell to reflect what it actually returns when getting modified rows.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1096 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch and build
- Based on the screenshot below, cast the cellData variable as SohoCellData instead of SohoDataGridDirtyCell
![image](https://user-images.githubusercontent.com/85279127/132313616-31d4522d-4e40-4e25-b6a2-062707b81934.png)


<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
