### PR TITLE
1101 - Add NG Types to allow Buttonset API access through the Contextual Action Panel

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v10.7.0
 
 - `[Alert]` Alert component test set-up. ([#1110](https://github.com/infor-design/enterprise-ng/issues/1110))
+- `[ContextualActionPanel]` Add typescript bindings for enabling control of ButtonSetAPI via the CAP API. ([#1101](https://github.com/infor-design/enterprise-ng/issues/1101))
 
 ### 10.7.0 Fixes
 

--- a/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
@@ -60,6 +60,15 @@ export class SohoContextualActionPanelRef<T> {
     return null;
   }
 
+  /**
+   * The buttonset API for the CAP dialog.
+   *
+   * @returns the buttonset API for the CAP dialog, if initialized.
+   */
+  public get buttonsetAPI(): SohoButtonsetStatic | undefined {
+    return this.contextualactionpanel ? this.contextualactionpanel.buttonsetAPI : undefined;
+  }
+
   // -------------------------------------------
   // Default options block
   // -------------------------------------------
@@ -386,7 +395,7 @@ export class SohoContextualActionPanelRef<T> {
   /**
    * Before Closed Event.
    * This event is fired before closing the panel.
-   * 
+   *
    * @param eventFn - the function to invoke when the panel before closing.
    */
   beforeClose(eventFn: Function): SohoContextualActionPanelRef<T> | null {
@@ -496,7 +505,7 @@ export class SohoContextualActionPanelRef<T> {
 
   /**
    * Handles the 'beforeclose' event.
-   * 
+   *
    * @param event - full event object.
    */
   private onBeforeClose(event: any) {

--- a/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
@@ -132,6 +132,8 @@ export class SohoContextualActionPanelRef<T> {
         cap.addClass(`${cssClass}`);
       });
     }
+
+    return this;
   }
 
   /** Add extra attributes like id's to the component **/

--- a/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/toolbar-flex/soho-toolbar-flex.component.ts
@@ -204,7 +204,7 @@ export class SohoToolbarFlexMoreButtonComponent {
   @Input() isDisabled = false;
 
   @Input() moreButtonId?: string;
-    /** @deprecated doesn't seem to be used **/
+  /** @deprecated doesn't seem to be used **/
   @Input() ajaxBeforeFunction?: Function;
   /** @deprecated doesn't seem to be used **/
 
@@ -362,6 +362,24 @@ export class SohoToolbarFlexComponent implements AfterViewChecked, AfterViewInit
     if (this.toolbarFlex) {
       this.ngZone.runOutsideAngular(() => this.toolbarFlex?.updated(settings));
     }
+  }
+
+  /**
+   * The buttonset API for the modal dialog.
+   *
+   * @returns the buttonset API for the modal dialog, if initialised.
+   */
+  public get buttonsetAPIs(): Array<SohoButtonsetStatic> | undefined {
+    return this.toolbarFlex ? this.toolbarFlex.buttonsetAPIs : undefined;
+  }
+
+  /**
+   * The buttonset API for the modal dialog.
+   *
+   * @returns the buttonset API for the modal dialog, if initialised.
+   */
+  public get buttonsets(): Array<HTMLElement> | undefined {
+    return this.toolbarFlex ? this.toolbarFlex.buttonsets : undefined;
   }
 
   // For testing

--- a/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
+++ b/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
@@ -103,6 +103,11 @@ interface SohoContextualActionPanelStatic {
   settings: SohoContextualActionPanelOptions;
 
   /**
+   * API for interacting with the buttons on the dialog.
+   */
+  buttonsetAPI: SohoButtonsetStatic;
+
+  /**
    * A jQuery selector to the element in the DOM where the
    * panel is placed after opening.
    */

--- a/projects/ids-enterprise-typings/lib/toolbar-flex/soho-toolbar-flex.d.ts
+++ b/projects/ids-enterprise-typings/lib/toolbar-flex/soho-toolbar-flex.d.ts
@@ -145,6 +145,12 @@ interface SohoToolbarFlexStatic {
   /** Control options. */
   settings: SohoToolbarFlexOptions;
 
+  /** If Applicable, references to buttonset APIs on this toolbar */
+  buttonsetAPIs?: Array<SohoButtonsetStatic>;
+
+  /** If Applicable, references to buttonset section elements on this toolbar */
+  buttonsets?: Array<HTMLElement>;
+
   /** If applicable, returns a link to the Searchfield Component's API */
   searchfieldAPI?: SohoToolbarFlexSearchFieldStatic;
 
@@ -219,7 +225,7 @@ interface SohoToolbarFlexMenuItemEvent extends SohoToolbarFlexButtonEvent {
   event: SohoToolbarFlexButtonEvent;
 }
 
-interface SohoToolbarFlexEvent extends JQuery.TriggeredEvent {}
+interface SohoToolbarFlexEvent extends JQuery.TriggeredEvent { }
 
 /**
  * Configuration options.

--- a/src/app/contextual-action-panel/contextual-action-panel-buttonsetapi.component.html
+++ b/src/app/contextual-action-panel/contextual-action-panel-buttonsetapi.component.html
@@ -1,0 +1,35 @@
+<form [formGroup]="form">
+  <div soho-tabs vertical="true">
+    <div soho-tab-list-container [verticalScrolling]="true">
+      <div class="tab-list-info">
+        <div class="field">
+          <label for="id" class="required">Id</label>
+          <input id="id" soho-input type="text" placeholder="Id" formControlName="id">
+        </div>
+      </div>
+      <ul soho-tab-list>
+        <li soho-tab><a soho-tab-title tabId="general">General</a></li>
+        <li soho-tab><a soho-tab-title tabId="details">Details</a></li>
+      </ul>
+    </div>
+  </div>
+  
+  <div soho-tab-panel-container [verticalScrolling]="true">
+    <div soho-tab-panel tabId="general">
+      <h2 [style.padding-bottom.rem]="2">General</h2>
+      <div class="field">
+        <label for="name">Name</label>
+        <input id="name" soho-input type="text" placeholder="Name" formControlName="name">
+      </div>
+  
+    </div>
+    <div soho-tab-panel tabId="details">
+      <h2 [style.padding-bottom.rem]="2">Details</h2>
+      <div class="field">
+        <label for="address">Address</label>
+        <input id="address" soho-input type="text" placeholder="Address" formControlName="address">
+      </div>
+    </div>
+  </div>
+  
+</form>

--- a/src/app/contextual-action-panel/contextual-action-panel-buttonsetapi.component.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel-buttonsetapi.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { FormBuilder, Validators, FormGroup } from '@angular/forms';
+
+
+@Component({
+  templateUrl: 'contextual-action-panel-buttonsetapi.component.html'
+})
+
+export class ContextualActionPanelButtonsetAPIComponent {
+  form: FormGroup;
+
+  constructor(private readonly fb: FormBuilder) {
+    this.form = this.fb.group({
+      id: ['', Validators.required],
+      name: [''],
+      address: [''],
+    })
+
+    setTimeout(() => {
+      this.form.updateValueAndValidity();
+    });
+  }
+}

--- a/src/app/contextual-action-panel/contextual-action-panel.component.html
+++ b/src/app/contextual-action-panel/contextual-action-panel.component.html
@@ -2,7 +2,7 @@
   <div class="six columns">
     <div class="field">
       <label for="company-name">Company Name</label>
-      <select id="company-name" name="company-name" class="dropdown">
+      <select soho-dropdown id="company-name" name="company-name" class="dropdown">
         <option value=""></option>
         <option value="jawbone" selected>Jawbone, Inc.</option>
         <option value="infor">Infor</option>
@@ -10,7 +10,7 @@
     </div>
     <div class="field">
       <label for="purchase-form">Purchase Form</label>
-      <select id="purchase-form" name="purchase-form" class="dropdown">
+      <select soho-dropdown id="purchase-form" name="purchase-form" class="dropdown">
         <option value=""></option>
         <option value="3567" selected>3567</option>
         <option value="3568">3568</option>
@@ -19,7 +19,7 @@
     </div>
     <div class="field">
       <label for="template">Template</label>
-      <select id="template" name="template" class="dropdown">
+      <select soho-dropdown id="template" name="template" class="dropdown">
         <option value="" selected>None</option>
         <option value="1">Template #1</option>
         <option value="2">Template #2</option>
@@ -33,7 +33,7 @@
   <div class="six columns">
     <div class="field">
       <label for="ship-terms">Ship Terms</label>
-      <select id="ship-terms" name="ship-terms" class="dropdown">
+      <select soho-dropdown id="ship-terms" name="ship-terms" class="dropdown">
         <option value=""></option>
         <option value="default" selected>Default</option>
         <option value="alternate">Alternate</option>
@@ -41,7 +41,7 @@
     </div>
     <div class="field">
       <label for="ship-via">Ship Via</label>
-      <select id="ship-via" name="ship-via" class="dropdown">
+      <select soho-dropdown id="ship-via" name="ship-via" class="dropdown">
         <option value=""></option>
         <option value="freight" selected>Freight</option>
         <option value="air">USPS Air</option>
@@ -49,7 +49,7 @@
     </div>
     <div class="field">
       <label for="issue-method">Issue Method</label>
-      <select id="issue-method" name="issue-method" class="dropdown">
+      <select soho-dropdown id="issue-method" name="issue-method" class="dropdown">
         <option value=""></option>
         <option value="phone">Telephone</option>
         <option value="email" selected>E-mail</option>
@@ -59,6 +59,10 @@
     <div class="field">
       <input type="checkbox" id="po-box" name="po-box" class="checkbox" checked/>
       <label for="po-box" class="checkbox-label">Freight</label>
+    </div>
+    <div class="field">
+      <input type="checkbox" id="disable-save" name="disable-save" class="checkbox" (click)="toggleSaveDisabled()"/>
+      <label for="disable-save" class="checkbox-label">Disable the Save Button</label>
     </div>
     <div class="field">
       <button id="open-nested-btn" soho-button (click)="openNested()">Nested</button>

--- a/src/app/contextual-action-panel/contextual-action-panel.component.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.component.ts
@@ -88,10 +88,10 @@ export class ContextualActionPanelComponent {
    * Enable/Disable a button on the CAP panel reference's buttonsetAPI
    */
   toggleSaveDisabled() {
-    debugger;
-
-    const btn = (this.panelRef as any).buttonsetAPI.buttons[0];
-    btn.disabled = !btn.disabled;
+    const btn = (this.panelRef as any).buttonsetAPI?.buttons[0];
+    if (btn) {
+      btn.disabled = !btn.disabled;
+    }
   }
 
 }

--- a/src/app/contextual-action-panel/contextual-action-panel.component.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.component.ts
@@ -76,11 +76,22 @@ export class ContextualActionPanelComponent {
         isDefault: true
       }];
 
-    this.panelService
+    this.panelRef = this.panelService
       // @ts-ignore
       .contextualactionpanel(NestedContextualActionPanelComponent, (this.placeholder as any))
       .modalSettings({ buttons, title: 'Nested CAP using modalSettings' })
       .open()
       .initializeContent(true);
   }
+
+  /**
+   * Enable/Disable a button on the CAP panel reference's buttonsetAPI
+   */
+  toggleSaveDisabled() {
+    debugger;
+
+    const btn = (this.panelRef as any).buttonsetAPI.buttons[0];
+    btn.disabled = !btn.disabled;
+  }
+
 }

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.html
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.html
@@ -10,6 +10,9 @@
     <div class="field">
       <button soho-button (click)="openSearchfieldFlexPanel()">Panel with Searchfield in flex toolbar</button>
     </div>
+    <div class="field">
+      <button soho-button (click)="openPanelWithFormValidation()">Panel with form validation / buttonsetAPI</button>
+    </div>
   </div>
 </div>
 

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.module.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.module.ts
@@ -14,6 +14,7 @@ import { ContextualActionPanelSearchfieldComponent } from './contextual-action-p
 import { ContextualActionPanelSearchfieldFlexComponent } from './contextual-action-panel-searchfield-flex.component';
 import { ContextualActionPanelFullSizeComponent } from './contextual-action-panel-fullsize.component';
 import { ContextualActionPanelVerticalTabsComponent } from './contextual-action-panel-tabs-vertical.component';
+import { ContextualActionPanelButtonsetAPIComponent } from './contextual-action-panel-buttonsetapi.component';
 
 @NgModule({
   declarations: [
@@ -23,12 +24,13 @@ import { ContextualActionPanelVerticalTabsComponent } from './contextual-action-
     ContextualActionPanelFullSizeComponent,
     ContextualActionPanelVerticalTabsComponent,
     ContextualActionPanelDemoComponent,
-    NestedModalDialogComponent
+    ContextualActionPanelButtonsetAPIComponent,
+    NestedModalDialogComponent,
   ],
   exports: [
   ],
   imports: [
-    BrowserModule,
+  BrowserModule,
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
@@ -42,7 +44,8 @@ import { ContextualActionPanelVerticalTabsComponent } from './contextual-action-
     ContextualActionPanelSearchfieldFlexComponent,
     ContextualActionPanelFullSizeComponent,
     ContextualActionPanelVerticalTabsComponent,
-    NestedModalDialogComponent
+    ContextualActionPanelButtonsetAPIComponent,
+    NestedModalDialogComponent,
   ],
 })
 export class ContextualActionPanelDemoModule { }

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -104,7 +104,9 @@ export class ContextualActionPanelDemoComponent {
         console.log('After Close Fires');
       });
 
-    debugger;
+    this.panelRef?.apply((ref: any) => {
+      ref.panelRef = this.panelRef;
+    }).open();
   }
 
   openPanel2() {

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -88,6 +88,7 @@ export class ContextualActionPanelDemoComponent {
       .modalSettings({ buttons, title: this.title, useFlexToolbar: true })
       .open()
       .initializeContent(true)
+      .cssClass('custom-panel')
       .opened(() => {
         console.log('Open Fires');
       })

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -85,7 +85,7 @@ export class ContextualActionPanelDemoComponent {
     }
 
     this.panelRef = (this.panelService as any).contextualactionpanel(ContextualActionPanelComponent, this.placeholder)
-      .modalSettings({ buttons, title: this.title })
+      .modalSettings({ buttons, title: this.title, useFlexToolbar: true })
       .open()
       .initializeContent(true)
       .opened(() => {
@@ -103,6 +103,8 @@ export class ContextualActionPanelDemoComponent {
       .afterClose(() => {
         console.log('After Close Fires');
       });
+
+    debugger;
   }
 
   openPanel2() {
@@ -133,7 +135,7 @@ export class ContextualActionPanelDemoComponent {
     }
 
     this.panelRef = this.panelService?.contextualactionpanel(NestedContextualActionPanelComponent, this.placeholder as any)
-      .modalSettings({ buttons, title: this.title })
+      .modalSettings({ buttons, title: this.title, useFlexToolbar: true })
       .open()
       .initializeContent(true);
   }
@@ -196,7 +198,6 @@ export class ContextualActionPanelDemoComponent {
 
     this.panelRef?.apply((ref: any) => {
       ref.panelRef = this.panelRef;
-    })
-      .open();
+    }).open();
   }
 }

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -11,6 +11,7 @@ import { ContextualActionPanelSearchfieldComponent } from './contextual-action-p
 import { ContextualActionPanelSearchfieldFlexComponent } from './contextual-action-panel-searchfield-flex.component';
 import { ContextualActionPanelVerticalTabsComponent } from './contextual-action-panel-tabs-vertical.component';
 import { NestedContextualActionPanelComponent } from './nested-contextualaction-panel.component';
+import { ContextualActionPanelButtonsetAPIComponent } from './contextual-action-panel-buttonsetapi.component';
 
 @Component({
   selector: 'app-contextual-action-panel-demo',
@@ -24,7 +25,7 @@ export class ContextualActionPanelDemoComponent {
    * This can be the ViewContainerRef of this component, or another component.
    */
   @ViewChild('panelPlaceholder', { read: ViewContainerRef, static: true })
-  placeholder?: ViewContainerRef | null;
+  private placeholder!: ViewContainerRef;
 
   /**
    * The interface to an instantiated instance of the Contextual Action Panel.
@@ -202,5 +203,53 @@ export class ContextualActionPanelDemoComponent {
     this.panelRef?.apply((ref: any) => {
       ref.panelRef = this.panelRef;
     }).open();
+  }
+
+  openPanelWithFormValidation(): void {
+    const buttons = [
+      {
+        id: 'save',
+        text: 'Save',
+        cssClass: 'btn',
+        icon: '#icon-save',
+        click: (_e: any, panel: any) => {
+          panel.close(true);
+        }
+      },
+      {
+        cssClass: 'separator'
+      },
+      {
+        text: 'Close',
+        cssClass: 'btn',
+        icon: '#icon-close',
+        click: (_e: any, panel: any) => {
+          panel.close(true);
+        },
+        isDefault: true
+      }
+    ];
+
+    const ref = this.panelService.contextualactionpanel<ContextualActionPanelButtonsetAPIComponent>(
+      ContextualActionPanelButtonsetAPIComponent,
+      this.placeholder
+    )
+      .modalSettings({
+        buttons,
+        title: 'CAP - Form Validation',
+        useFlexToolbar: true, // 👈 needed to use buttonsetAPI
+      })
+      .open();
+
+    ref.cssClass('tabs-modal page-container');
+    ref.apply(component => {
+      const saveButton = ref.buttonsetAPI?.buttons.find(button => button.settings.id === 'save');
+      if (saveButton) {
+        component.form.statusChanges.subscribe(status => {
+          saveButton.disabled = status !== 'VALID';
+        });
+      }
+    })
+
   }
 }

--- a/src/app/contextual-action-panel/nested-contextualaction-panel.component.html
+++ b/src/app/contextual-action-panel/nested-contextualaction-panel.component.html
@@ -2,7 +2,7 @@
   <div class="six columns">
     <div class="field">
       <label for="supplier-name">Supplier Name</label>
-      <select id="supplier-name" name="supplier-name" class="dropdown">
+      <select soho-dropdown id="supplier-name" name="supplier-name" class="dropdown">
         <option value=""></option>
         <option value="jawbone" selected>Jawbone, Inc.</option>
         <option value="infor">Infor</option>
@@ -10,7 +10,7 @@
     </div>
     <div class="field">
       <label for="template">Template</label>
-      <select id="template" name="template" class="dropdown">
+      <select soho-dropdown id="template" name="template" class="dropdown">
         <option value="" selected>None</option>
         <option value="1">Template #1</option>
         <option value="2">Template #2</option>
@@ -24,7 +24,7 @@
   <div class="six columns">
     <div class="field">
       <label for="details-terms">Details Terms</label>
-      <select id="details-terms" name="details-terms" class="dropdown">
+      <select soho-dropdown id="details-terms" name="details-terms" class="dropdown">
         <option value=""></option>
         <option value="default" selected>Default</option>
         <option value="alternate">Alternate</option>
@@ -32,7 +32,7 @@
     </div>
     <div class="field">
       <label for="ship-via">Control Via</label>
-      <select id="ship-via" name="ship-via" class="dropdown">
+      <select soho-dropdown id="ship-via" name="ship-via" class="dropdown">
         <option value=""></option>
         <option value="freight" selected>Freight</option>
         <option value="air">USPS Air</option>

--- a/src/app/toolbar-flex/toolbar-flex-basic.demo.html
+++ b/src/app/toolbar-flex/toolbar-flex-basic.demo.html
@@ -1,168 +1,171 @@
 <form onsubmit="onSubmit()">
   <div class="row top-padding">
     <div class="twelve columns">
+      <!-- BEGIN Toolbar with All Buttons (Buttonset Favoring) -->
+      <soho-toolbar-flex
+      (selected)="onSelected($event)">
+        <soho-toolbar-flex-section [isTitle]="true">
+          <h2>Incredibly Long Toolbar (Favor's Buttonset)</h2>
+        </soho-toolbar-flex-section>
 
-    <!-- BEGIN Toolbar with All Buttons (Buttonset Favoring) -->
-    <soho-toolbar-flex
-     (selected)="onSelected($event)">
-      <soho-toolbar-flex-section [isTitle]="true">
-        <h2>Incredibly Long Toolbar (Favor's Buttonset)</h2>
-      </soho-toolbar-flex-section>
+        <soho-toolbar-flex-section [isButtonSet]="true">
+          <button soho-button="btn">
+            <span>Text Button</span>
+          </button>
 
-      <soho-toolbar-flex-section [isButtonSet]="true">
-        <button soho-button="btn">
-          <span>Text Button</span>
-        </button>
+          <button soho-menu-button>
+            <span>Menu Button</span>
+          </button>
+          <ul class="popupmenu">
+            <li><a href="#">Item One</a></li>
+            <li><a href="#">Item Two</a></li>
+            <li class="submenu">
+              <a href="#">Item Three</a>
+              <ul class="popupmenu">
+                <li><a href="#">Sub-Item One</a></li>
+                <li><a href="#">Sub-Item Two</a></li>
+              </ul>
+            </li>
+            <li><a href="#">Item Four</a></li>
+          </ul>
 
-        <button soho-menu-button>
-          <span>Menu Button</span>
-        </button>
-        <ul class="popupmenu">
-          <li><a href="#">Item One</a></li>
-          <li><a href="#">Item Two</a></li>
-          <li class="submenu">
-            <a href="#">Item Three</a>
-            <ul class="popupmenu">
-              <li><a href="#">Sub-Item One</a></li>
-              <li><a href="#">Sub-Item Two</a></li>
-            </ul>
-          </li>
-          <li><a href="#">Item Four</a></li>
-        </ul>
+          <button soho-button="icon" icon="settings" [disabled]="true">Settings</button>
+          <button soho-button="icon" icon="delete">Delete</button>
+        </soho-toolbar-flex-section>
 
-        <button soho-button="icon" icon="settings" [disabled]="true">Settings</button>
-        <button soho-button="icon" icon="delete">Delete</button>
-      </soho-toolbar-flex-section>
+        <soho-toolbar-flex-section [isSearch]="true">
+          <input soho-toolbar-flex-searchfield (cleared)="onCleared($event)" (change)="onChange($event)" placeholder="Search Here" [clearable]="true" [collapsible]="true"/>
+        </soho-toolbar-flex-section>
 
-      <soho-toolbar-flex-section [isSearch]="true">
-        <input soho-toolbar-flex-searchfield (cleared)="onCleared($event)" (change)="onChange($event)" placeholder="Search Here" [clearable]="true" [collapsible]="true"/>
-      </soho-toolbar-flex-section>
-
-      <soho-toolbar-flex-more-button [moreButtonId]="moreButtonId">
-        <ul class="popupmenu">
-          <li><a href="#" id="item-one">Pre-defined Item #1</a></li>
-          <li><a href="#" id="item-two">Pre-defined Item #2</a></li>
-          <li><a href="#" id="item-three">Pre-defined Item #3</a></li>
-        </ul>
-      </soho-toolbar-flex-more-button>
-    </soho-toolbar-flex>
-    <!-- END Toolbar with All Buttons (Buttonset Favoring) -->
-
-  </div>
-  </div>
-  <div class="row top-padding">
-  <div class="twelve columns">
-
-    <!-- BEGIN Toolbar with All Buttons (Title Favoring) -->
-    <soho-toolbar-flex>
-      <soho-toolbar-flex-section [isTitle]="true" [isTitleFavor]="true">
-        <h2>Incredibly Long Toolbar (Favor's Title)</h2>
-      </soho-toolbar-flex-section>
-
-      <soho-toolbar-flex-section [isButtonSet]="true">
-        <button soho-button="btn">
-          <span>Text Button</span>
-        </button>
-
-        <button soho-menu-button>
-          <span>Menu Button</span>
-        </button>
-        <ul class="popupmenu">
-          <li><a href="#">Item One</a></li>
-          <li><a href="#">Item Two</a></li>
-          <li class="submenu">
-            <a href="#">Item Three</a>
-            <ul class="popupmenu">
-              <li><a href="#">Sub-Item One</a></li>
-              <li><a href="#">Sub-Item Two</a></li>
-            </ul>
-          </li>
-          <li><a href="#">Item Four</a></li>
-        </ul>
-
-        <button soho-button="icon" icon="settings"> Settings </button>
-
-        <button soho-button="icon" icon="delete"> Trash </button>
-      </soho-toolbar-flex-section>
-
-      <soho-toolbar-flex-section [isSearch]="true">
-        <input soho-toolbar-flex-searchfield placeholder="Search..." [clearable]="true" [collapsible]="true"/>
-      </soho-toolbar-flex-section>
-
-      <soho-toolbar-flex-more-button>
-        <ul class="popupmenu">
-          <li><a href="#">Pre-defined Item #1</a></li>
-          <li><a href="#">Pre-defined Item #2</a></li>
-          <li><a href="#">Pre-defined Item #3</a></li>
-        </ul>
-      </soho-toolbar-flex-more-button>
-    </soho-toolbar-flex>
-    <!-- END Toolbar with All Buttons (Title Favoring) -->
-
-  </div>
-  </div>
-  <div class="row top-padding">
-  <div class="twelve columns">
-
-    <!-- BEGIN Toolbar similar to Header Toolbar -->
-    <soho-toolbar-flex>
-      <soho-toolbar-flex-section><button soho-toolbar-flex-nav-button>Show Navigation</button></soho-toolbar-flex-section>
-      <soho-toolbar-flex-section [isTitle]="true">
-        <h2>Toolbar Title</h2>
-      </soho-toolbar-flex-section>
-
-      <soho-toolbar-flex-section [isButtonSet]="true">
-        <a class="hyperlink" href="#">Outbound Link</a>
-      </soho-toolbar-flex-section>
-
-      <soho-toolbar-flex-section [isSearch]="true">
-        <input soho-toolbar-flex-searchfield placeholder="Search..." [clearable]="true" [collapsible]="true"/>
-      </soho-toolbar-flex-section>
-    </soho-toolbar-flex>
-    <!-- END Toolbar similar to Header Toolbar -->
-
-  </div>
-  </div>
-  <div class="row top-padding">
-  <div class="twelve columns">
-
-    <!-- BEGIN Toolbar with Title Eyebrow -->
-    <soho-toolbar-flex>
-      <soho-toolbar-flex-section>
-        <button soho-button="icon" icon="bullet-steps">
-          Workflow Steps
-        </button>
-      </soho-toolbar-flex-section>
-
-      <soho-toolbar-flex-section [isTitle]="true">
-        <h2 soho-toolbar-flex-page-title>Page Title</h2>
-        <span soho-toolbar-flex-section-title>Smaller Subsection Title with Details</span>
-      </soho-toolbar-flex-section>
-
-      <soho-toolbar-flex-section [isSearch]="true">
-        <input soho-toolbar-flex-searchfield placeholder="Search..." [clearable]="true" [collapsible]="true"/>
-      </soho-toolbar-flex-section>
-
-      <soho-toolbar-flex-more-button>
-        <ul class="popupmenu">
-          <li><a href="#">Pre-defined Item #1</a></li>
-          <li><a href="#">Pre-defined Item #2</a></li>
-          <li><a href="#">Pre-defined Item #3</a></li>
-        </ul>
-      </soho-toolbar-flex-more-button>
-    </soho-toolbar-flex>
-    <!-- END Toolbar with Title Eyebrow -->
-
+        <soho-toolbar-flex-more-button [moreButtonId]="moreButtonId">
+          <ul class="popupmenu">
+            <li><a href="#" id="item-one">Pre-defined Item #1</a></li>
+            <li><a href="#" id="item-two">Pre-defined Item #2</a></li>
+            <li><a href="#" id="item-three">Pre-defined Item #3</a></li>
+          </ul>
+        </soho-toolbar-flex-more-button>
+      </soho-toolbar-flex>
+      <!-- END Toolbar with All Buttons (Buttonset Favoring) -->
+    </div>
   </div>
 
   <div class="row top-padding">
     <div class="twelve columns">
+      <!-- BEGIN Toolbar with All Buttons (Title Favoring) -->
+      <soho-toolbar-flex>
+        <soho-toolbar-flex-section [isTitle]="true" [isTitleFavor]="true">
+          <h2>Incredibly Long Toolbar (Favor's Title)</h2>
+        </soho-toolbar-flex-section>
 
-        <fieldset>
-          <label for="simpleInput">Press OK in the input:</label>
-          <input soho-input id="simpleInput"/>
-        </fieldset>
+        <soho-toolbar-flex-section [isButtonSet]="true">
+          <button soho-button="btn">
+            <span>Text Button</span>
+          </button>
+
+          <button soho-menu-button>
+            <span>Menu Button</span>
+          </button>
+          <ul class="popupmenu">
+            <li><a href="#">Item One</a></li>
+            <li><a href="#">Item Two</a></li>
+            <li class="submenu">
+              <a href="#">Item Three</a>
+              <ul class="popupmenu">
+                <li><a href="#">Sub-Item One</a></li>
+                <li><a href="#">Sub-Item Two</a></li>
+              </ul>
+            </li>
+            <li><a href="#">Item Four</a></li>
+          </ul>
+
+          <button soho-button="icon" icon="settings"> Settings </button>
+
+          <button soho-button="icon" icon="delete"> Trash </button>
+        </soho-toolbar-flex-section>
+
+        <soho-toolbar-flex-section [isSearch]="true">
+          <input soho-toolbar-flex-searchfield placeholder="Search..." [clearable]="true" [collapsible]="true"/>
+        </soho-toolbar-flex-section>
+
+        <soho-toolbar-flex-more-button>
+          <ul class="popupmenu">
+            <li><a href="#">Pre-defined Item #1</a></li>
+            <li><a href="#">Pre-defined Item #2</a></li>
+            <li><a href="#">Pre-defined Item #3</a></li>
+          </ul>
+        </soho-toolbar-flex-more-button>
+      </soho-toolbar-flex>
+      <!-- END Toolbar with All Buttons (Title Favoring) -->
     </div>
-</div>
+  </div>
+
+  <div class="row top-padding">
+    <div class="twelve columns">
+      <!-- BEGIN Toolbar similar to Header Toolbar -->
+      <soho-toolbar-flex>
+        <soho-toolbar-flex-section><button soho-toolbar-flex-nav-button>Show Navigation</button></soho-toolbar-flex-section>
+        <soho-toolbar-flex-section [isTitle]="true">
+          <h2>Toolbar Title</h2>
+        </soho-toolbar-flex-section>
+
+        <soho-toolbar-flex-section [isButtonSet]="true">
+          <a class="hyperlink" href="#">Outbound Link</a>
+        </soho-toolbar-flex-section>
+
+        <soho-toolbar-flex-section [isSearch]="true">
+          <input soho-toolbar-flex-searchfield placeholder="Search..." [clearable]="true" [collapsible]="true"/>
+        </soho-toolbar-flex-section>
+      </soho-toolbar-flex>
+      <!-- END Toolbar similar to Header Toolbar -->
+    </div>
+  </div>
+
+  <div class="row top-padding">
+    <div class="twelve columns">
+      <!-- BEGIN Toolbar with Title Eyebrow -->
+      <soho-toolbar-flex>
+        <soho-toolbar-flex-section>
+          <button soho-button="icon" icon="bullet-steps">
+            Workflow Steps
+          </button>
+        </soho-toolbar-flex-section>
+
+        <soho-toolbar-flex-section [isTitle]="true">
+          <h2 soho-toolbar-flex-page-title>Page Title</h2>
+          <span soho-toolbar-flex-section-title>Smaller Subsection Title with Details</span>
+        </soho-toolbar-flex-section>
+
+        <soho-toolbar-flex-section [isSearch]="true">
+          <input soho-toolbar-flex-searchfield placeholder="Search..." [clearable]="true" [collapsible]="true"/>
+        </soho-toolbar-flex-section>
+
+        <soho-toolbar-flex-more-button>
+          <ul class="popupmenu">
+            <li><a href="#">Pre-defined Item #1</a></li>
+            <li><a href="#">Pre-defined Item #2</a></li>
+            <li><a href="#">Pre-defined Item #3</a></li>
+          </ul>
+        </soho-toolbar-flex-more-button>
+      </soho-toolbar-flex>
+      <!-- END Toolbar with Title Eyebrow -->
+    </div>
+  </div>
+
+  <div class="row top-padding">
+    <div class="twelve columns">
+      <fieldset>
+        <label for="simpleInput">Press OK in the input:</label>
+        <input soho-input id="simpleInput"/>
+      </fieldset>
+    </div>
+  </div>
+
+  <div class="row top-padding">
+    <div class="twelve columns">
+      <div class="field">
+        <input soho-checkbox id="toggle-disabled" type="checkbox" name="disabled-menu-button" (click)="toggleDisabled()">
+        <label for="toggle-disabled">Toggle Disabled on "Menu Button" on the first Toolbar</label>
+      </div>
+    </div>
   </div>
 </form>

--- a/src/app/toolbar-flex/toolbar-flex-basic.demo.ts
+++ b/src/app/toolbar-flex/toolbar-flex-basic.demo.ts
@@ -1,10 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { SohoToolbarFlexComponent } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'app-toolbar-flex-basic-demo',
   templateUrl: 'toolbar-flex-basic.demo.html'
 })
 export class ToolbarFlexBasicDemoComponent {
+  @ViewChild(SohoToolbarFlexComponent) toolbarFlex!: SohoToolbarFlexComponent;
+
   onSelected(event: SohoToolbarFlexSelectedEvent) {
     if (event.item.type === 'actionbutton' || event.item.type === 'menubutton') {
       console.log(event.item.selectedAnchor[0].getAttribute('id'));
@@ -27,4 +30,8 @@ export class ToolbarFlexBasicDemoComponent {
     console.log('Clear Fired', event);
   }
 
+  toggleDisabled() {
+    const btn = (this.toolbarFlex.buttonsetAPIs as any)[0].buttons[1];
+    btn.disabled = !btn.disabled;
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds NG types for the new `buttonsetAPI` property on Contextual Action Panels, as well as a demonstration of the new control available over CAP Toolbar Buttonset areas via the Buttonset API.

**Related github/jira issue (required)**:
- Closes #1101
- Related to infor-design/enterprise#5645

**Steps necessary to review your pull request (required)**:
- Pull this branch
- NPM Link or Symbolic Link to the EP branch provided on infor-design/enterprise#5645
- Build/Run
- Open http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- Click the "Panel" button
- Toggle the "Disable the Save Button" checkbox.  This should disable/enable the Save button in the CAP's Toolbar.  This function is accessing the `buttonsetAPI` property on the CAP component.
- Open http://localhost:4200/ids-enterprise-ng-demo/toolbar-flex-basic
- Click the "toggle disabled on Menu Button on the first toolbar" checkbox.  It should toggle disabled/enabled the "Menu Button" button on the first toolbar.