### PR TITLE
1208 - Added isVerticalScrollToEnd property in datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v13.1.0
 
+### 13.1.0 Features
+
+- `[Datagrid]` Added isVerticalScrollToEnd property in datagrid. ([#1208](https://github.com/infor-design/enterprise/issues/1208))
+
 ### 13.1.0 Fixes
 
 - `[General]` Placeholder for next version. ([#1170](https://github.com/infor-design/enterprise/issues/1170))

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -267,6 +267,14 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
     return this._gridOptions.cellNavigation;
   }
 
+  get isVerticalScrollToEnd(): boolean | undefined {
+    if (this.datagrid) {
+      return (this.datagrid as any).isVerticalScrollToEnd;
+    }
+
+    return false;
+  }
+
   /**
    * Changes the row navigation setting of the data grid. If rowNavigation
    * is "false” then a border is not displayed around the row.

--- a/src/app/datagrid/datagrid-vertical-scroll-to-end.demo.ts
+++ b/src/app/datagrid/datagrid-vertical-scroll-to-end.demo.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { SohoDataGridComponent, SohoToastService } from 'ids-enterprise-ng';
 import { CODE_BLOCK_DATA } from '../demodata/code-block-data';
 
 @Component({
@@ -7,22 +8,26 @@ import { CODE_BLOCK_DATA } from '../demodata/code-block-data';
     styleUrls: ['../code-block/code-block.formatter.css']
 })
 export class DataGridVerticalScrollDemoComponent {
-public columns: SohoDataGridColumn[] = [
+  @ViewChild(SohoDataGridComponent, { static: true }) datagrid?: SohoDataGridComponent;
+
+  private position: SohoToastPosition = SohoToastService.TOP_RIGHT;
+
+  public columns: SohoDataGridColumn[] = [
     { id: 'companyId', name: 'Company', field: 'companyId', width: 200},
     { id: 'companyName', name: 'Name', field: 'companyName', width: 200}
   ];
 
   public data = CODE_BLOCK_DATA;
 
-  constructor() {}
+  constructor(private toastService: SohoToastService) {}
 
   onVerticalScroll(_args: any) {
-    if (_args.percent  >= 90 && _args.percent < 100) {
+    if (_args.percent  >= 95 && _args.percent < 100) {
       console.log( `${_args.percent}% scrolled, Almost there!`);
-    } else if (_args.percent === 100){
-      console.log( `${_args.percent}% scrolled. Hooray! You reached the bottom of the list!`);
-    } else {
+    } else if (_args.percent < 100) {
       console.log( `${_args.percent}% scrolled`);
+    } else if (this.datagrid && this.datagrid.isVerticalScrollToEnd) {
+      this.toastService.show({ title: 'Vertical Scroll End', message: 'Hooray! You reached the bottom of the list!' });
     }
   }
 

--- a/src/app/datagrid/datagrid-vertical-scroll-to-end.demo.ts
+++ b/src/app/datagrid/datagrid-vertical-scroll-to-end.demo.ts
@@ -22,7 +22,7 @@ export class DataGridVerticalScrollDemoComponent {
   constructor(private toastService: SohoToastService) {}
 
   onVerticalScroll(_args: any) {
-    if (_args.percent  >= 95 && _args.percent < 100) {
+    if (_args.percent  >= 90 && _args.percent < 100) {
       console.log( `${_args.percent}% scrolled, Almost there!`);
     } else if (_args.percent < 100) {
       console.log( `${_args.percent}% scrolled`);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added isVerticalScrollToEnd property in datagrid. Implementation is based on example page in IDS: https://github.com/infor-design/enterprise/blob/main/app/views/components/datagrid/example-vertical-scroll-to-end-event.html

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1208 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/datagrid-vertical-scroll
- Scroll to the end of the datagrid
- Toast should pop up when at end

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
