### PR TITLE
1164 - Implement Swipe Action Component Wrapper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,5 @@
 # What's New with Enterprise-NG
 
-## v10.11.0 Features
-
-- `[Swipe Action]` Added a wrapper for Swipe Action Component. ([#1164](https://github.com/infor-design/enterprise-ng/issues/1164)) `EA`
-
 ## v10.10.0
 
 - `[Calendar]` Added first day of the week parameter in calendar settings. ([#5775](https://github.com/infor-design/enterprise/issues/5775))
@@ -21,6 +17,7 @@
 
 - `[ApplicationMenu]` Added Wrapper for Resizable Feature ([#1143](https://github.com/infor-design/enterprise-ng/issues/1143))
 - `[Message]` Added `showCloseBtn` setting to `SohoMessageOptions`. ([#1161](https://github.com/infor-design/enterprise-ng/issues/1161)) `EA`
+- `[Swipe Action]` Added a wrapper for Swipe Action Component. ([#1164](https://github.com/infor-design/enterprise-ng/issues/1164)) `EA`
 
 ## v10.9.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise-NG
 
+## v10.11.0 Features
+
+- `[Swipe Action]` Added a wrapper for Swipe Action Component. ([#1164](https://github.com/infor-design/enterprise-ng/issues/1164)) `EA`
+
 ## v10.10.0
 
 - `[Calendar]` Added first day of the week parameter in calendar settings. ([#5775](https://github.com/infor-design/enterprise/issues/5775))

--- a/projects/ids-enterprise-ng/src/lib/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/index.ts
@@ -70,6 +70,7 @@ export * from './splitter/index';
 export * from './stepchart/index';
 export * from './stepprocess/index';
 export * from './swaplist/index';
+export * from './swipe-action/index';
 export * from './tag/index';
 export * from './tabs/index';
 export * from './textarea/index';

--- a/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
@@ -71,6 +71,7 @@ import { SohoSpinboxModule } from './spinbox/soho-spinbox.module';
 import { SohoStepChartModule } from './stepchart';
 import { SohoStepProcessModule } from './stepprocess/soho-stepprocess.module';
 import { SohoSwapListModule } from './swaplist/soho-swaplist.module';
+import { SohoSwipeActionModule } from './swipe-action/soho-swipe-action.module';
 import { SohoTabsModule } from './tabs/soho-tabs.module';
 import { SohoTagModule } from './tag/soho-tag.module';
 import { SohoTextAreaModule } from './textarea/soho-textarea.module';
@@ -160,6 +161,7 @@ import { SohoWizardModule } from './wizard/soho-wizard.module';
     SohoStepChartModule,
     SohoStepProcessModule,
     SohoSwapListModule,
+    SohoSwipeActionModule,
     SohoTabsModule,
     SohoTagModule,
     SohoTextAreaModule,
@@ -247,6 +249,7 @@ import { SohoWizardModule } from './wizard/soho-wizard.module';
     SohoStepChartModule,
     SohoStepProcessModule,
     SohoSwapListModule,
+    SohoSwipeActionModule,
     SohoTabsModule,
     SohoTagModule,
     SohoTextAreaModule,

--- a/projects/ids-enterprise-ng/src/lib/swipe-action/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/swipe-action/index.ts
@@ -1,0 +1,2 @@
+export * from './soho-swipe-action.component';
+export * from './soho-swipe-action.module';

--- a/projects/ids-enterprise-ng/src/lib/swipe-action/soho-swipe-action.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/swipe-action/soho-swipe-action.component.ts
@@ -1,0 +1,48 @@
+import {
+  Component,
+  HostBinding,
+  Input,
+  NgZone,
+} from '@angular/core';
+
+@Component({
+  selector: '[soho-swipe-action]', // eslint-disable-line
+  template: `
+    <div class="swipe-container">
+      <ng-content></ng-content>
+    </div>`,
+})
+export class SohoSwipeActionComponent {
+
+  /** Options */
+  private _options: SohoSwipeActionOptions = {};
+  private _swipeaction?: SohoSwipeActionStatic | null;
+
+  @HostBinding('class.swipe-action') get isSwipeAction() {
+    return true;
+  }
+
+  @Input()
+  public set swipeType(swipeType: SohoSwipeType) {
+    this._options.swipeType = swipeType;
+    if (this._swipeaction) {
+      this._swipeaction.settings.swipeType = swipeType;
+      this.updated(this._swipeaction.settings);
+    }
+  }
+  public get swipeType(): SohoSwipeType {
+    if (!this._swipeaction) {
+      return this._options.swipeType;
+    }
+    return this._swipeaction.settings.swipeType;
+  }
+
+  constructor(
+    private ngZone: NgZone,
+  ) { }
+
+  public updated(settings: any): SohoSwipeActionComponent {
+    this.ngZone.runOutsideAngular(() => this._swipeaction?.updated(settings));
+    return this;
+  }
+}

--- a/projects/ids-enterprise-ng/src/lib/swipe-action/soho-swipe-action.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/swipe-action/soho-swipe-action.component.ts
@@ -1,8 +1,10 @@
 import {
+  AfterViewInit,
   Component,
+  ElementRef,
   HostBinding,
-  Input,
   NgZone,
+  OnDestroy,
 } from '@angular/core';
 
 @Component({
@@ -12,37 +14,44 @@ import {
       <ng-content></ng-content>
     </div>`,
 })
-export class SohoSwipeActionComponent {
+export class SohoSwipeActionComponent implements AfterViewInit, OnDestroy {
 
   /** Options */
-  private _options: SohoSwipeActionOptions = {};
-  private _swipeaction?: SohoSwipeActionStatic | null;
+  private swipeaction?: SohoSwipeActionStatic | null;
+  private jQueryElement!: JQuery;
 
   @HostBinding('class.swipe-action') get isSwipeAction() {
     return true;
   }
 
-  @Input()
-  public set swipeType(swipeType: SohoSwipeType) {
-    this._options.swipeType = swipeType;
-    if (this._swipeaction) {
-      this._swipeaction.settings.swipeType = swipeType;
-      this.updated(this._swipeaction.settings);
-    }
-  }
-  public get swipeType(): SohoSwipeType {
-    if (!this._swipeaction) {
-      return this._options.swipeType;
-    }
-    return this._swipeaction.settings.swipeType;
-  }
-
   constructor(
+    private element: ElementRef,
     private ngZone: NgZone,
   ) { }
 
+  ngAfterViewInit() {
+    this.ngZone.runOutsideAngular(() => {
+      this.jQueryElement = jQuery(this.element.nativeElement);
+
+      // Initialize the component
+      this.jQueryElement.swipeaction();
+    });
+  }
+
+  ngOnDestroy() {
+    this.ngZone.runOutsideAngular(() => {
+      if (this.jQueryElement) {
+        this.jQueryElement.off();
+      }
+      if (this.swipeaction) {
+        this.swipeaction.destroy();
+        this.swipeaction = null;
+      }
+    });
+  }
+
   public updated(settings: any): SohoSwipeActionComponent {
-    this.ngZone.runOutsideAngular(() => this._swipeaction?.updated(settings));
+    this.ngZone.runOutsideAngular(() => this.swipeaction?.updated(settings));
     return this;
   }
 }

--- a/projects/ids-enterprise-ng/src/lib/swipe-action/soho-swipe-action.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/swipe-action/soho-swipe-action.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import {
+  SohoSwipeActionComponent
+} from './soho-swipe-action.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+  declarations: [
+    SohoSwipeActionComponent,
+  ],
+  exports: [
+    SohoSwipeActionComponent,
+  ],
+})
+export class SohoSwipeActionModule { }

--- a/projects/ids-enterprise-ng/src/lib/swipe-action/soho-swipe-action.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/swipe-action/soho-swipe-action.spec.ts
@@ -1,0 +1,110 @@
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+
+import { By } from '@angular/platform-browser';
+
+import {
+  Component,
+  DebugElement,
+  ViewChild,
+} from '@angular/core';
+
+import { SohoSwipeActionComponent } from './soho-swipe-action.component';
+
+@Component({
+  template: `
+  <div class="row top-padding">
+  <div class="six columns">
+    <span class="label">Swipe Action</span>
+    <soho-card ngClass="card-variant">
+      <div soho-swipe-action data-options="{ swipeType: 'reveal' }">
+        <div class="swipe-action-left">
+          <button id="action-left-reveal" class="btn-swipe-action-left">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-reply"></use>
+            </svg>
+            <span>Left Action</span>
+          </button>
+        </div>
+        <div class="swipe-element">
+          <div class="card-content">
+            <div class="card-content-header">Tuesday, 21nd September</div>
+            <div class="card-content-sub">8:40AM-2:00PM</div>
+          </div>
+          <div class="card-buttonset">
+            <div class="card-content-action">
+              <button soho-button="icon" icon="more" soho-context-menu menu="action-popupmenu" trigger="click"
+                class="btn-actions"></button>
+            </div>
+          </div>
+        </div>
+        <div class="swipe-action-right">
+          <button id="action-right-reveal" class="btn-swipe-action-right">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-tack"></use>
+            </svg>
+            <span>Right Action</span>
+          </button>
+        </div>
+      </div>
+    </soho-card>
+    <ul soho-popupmenu id="action-popupmenu">
+      <li soho-popupmenu-item><a soho-popupmenu-label>Left Action</a></li>
+      <li soho-popupmenu-item><a soho-popupmenu-label>Right Action</a></li>
+      <li soho-popupmenu-item><a soho-popupmenu-label>Desktop Only Action</a></li>
+    </ul>
+  </div>
+</div>
+  `
+})
+class SohoSwipeActionTestComponent {
+  @ViewChild(SohoSwipeActionComponent) swipeaction?: SohoSwipeActionComponent;
+}
+
+describe('Soho Swipe Action (Reveal)', () => {
+  let component: SohoSwipeActionComponent | undefined;
+  let fixture: ComponentFixture<SohoSwipeActionTestComponent>;
+  let de: DebugElement;
+  let el: HTMLElement;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [SohoSwipeActionTestComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SohoSwipeActionTestComponent);
+    fixture.detectChanges();
+
+    de = fixture.debugElement;
+    el = de.query(By.css('[soho-swipe-action]')).nativeElement;
+    component = fixture.componentInstance.swipeaction;
+  });
+
+  it('check HTML content', () => {
+    expect(el.hasAttribute('soho-swipe-action')).toBeTruthy('soho-swipe-action');
+  });
+
+  it('check swipe action left element', () => {
+    expect(el.querySelector('.swipe-action-left')).toBeTruthy();
+    expect(el.querySelector('.btn-swipe-action-left')).toBeTruthy();
+  });
+
+  it('check swipe action element', () => {
+    expect(el.querySelector('.swipe-element')).toBeTruthy();
+  });
+
+  it('check swipe action right element', () => {
+    expect(el.querySelector('.swipe-action-right')).toBeTruthy();
+    expect(el.querySelector('.btn-swipe-action-right')).toBeTruthy();
+  });
+
+  it('check swipe type', () => {
+    expect(el.getAttribute('data-options')).toEqual("{ swipeType: 'reveal' }");
+  });
+});

--- a/projects/ids-enterprise-typings/index.d.ts
+++ b/projects/ids-enterprise-typings/index.d.ts
@@ -71,6 +71,7 @@
 /// <reference path='lib/stepchart/soho-stepchart.d.ts' />
 /// <reference path='lib/stepprocess/soho-stepprocess.d.ts' />
 /// <reference path='lib/swaplist/soho-swaplist.d.ts' />
+/// <reference path='lib/swipe-action/soho-swipe-action.d.ts' />
 /// <reference path='lib/tabs/soho-tabs.d.ts' />
 /// <reference path='lib/tag/soho-tag.d.ts' />
 /// <reference path='lib/textarea/soho-textarea.d.ts' />

--- a/projects/ids-enterprise-typings/lib/swipe-action/soho-swipe-action.d.ts
+++ b/projects/ids-enterprise-typings/lib/swipe-action/soho-swipe-action.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Soho Swap Action Control.
+ * 
+ * This file contains the Typescript mappings for the public
+ * interface of the Soho jQuery swipe action control.
+ */
+
+type SohoSwipeType = 'continuous' | 'reveal' | undefined;
+
+interface SohoSwipeActionOptions {
+  swipeType?: SohoSwipeType;
+}
+
+interface SohoSwipeActionStatic {
+  settings: SohoSwipeActionOptions;
+
+  updated(settings?: SohoSwipeActionOptions): void;
+
+  destroy(): void;
+}
+
+interface JQueryStatic {
+  swipeaction: SohoSwipeActionStatic;
+}
+
+interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
+  swipeaction(options?: SohoSwipeActionOptions): JQuery;
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -210,6 +210,7 @@ import { SwapListDynamicDemoComponent } from './swaplist/swaplist-dynamic.demo';
 import { SwapListFullAccessDemoComponent } from './swaplist/swaplist-full-access.demo';
 import { SwapListSearchDemoComponent } from './swaplist/swaplist-search.demo';
 import { SwapListServiceDemoComponent } from './swaplist/swaplist-service.demo';
+import { SwipeActionDemoComponent } from './swipe-action/swipe-action.demo';
 import { TabsBasicDemoComponent } from './tabs/tabs-basic.demo';
 import { TabsCountsDemoComponent } from './tabs/tabs-counts.demo';
 import { TabsDataDrivenDemoComponent } from './tabs/tabs-datadriven.demo';
@@ -455,6 +456,7 @@ import { DataGridVerticalScrollDemoComponent } from './datagrid/datagrid-vertica
     SwapListFullAccessDemoComponent,
     SwapListSearchDemoComponent,
     SwapListServiceDemoComponent,
+    SwipeActionDemoComponent,
     TabsBasicDemoComponent,
     TabsCountsDemoComponent,
     TabsDataDrivenDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -165,6 +165,7 @@ import { SwapListDynamicDemoComponent } from './swaplist/swaplist-dynamic.demo';
 import { SwapListFullAccessDemoComponent } from './swaplist/swaplist-full-access.demo';
 import { SwapListSearchDemoComponent } from './swaplist/swaplist-search.demo';
 import { SwapListServiceDemoComponent } from './swaplist/swaplist-service.demo';
+import { SwipeActionDemoComponent } from './swipe-action/swipe-action.demo';
 import { TabsBasicDemoComponent } from './tabs/tabs-basic.demo';
 import { TabsCountsDemoComponent } from './tabs/tabs-counts.demo';
 import { TabsDataDrivenDemoComponent } from './tabs/tabs-datadriven.demo';
@@ -389,6 +390,7 @@ export const routes: Routes = [
   { path: 'swaplist-full-access', component: SwapListFullAccessDemoComponent },
   { path: 'swaplist-search', component: SwapListSearchDemoComponent },
   { path: 'swaplist-service', component: SwapListServiceDemoComponent },
+  { path: 'swipe-action', component: SwipeActionDemoComponent },
   { path: 'spinbox', component: SpinboxDemoComponent },
   { path: 'tabs-basic', component: TabsBasicDemoComponent },
   { path: 'tabs-counts', component: TabsCountsDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -244,6 +244,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['swaplist-full-access']"><span>Swap List - Full Access</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['swaplist-search']"><span>Swap List - Search</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['swaplist-service']"><span>Swap List - Service</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['swipe-action']"><span>Swipe Action</span></a></div>
   </div>
 
   <!-- T -->

--- a/src/app/swipe-action/swipe-action.demo.html
+++ b/src/app/swipe-action/swipe-action.demo.html
@@ -41,7 +41,7 @@
   </div>
 </div>
 
-<div class="row top-padding">
+<div class="row">
   <div class="six columns">
     <span class="label">Swipe Action (Reveal / One Action)</span>
     <soho-card ngClass="card-variant">
@@ -73,5 +73,54 @@
       <li soho-popupmenu-item><a soho-popupmenu-label>Right Action</a></li>
       <li soho-popupmenu-item><a soho-popupmenu-label>Desktop Only Action</a></li>
     </ul>
+  </div>
+</div>
+
+<div class="row">
+  <div class="six columns">
+    <span class="label">Swipe Action (Continuous)</span>
+    <soho-card ngClass="card-variant">
+      <div soho-swipe-action data-options="{'swipeType': 'continuous'}">
+        <div class="swipe-action-left">
+          <button id="action-left-continuous" class="btn-swipe-action-left">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-reply"></use>
+            </svg>
+            <span>Left Action</span>
+          </button>
+        </div>
+        <div class="swipe-element">
+          <div class="card-content">
+            <div class="card-content-header">Thursday, 23nd September</div>
+            <div class="card-content-sub">9:40AM-3:00PM</div>
+          </div>
+          <div class="card-buttonset">
+            <div class="card-content-action">
+              <button soho-button="icon" icon="more" soho-context-menu menu="action-popupmenu-3" trigger="click"
+                class="btn-actions"></button>
+            </div>
+          </div>
+        </div>
+        <div class="swipe-action-right">
+          <button id="action-right-continuous" class="btn-swipe-action-right">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-tack"></use>
+            </svg>
+            <span>Right Action</span>
+          </button>
+        </div>
+      </div>
+    </soho-card>
+    <ul soho-popupmenu id="action-popupmenu-3">
+      <li soho-popupmenu-item><a soho-popupmenu-label>Left Action</a></li>
+      <li soho-popupmenu-item><a soho-popupmenu-label>Right Action</a></li>
+      <li soho-popupmenu-item><a soho-popupmenu-label>Desktop Only Action</a></li>
+    </ul>
+  </div>
+</div>
+
+<div class="row">
+  <div class="six columns">
+    <span class="label" id="output">&nbsp;</span>
   </div>
 </div>

--- a/src/app/swipe-action/swipe-action.demo.html
+++ b/src/app/swipe-action/swipe-action.demo.html
@@ -1,0 +1,77 @@
+<div class="row top-padding">
+  <div class="six columns">
+    <span class="label">Swipe Action (Reveal)</span>
+    <soho-card ngClass="card-variant">
+      <div soho-swipe-action>
+        <div class="swipe-action-left">
+          <button id="action-left-reveal" class="btn-swipe-action-left">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-reply"></use>
+            </svg>
+            <span>Left Action</span>
+          </button>
+        </div>
+        <div class="swipe-element">
+          <div class="card-content">
+            <div class="card-content-header">Tuesday, 21nd September</div>
+            <div class="card-content-sub">8:40AM-2:00PM</div>
+          </div>
+          <div class="card-buttonset">
+            <div class="card-content-action">
+              <button soho-button="icon" icon="more" soho-context-menu menu="action-popupmenu" trigger="click"
+                class="btn-actions"></button>
+            </div>
+          </div>
+        </div>
+        <div class="swipe-action-right">
+          <button id="action-right-reveal" class="btn-swipe-action-right">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-tack"></use>
+            </svg>
+            <span>Right Action</span>
+          </button>
+        </div>
+      </div>
+    </soho-card>
+    <ul soho-popupmenu id="action-popupmenu">
+      <li soho-popupmenu-item><a soho-popupmenu-label>Left Action</a></li>
+      <li soho-popupmenu-item><a soho-popupmenu-label>Right Action</a></li>
+      <li soho-popupmenu-item><a soho-popupmenu-label>Desktop Only Action</a></li>
+    </ul>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <span class="label">Swipe Action (Reveal / One Action)</span>
+    <soho-card ngClass="card-variant">
+      <div soho-swipe-action>
+        <div class="swipe-element">
+          <div class="card-content">
+            <div class="card-content-header">Wednesday, 22nd September</div>
+            <div class="card-content-sub">8:40AM-2:00PM</div>
+          </div>
+          <div class="card-buttonset">
+            <div class="card-content-action">
+              <button soho-button="icon" icon="more" soho-context-menu menu="action-popupmenu-2" trigger="click"
+                class="btn-actions"></button>
+            </div>
+          </div>
+        </div>
+        <div class="swipe-action-right">
+          <button id="action-right-reveal-one" class="btn-swipe-action-right">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-tack"></use>
+            </svg>
+            <span>Right Action</span>
+          </button>
+        </div>
+      </div>
+    </soho-card>
+    <ul soho-popupmenu id="action-popupmenu-2">
+      <li soho-popupmenu-item><a soho-popupmenu-label>Left Action</a></li>
+      <li soho-popupmenu-item><a soho-popupmenu-label>Right Action</a></li>
+      <li soho-popupmenu-item><a soho-popupmenu-label>Desktop Only Action</a></li>
+    </ul>
+  </div>
+</div>

--- a/src/app/swipe-action/swipe-action.demo.html
+++ b/src/app/swipe-action/swipe-action.demo.html
@@ -41,7 +41,7 @@
   </div>
 </div>
 
-<div class="row">
+<div class="row top-padding">
   <div class="six columns">
     <span class="label">Swipe Action (Reveal / One Action)</span>
     <soho-card ngClass="card-variant">
@@ -76,7 +76,7 @@
   </div>
 </div>
 
-<div class="row">
+<div class="row top-padding">
   <div class="six columns">
     <span class="label">Swipe Action (Continuous)</span>
     <soho-card ngClass="card-variant">

--- a/src/app/swipe-action/swipe-action.demo.ts
+++ b/src/app/swipe-action/swipe-action.demo.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-swipe-action-demo',
+  templateUrl: 'swipe-action.demo.html'
+})
+export class SwipeActionDemoComponent {
+
+}

--- a/src/app/swipe-action/swipe-action.demo.ts
+++ b/src/app/swipe-action/swipe-action.demo.ts
@@ -1,9 +1,38 @@
-import { Component } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+} from '@angular/core';
 
 @Component({
   selector: 'app-swipe-action-demo',
   templateUrl: 'swipe-action.demo.html'
 })
-export class SwipeActionDemoComponent {
+export class SwipeActionDemoComponent implements AfterViewInit {
 
+  constructor(
+    private element: ElementRef,
+  ) { }
+
+  ngAfterViewInit() {
+    this.element.nativeElement.querySelector('#action-left-reveal').addEventListener('click', () => {
+      this.element.nativeElement.querySelector('#output').textContent = 'Left Action (Reveal Mode) was chosen';
+    });
+
+    this.element.nativeElement.querySelector('#action-right-reveal').addEventListener('click', () => {
+      this.element.nativeElement.querySelector('#output').textContent = 'Right Action (Reveal Mode) was chosen';
+    });
+
+    this.element.nativeElement.querySelector('#action-right-reveal-one').addEventListener('click', () => {
+      this.element.nativeElement.querySelector('#output').textContent = 'Right Action (Reveal Mode) was chosen';
+    });
+
+    this.element.nativeElement.querySelector('#action-left-continuous').addEventListener('click', () => {
+      this.element.nativeElement.querySelector('#output').textContent = 'Left Action (Continuous Mode) was chosen';
+    });
+
+    this.element.nativeElement.querySelector('#action-right-continuous').addEventListener('click', () => {
+      this.element.nativeElement.querySelector('#output').textContent = 'Right Action (Continuous Mode) was chosen';
+    });
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR implements Swipe Action Component Wrapper.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise-ng/issues/1164

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and start the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/swipe-action
- If in the browser, activate the device toolbar in chrome or try this on chrome with the magic mouse or on a ios / android device
- for the first one you swipe left or right
- click the button and you should see the text change indicating the swipe "clicked" the button
- for the second one you swipe only left
- click the button and you should see the text change indicating the swipe "clicked" the button
- for the third one one you swipe left or right
- you should see the text change indicating the swipe "clicked" the button immediately

**Included in this Pull Request**
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.