### PR TITLE
F1215 - Follow up for CAP Modal CSS

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/contextual-action-panel/soho-contextual-action-panel.ref.ts
@@ -132,9 +132,9 @@ export class SohoContextualActionPanelRef<T> {
         cap.addClass(`${cssClass}`);
       });
     } else {
-      this._options = $.extend(true, this._options, { cssClass: cssClass });
+      this._options.modalSettings = $.extend(true, this._options.modalSettings, { cssClass: cssClass });
       if (this.contextualactionpanel) {
-        this.contextualactionpanel.settings = this._options;
+        this.contextualactionpanel.settings.modalSettings = this._options.modalSettings;
       }
     }
 

--- a/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
+++ b/projects/ids-enterprise-typings/lib/contextual-action-panel/soho-contextual-action-panel.d.ts
@@ -32,8 +32,6 @@ interface SohoContextualActionPanelOptions {
   /** The string used as the title for the panel - not defaulted. */
   title?: string;
 
-  cssClass?: string;
-
   /** Settings to pass through to the modal */
   modalSettings?: SohoModalOptions;
 

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.html
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.html
@@ -5,7 +5,13 @@
       <button soho-button (click)="openPanel()" data-modal="contextual-action-modal-1">Panel</button>
     </div>
     <div class="field">
-      <button soho-button (click)="openPanelCSS()" data-modal="contextual-action-modal-1">Panel CSS</button>
+      <button soho-button (click)="openPanelCSSBeforeOpen()" data-modal="contextual-action-modal-1">Panel CSS Before Open</button>
+    </div>
+    <div class="field">
+      <button soho-button (click)="openPanelCSSAfterOpen()" data-modal="contextual-action-modal-1">Panel CSS After Open</button>
+    </div>
+    <div class="field">
+      <button soho-button (click)="openPanelCSSModalSettings()" data-modal="contextual-action-modal-1">Panel CSS with Modal Settings</button>
     </div>
     <div class="field">
       <button soho-button (click)="tabsVertical()"  data-modal="contextual-action-modal-1">CAP - Tabs Vertical</button>

--- a/src/app/contextual-action-panel/contextual-action-panel.demo.ts
+++ b/src/app/contextual-action-panel/contextual-action-panel.demo.ts
@@ -111,15 +111,46 @@ export class ContextualActionPanelDemoComponent {
     }).open();
   }
 
-  openPanelCSS() {
+  openPanelCSSBeforeOpen() {
     if (!this.panelService || !this.placeholder) {
       return;
     }
 
     this.panelRef = (this.panelService as any).contextualactionpanel(ContextualActionPanelComponent, this.placeholder)
-      .modalSettings({ title: this.title, useFlexToolbar: true })
+      .modalSettings({ title: 'Open Panel CSS Before Open', useFlexToolbar: true })
+      .cssClass('my-custom-panel-before-open')
       .open()
-      .cssClass('my-custom-panel-test')
+      .initializeContent(true);
+
+    this.panelRef?.apply((ref: any) => {
+      ref.panelRef = this.panelRef;
+    }).open();
+  }
+
+  openPanelCSSAfterOpen() {
+    if (!this.panelService || !this.placeholder) {
+      return;
+    }
+
+    this.panelRef = (this.panelService as any).contextualactionpanel(ContextualActionPanelComponent, this.placeholder)
+      .modalSettings({ title: 'Open Panel CSS After Open', useFlexToolbar: true })
+      .open()
+      .cssClass('my-custom-panel-after-open')
+      .initializeContent(true);
+
+    this.panelRef?.apply((ref: any) => {
+      ref.panelRef = this.panelRef;
+    }).open();
+  }
+
+  openPanelCSSModalSettings() {
+    if (!this.panelService || !this.placeholder) {
+      return;
+    }
+
+    this.panelRef = (this.panelService as any).contextualactionpanel(ContextualActionPanelComponent, this.placeholder)
+      .modalSettings({ title: this.title, useFlexToolbar: true, cssClass: 'my-custom-panel-modal-settings' })
+      .open()
       .initializeContent(true);
 
     this.panelRef?.apply((ref: any) => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR is a follow up fix for [#1215.](https://github.com/infor-design/enterprise-ng/issues/1215)

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1215

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- Notice there are three `Panel CSS` Buttons. This leads to different calls of cssClass() and modalSettings
- `Panel CSS Before Open` calls the .cssClass() before open()
- `Panel CSS After Open` calls the .cssClass() after open()
- `Panel CSS with Modal Settings` is the cssClass put inside the `modalSettings`
- Open `Developer Console`
- Inspect and Check to see `my-custom-panel-before-open` inside the CAP if you click the `Panel CSS Before Open`
- Inspect and Check to see `my-custom-panel-after-open` inside the CAP if you click the `Panel CSS After Open`
- Inspect and Check to see `my-custom-panel-modal-settings` inside the CAP if you click the `Panel CSS with Modal Settings`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

