### PR TITLE
1150 - Fix on beforeRemove event in tag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,15 +1,14 @@
 # What's New with Enterprise-NG
 
-## v10.11.0
+## v10.11.0 Fixes
 
-- `[Placeholder]` TODO. ([#nnnn](https://github.com/infor-design/enterprise/issues/nnnn))
+- `[Tag]` Updated arguments and handler in tag events. ([#5562](https://github.com/infor-design/enterprise/issues/5562))
 
 ## v10.10.0
 
 - `[Calendar]` Added first day of the week parameter in calendar settings. ([#5775](https://github.com/infor-design/enterprise/issues/5775))
 - `[Datagrid]` Added vertical scroll event in datagrid. ([#1154](https://github.com/infor-design/enterprise/issues/1154))
 - `[Notification]` Added hide, hideLatest, and hideAll in notification service. ([#5562](https://github.com/infor-design/enterprise/issues/5562))
-- `[Tag]` Updated arguments and handler in tag events. ([#5562](https://github.com/infor-design/enterprise/issues/5562))
 
 ### 10.10.0 Fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Calendar]` Added first day of the week parameter in calendar settings. ([#5775](https://github.com/infor-design/enterprise/issues/5775))
 - `[Datagrid]` Added vertical scroll event in datagrid. ([#1154](https://github.com/infor-design/enterprise/issues/1154))
 - `[Notification]` Added hide, hideLatest, and hideAll in notification service. ([#5562](https://github.com/infor-design/enterprise/issues/5562))
+- `[Tag]` Updated arguments and handler in tag events. ([#5562](https://github.com/infor-design/enterprise/issues/5562))
 
 ### 10.10.0 Fixes
 

--- a/projects/ids-enterprise-ng/src/lib/tag/soho-tag.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tag/soho-tag.component.ts
@@ -70,20 +70,24 @@ export class SohoTagListComponent implements AfterViewInit, OnDestroy {
 
       // Add event handlers for the outer tag list.
       this.jQueryElement
-        .on('aftertagremove', (e: JQuery.TriggeredEvent) => this.onAfterTagRemove(e));
+        .on('aftertagremove', (e: JQuery.TriggeredEvent, tag: SohoTag) => this.onAfterTagRemove(e, tag));
       this.jQueryElement
-        .on('beforetagremove', (e: JQuery.TriggeredEvent) => this.onBeforeTagRemove(e));
+        .on('beforetagremove', (e: JQuery.TriggeredEvent, tag: SohoTag) => this.onBeforeTagRemove(e, tag));
     });
   }
 
-  private onAfterTagRemove(e: JQuery.TriggeredEvent) {
-    this.ngZone.run(() =>
-      this.afterRemove.next(e));
+  private onAfterTagRemove(e: SohoTagAfterRemoveEvent, tag: SohoTag) {
+    this.ngZone.run(() => {
+      e.tag = tag;
+      this.afterRemove.next(e)
+    });
   }
 
-  private onBeforeTagRemove(e: JQuery.TriggeredEvent) {
-    this.ngZone.run(() =>
-      this.beforeRemove.next(e));
+  private onBeforeTagRemove(e: SohoTagBeforeRemoveEvent, tag: SohoTag) {
+    this.ngZone.run(() => {
+      e.tag = tag;
+      this.beforeRemove.next(e);
+    });
   }
 
 
@@ -220,16 +224,23 @@ export class SohoTagComponent implements AfterViewInit, OnDestroy {
 
       // @todo - add event binding control so we don't bind if not required.
       // this.jQueryElement
+      const tagElem = this.tag?.element;
+      const parent = tagElem ? jQuery(tagElem).parent() : null;
 
       this.jQueryElement
-        .on('beforetagremove', (e: JQuery.TriggeredEvent, element: HTMLElement) => this.onBeforeTagRemove(e, element))
         .on('click', (e: JQuery.TriggeredEvent) => this.onClick(e));
+      
+      if (parent) {
+        parent.on('beforetagremove', (e: JQuery.TriggeredEvent, tag: SohoTag) => this.onBeforeTagRemove(e, tag));
+      }
     });
   }
 
-  private onBeforeTagRemove(event: JQuery.TriggeredEvent, _element: HTMLElement) {
-    this.ngZone.run(() =>
-      this.beforeTagRemove.next(event));
+  private onBeforeTagRemove(event: SohoTagBeforeRemoveEvent, tag: SohoTag) {
+    this.ngZone.run(() => {
+      event.tag = tag;
+      this.beforeTagRemove.next(event)
+    });
   }
 
   private onClick(event: JQuery.TriggeredEvent) {

--- a/projects/ids-enterprise-typings/lib/tag/soho-tag.d.ts
+++ b/projects/ids-enterprise-typings/lib/tag/soho-tag.d.ts
@@ -39,9 +39,13 @@ interface SohoTag {
   destroy(): void;
 }
 
-interface SohoTagBeforeRemoveEvent extends JQuery.TriggeredEvent {}
+interface SohoTagBeforeRemoveEvent extends JQuery.TriggeredEvent {
+  tag?: SohoTag;
+}
 
-interface SohoTagAfterRemoveEvent extends JQuery.TriggeredEvent {}
+interface SohoTagAfterRemoveEvent extends JQuery.TriggeredEvent {
+  tag?: SohoTag;
+}
 
 interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
   tag(options?: SohoTagOptions): JQuery;

--- a/src/app/tag/tag.demo.html
+++ b/src/app/tag/tag.demo.html
@@ -13,6 +13,10 @@
 
       <br/>
 
+      <div soho-tag-list>
+        <a href="#" soho-tag="secondary" [isDismissible]="true" (beforeTagRemove)="beforeRemoveSolo($event)">#Solo Tag</a>
+      </div>
+
       <div soho-tag-list (afterRemove)="afterRemove($event)" (beforeRemove)="beforeRemove($event)">
         <a href="#" soho-tag="secondary" [isDismissible]="true">#Administrative Assistant</a>
         <a href="#" soho-tag="secondary" [isDismissible]="true">#Office Manager </a>

--- a/src/app/tag/tag.demo.ts
+++ b/src/app/tag/tag.demo.ts
@@ -13,11 +13,15 @@ export class TagDemoComponent implements OnInit {
   }
 
   afterRemove(e: any) {
-    alert(`afterRemove`);
+    alert(`afterRemove ${e.tag.settings.content}`);
   }
 
   beforeRemove(e: any) {
-    alert(`beforeRemove`);
+    alert(`beforeRemove ${e.tag.settings.content}`);
+  }
+
+  beforeRemoveSolo(e: any) {
+    alert(`beforeRemove (solo) ${e.tag.settings.content}`);
   }
 
   onClick(e: any) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Tag should emit beforeRemove event on click. Also added the tag element in the arguments passed for before and after remove events to know which tag was removed.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1150 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/tags
- Remove tags in the second and third tag list
- Alert should pop up indicating the event emitted and the tag content

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
