### PR TITLE
1200 - Bug fix on initial range values not showing correctly in datepicker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 13.1.0 Fixes
 
+- `[Datepicker]` Bug fix on initial range values in datepicker. ([#1200](https://github.com/infor-design/enterprise-ng/issues/1200))
 - `[Dropdown]` Updated readonly property to include readonly attr. ([#1189](https://github.com/infor-design/enterprise-ng/issues/1189))
 
 ### 13.1.0 Features

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -524,14 +524,12 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
       // The processing is required to ensure we use the correct format
       // in the control.
       if (typeof value === 'string' && this._options.range?.useRange) {
-        let startValue = this._options.range?.start;
+        const dates = value.split('-');
+        const startValue = new Date(dates[0]);
+        const endValue = new Date(dates[1]);
         
-        if (startValue && typeof startValue === 'string') {
-          startValue = new Date(startValue)
-        } else {
-          startValue = new Date(value.split('-')[0]);
-        }
-
+        (this.datepicker as any).settings.range.start = startValue;
+        (this.datepicker as any).settings.range.end = endValue;
         this.datepicker.setValue(startValue, false);
       } else {
         this.datepicker.setValue(value, false);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated range settings in datepicker API before setting the value. 

This fix will need a fix in IDS for it to work: https://github.com/infor-design/enterprise/pull/6089

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
- Pull branch: https://github.com/infor-design/enterprise/pull/6089
- Build IDS, use this version for angular
- Pull this branch, build and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datepicker
- "Date with Range (set via mode)" and "Date with Range (set via range)" should have initial values

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
