### PR TITLE
1031 - Update the type of activePage in Datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 10.7.0 Fixes
 
-- `[Datagrid]` Updated the type of activePage property. ([#1035](https://github.com/infor-design/enterprise/issues/1035)) `EA`
+- `[Datagrid]` Updated the type of activePage property. ([#1031](https://github.com/infor-design/enterprise-ng/issues/1031)) `EA`
 
 ## v10.6.3
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 10.7.0 Fixes
 
-- `[Placeholder]` Change me. ([#1035](https://github.com/infor-design/enterprise/issues/1035))
+- `[Datagrid]` Updated the type of activePage property. ([#1035](https://github.com/infor-design/enterprise/issues/1035)) `EA`
 
 ## v10.6.3
 

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -1384,7 +1384,7 @@ interface SohoDataGridSettingsChangedEvent {
   rowHeight?: SohoDataGridRowHeight;
   sortOrder?: { columnId: string, ascending?: boolean };
   pagesize?: number;
-  activePage?: string;
+  activePage?: string | number;
   filter?: Array<SohoDataGridFilterCondition>;
 }
 

--- a/projects/ids-enterprise-typings/lib/pager/soho-pager.d.ts
+++ b/projects/ids-enterprise-typings/lib/pager/soho-pager.d.ts
@@ -95,7 +95,7 @@ interface SohoPagerOptions {
   position: SohoPagerPosition;
 
   /** Current page. */
-  activePage?: number;
+  activePage?: string | number;
 
   /** Source Function */
   source?: SohoDataGridSourceFunction;

--- a/src/app/datagrid/datagrid-paging-service.demo.ts
+++ b/src/app/datagrid/datagrid-paging-service.demo.ts
@@ -87,6 +87,8 @@ export class DataGridPagingServiceDemoComponent implements OnInit {
     lscache.set(this.uniqueId + 'pagesize', event.pagesize);
     lscache.set(this.uniqueId + 'activePage', event.activePage);
     lscache.set(this.uniqueId + 'filter', JSON.stringify(event.filter));
+
+    console.log('activePage type', typeof event.activePage)
   }
 
   onRendered(_event: SohoDataGridRenderedEvent) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the type of `activePage` in Datagrid.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise-ng/issues/1031

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, start
- Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-paging-service
- Go to the next page
- Check the console tab
- Should see `activePage type number`
- Current type is just `string` then changed to `string | number`

