### PR TITLE
1145 - Removed aria-pressed if button is not toggle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 10.10.0 Fixes
 
+- `[Button]` Removed aria-pressed if button is not toggle. ([#1145](https://github.com/infor-design/enterprise-ng/issues/1145))
 - `[Datagrid]` Added vertical scroll event in datagrid. ([#1154](https://github.com/infor-design/enterprise/issues/1154))
 - `[Datepicker]` Fix on error when value in input is string and datepicker mode is range. ([#1140](https://github.com/infor-design/enterprise-ng/issues/1140))
 - `[Notification]` Added hide in notification service. ([#5562](https://github.com/infor-design/enterprise/issues/5562))

--- a/projects/ids-enterprise-ng/src/lib/button/soho-button.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/button/soho-button.component.ts
@@ -305,6 +305,13 @@ export class SohoButtonComponent implements AfterViewInit, OnDestroy, OnInit {
           this.jQueryElement.off('click.favorite');
         }
       }
+
+      // Remove aria-pressed attribute if button is not toggle
+      if (!this.isToggle) {
+        if (this.jQueryElement.attr('aria-pressed') !== undefined) {
+          this.jQueryElement.removeAttr('aria-pressed');
+        }
+      }
     });
 
     // There are no 'extra' event handlers for button.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Removed the aria-pressed attribute in button if it's not toggle.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1145 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/button
- Inspect the buttons
- Buttons that are not in the toggle category should not have aria-pressed

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
