### PR TITLE
Fix description for datagrid removeRow

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `[Context Menu]` Context menu should appear even when dataset is updated in listview. ([#1119](https://github.com/infor-design/enterprise-ng/issues/1119))
 
+- `[Datagrid]` Fixed removeRow typing ([#1238](https://github.com/infor-design/enterprise-ng/issues/1238))
+
 ## v13.1.1
 
 ### 13.1.1 Fixes

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1513,13 +1513,13 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   /**
-   * Removes a row matching the data passed in from the data and grid.
+   * Removes a row matching the rowIndex passed in from the data and grid.
    *
-   * @param data the row of data to remove
+   * @param rowIndex the index of the row to remove.
    */
-  removeRow(data: any, noSync?: boolean, noTrigger?: boolean) {
+  removeRow(rowIndex: number, noSync?: boolean, noTrigger?: boolean) {
     this.ngZone.runOutsideAngular(() => {
-      this.datagrid?.removeRow(data, noSync, noTrigger);
+      this.datagrid?.removeRow(rowIndex, noSync, noTrigger);
     });
   }
 
@@ -2476,7 +2476,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   /**
    * Event fired after vertical scroll
    */
-   private onFilterOperatorChanged(args: SohoDataGridFilterOperatorChangedEvent) {
+  private onFilterOperatorChanged(args: SohoDataGridFilterOperatorChangedEvent) {
     this.ngZone.run(() => {
       this.filteroperatorchanged.next(args);
     })


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The removeRow typing is explained incorrectly, the function requires the index of the row wishing to be removed pass through, and not the data of the row wishing to be removed.

**Related github/jira issue (required)**:
Fixes #1238

**Steps necessary to review your pull request (required)**:
1. Build the project
2. Open datagrid-tab.demo.ts
3. Check typing is correct by creating a function and using removeRow
```Typescript
test() {
    this.datagrid?.removeRow
  }
```
