### PR TITLE
1140 - Fix on error thrown when field value of datepicker is string

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 10.10.0 Fixes
 
-- `[Placeholder]` Remove me.
+- `[Datepicker]` Fix on error when value in input is string and datepicker mode is range. ([#1140](https://github.com/infor-design/enterprise-ng/issues/1140))
 
 ### 10.10.0 Features
 

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -523,7 +523,19 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
     if (this.datepicker) {
       // The processing is required to ensure we use the correct format
       // in the control.
-      this.datepicker.setValue(value, false);
+      if (typeof value === 'string' && this._options.range?.useRange) {
+        let startValue = this._options.range?.start;
+        
+        if (startValue && typeof startValue === 'string') {
+          startValue = new Date(startValue)
+        } else {
+          startValue = new Date(value.split('-')[0]);
+        }
+
+        this.datepicker.setValue(startValue, false);
+      } else {
+        this.datepicker.setValue(value, false);
+      }
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
An error occurs if the input field value of datepicker is a string and its mode is range because IDS tries to use functions that only exist in Date (and not string). Added a check to see if value is string and mode is range and change value into a Date object before passing it to the setValue function.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1140 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/datepicker
- Errors shown in the console (stated in the issue) should not appear when page is loaded and when using the "Date with Range" pickers

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
