### PR TITLE
1215 - CAP cssClass setting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### 13.2.0 Fixes
 
-- `[Datagrid]` Added missing type for `doNotEmptyCellWhenEditing`. ([#5849](https://github.com/infor-design/enterprise/issues/5849))
+- `[ContextualActionPanel]` Added setting for cssClass in CAP. ([#1215](https://github.com/infor-design/enterprise-ng/issues/1215))
 - `[Context Menu]` Context menu should appear even when dataset is updated in listview. ([#1119](https://github.com/infor-design/enterprise-ng/issues/1119))
-
+- `[Datagrid]` Added missing type for `doNotEmptyCellWhenEditing`. ([#5849](https://github.com/infor-design/enterprise/issues/5849))
 - `[Datagrid]` Fixed removeRow typing ([#1238](https://github.com/infor-design/enterprise-ng/issues/1238))
 
 ## v13.1.1

--- a/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
@@ -131,6 +131,11 @@ export class SohoContextualActionPanelRef<T> {
         const cap = jQuery('div.contextual-action-panel.modal');
         cap.addClass(`${cssClass}`);
       });
+    } else {
+      this._options = $.extend(true, this._options, { cssClass: cssClass });
+      if (this.contextualactionpanel) {
+        this.contextualactionpanel.settings = this._options;
+      }
     }
 
     return this;

--- a/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
+++ b/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
@@ -32,6 +32,8 @@ interface SohoContextualActionPanelOptions {
   /** The string used as the title for the panel - not defaulted. */
   title?: string;
 
+  cssClass?: string;
+
   /** Settings to pass through to the modal */
   modalSettings?: SohoModalOptions;
 

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.html
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.html
@@ -5,6 +5,9 @@
       <button soho-button (click)="openPanel()" data-modal="contextual-action-modal-1">Panel</button>
     </div>
     <div class="field">
+      <button soho-button (click)="openPanelCSS()" data-modal="contextual-action-modal-1">Panel CSS</button>
+    </div>
+    <div class="field">
       <button soho-button (click)="tabsVertical()"  data-modal="contextual-action-modal-1">CAP - Tabs Vertical</button>
     </div>
     <div class="field">

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -111,6 +111,23 @@ export class ContextualActionPanelDemoComponent {
     }).open();
   }
 
+  openPanelCSS() {
+    if (!this.panelService || !this.placeholder) {
+      return;
+    }
+
+    this.panelRef = (this.panelService as any).contextualactionpanel(ContextualActionPanelComponent, this.placeholder)
+      .modalSettings({ title: this.title, useFlexToolbar: true })
+      .cssClass('my-custom-panel-test')
+      .open()
+      .initializeContent(true);
+
+    this.panelRef?.apply((ref: any) => {
+      ref.panelRef = this.panelRef;
+    }).open();
+  }
+
+
   openPanel2() {
     const buttons = [
       {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will added setting for cssClass option in CAP.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1215

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- Click the button `Open Panel CSS`
- Open `Developer Console`
- Inspect and Check to see `my-custom-panel-test` inside the CAP


**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

