### PR TITLE
1256 - Datepicker not clearing field using clear button

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 13.4.0 Fixes
 
-- `[Datepicker]` Fix datepicker presentation and clearing datepicker with range dates using the clear button. ([#1256](https://github.com/infor-design/enterprise-ng/issues/1256))
+- `[Datepicker]` Fixed datepicker presentation and clearing datepicker with range dates using the clear button. ([#1256](https://github.com/infor-design/enterprise-ng/issues/1256))
 - `[Placeholder]` Fill me in. ([#6242](https://github.com/infor-design/enterprise/issues/6242))
 
 ## v13.3.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### 13.4.0 Fixes
 
 - `[Datepicker]` Fixed datepicker presentation and clearing datepicker with range dates using the clear button. ([#1256](https://github.com/infor-design/enterprise-ng/issues/1256))
-- `[Placeholder]` Fill me in. ([#6242](https://github.com/infor-design/enterprise/issues/6242))
 
 ## v13.3.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 13.4.0 Fixes
 
-- `[Datepicker]` Fixes datepicker presentation and clearing datepicker with range dates using the clear button. ([#1256](https://github.com/infor-design/enterprise-ng/issues/1256))
+- `[Datepicker]` Fix datepicker presentation and clearing datepicker with range dates using the clear button. ([#1256](https://github.com/infor-design/enterprise-ng/issues/1256))
 - `[Placeholder]` Fill me in. ([#6242](https://github.com/infor-design/enterprise/issues/6242))
 
 ## v13.3.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### 13.4.0 Fixes
 
-- `[Placeholder]` Fill me in. ([#6242](https://github.com/infor-design/enterprise-ng/issues/6242))
+- `[Datepicker]` Fixes datepicker presentation and clearing datepicker with range dates using the clear button. ([#1256](https://github.com/infor-design/enterprise-ng/issues/1256))
+- `[Placeholder]` Fill me in. ([#6242](https://github.com/infor-design/enterprise/issues/6242))
 
 ## v13.3.0
 

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -396,8 +396,8 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
    * Public API
    */
 
-  public setValue(value: string | Date | number | string[]) {
-    this.datepicker?.setValue(value, true);
+  public setValue(value: string | Date | number | string[], trigger: boolean, isTime: boolean) {
+    this.datepicker?.setValue(value, trigger, isTime);
   }
 
   public getValue(asDate: boolean = false): string | Date | number | string[] {
@@ -527,7 +527,7 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
         const dates = value.split('-');
         const startValue = new Date(dates[0]);
         const endValue = new Date(dates[1]);
-        
+
         (this.datepicker as any).settings.range.start = startValue;
         (this.datepicker as any).settings.range.end = endValue;
         this.datepicker.setValue(startValue, false);

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
@@ -412,7 +412,7 @@ describe('Soho Datepicker Unit Tests', () => {
     const dateWithoutTime = getDateWithoutTime(date);
 
     expect(Soho.Locale.currentLocale.name).toEqual('en-US');
-    comp.datepicker?.setValue(date);
+    comp.datepicker?.setValue(date, true, false);
 
     fixture.detectChanges();
 

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.spec.ts
@@ -268,7 +268,7 @@ describe('Soho Datepicker Unit Tests', () => {
     //   expect(x).toBe(date, 'Incorrect value passed to event');
     // });
     expect(Soho.Locale.currentLocale.name).toEqual('en-US');
-    comp.datepicker?.setValue(date);
+    comp.datepicker?.setValue(date, true, false);
 
     fixture.detectChanges();
 
@@ -389,7 +389,7 @@ describe('Soho Datepicker Unit Tests', () => {
     const dateWithoutTime = getDateWithoutTime(date);
 
     expect(Soho.Locale.currentLocale.name).toEqual('en-US');
-    comp.datepicker?.setValue(date);
+    comp.datepicker?.setValue(date, true, false);
 
     fixture.detectChanges();
 
@@ -435,7 +435,7 @@ describe('Soho Datepicker Unit Tests', () => {
     const dateWithoutTime = getDateWithoutTime(date);
 
     expect(Soho.Locale.currentLocale.name).toEqual('en-US');
-    comp.datepicker?.setValue(date);
+    comp.datepicker?.setValue(date, true, false);
 
     fixture.detectChanges();
 

--- a/projects/ids-enterprise-typings/lib/datepicker/soho-datepicker.d.ts
+++ b/projects/ids-enterprise-typings/lib/datepicker/soho-datepicker.d.ts
@@ -187,7 +187,7 @@ interface SohoDatePickerStatic {
   getCurrentDate(): Date;
 
   // Sets the value of the date picker.
-  setValue(value: Date | string | string[] | number, trigger?: boolean): void;
+  setValue(value: Date | string | string[] | number, trigger?: boolean, isTime?: boolean): void;
 
   readonly(): void;
 

--- a/src/app/datagrid/datagrid-angular-editor.demo.ts
+++ b/src/app/datagrid/datagrid-angular-editor.demo.ts
@@ -226,7 +226,7 @@ export class DemoCellDatePickerEditorComponent implements SohoDataGridCellEditor
 
   val(value?: any) {
     if (value) {
-      this.datePicker?.setValue(value);
+      this.datePicker?.setValue(value, true, false);
     }
     return this.datePicker?.getValue();
   }

--- a/src/app/datepicker/datepicker.demo.html
+++ b/src/app/datepicker/datepicker.demo.html
@@ -5,6 +5,10 @@
         <label for="statechange" class="label">State Change</label>
         <input soho-datepicker name="statechange" dateFormat="MM/dd/yyyy" mode="standard" placeholder="MM/dd/yyyy" [(ngModel)]="model.standard" (change)="onChange($event)"/>
       </div>
+      <div class="field">
+        <label for="statechange" class="label">State Change</label>
+        <input soho-datepicker name="range2" dateFormat="MM/dd/yyyy" mode="standard" placeholder="MM/dd/yyyy" [range]="rangeOptions" [(ngModel)]="model.range2" (change)="onChange($event)" class="input-mm"/>
+      </div>
       <div>
         <button soho-button [disabled]="datepickerReadOnly" (click)="setReadonly()">Read Only</button>
         <button soho-button [disabled]="datepickerDisabled" (click)="setDisable()">Disable</button>

--- a/src/app/datepicker/datepicker.demo.html
+++ b/src/app/datepicker/datepicker.demo.html
@@ -2,12 +2,12 @@
   <div class="row top-padding">
     <div class="eight columns">
       <div class="field">
-        <label for="statechange" class="label">State Change</label>
+        <label for="statechange" class="label">State Change - No Range</label>
         <input soho-datepicker name="statechange" dateFormat="MM/dd/yyyy" mode="standard" placeholder="MM/dd/yyyy" [(ngModel)]="model.standard" (change)="onChange($event)"/>
       </div>
       <div class="field">
-        <label for="statechange" class="label">State Change</label>
-        <input soho-datepicker name="range2" dateFormat="MM/dd/yyyy" mode="standard" placeholder="MM/dd/yyyy" [range]="rangeOptions" [(ngModel)]="model.range2" (change)="onChange($event)" class="input-mm"/>
+        <label for="statechange" class="label">State Change - Range</label>
+        <input soho-datepicker name="statechangerange" dateFormat="MM/dd/yyyy" mode="standard" placeholder="MM/dd/yyyy" [range]="rangeOptions" [(ngModel)]="model.range2" (change)="onChange($event)" class="input-mm" #rangedate/>
       </div>
       <div>
         <button soho-button [disabled]="datepickerReadOnly" (click)="setReadonly()">Read Only</button>
@@ -23,6 +23,12 @@
   </div>
   <div class="row top-padding"></div>
   <div class="row">
+    <div class="twelve columns">
+      <div class="field">
+        <h2 class="fieldset-title">Datepicker Presentation</h2>
+        <h3>Note: This are not affected by the buttons above this example page.</h3>
+      </div>
+    </div>
     <div class="four columns">
       <div class="field">
         <label for="standard" class="label">Standard Date</label>

--- a/src/app/datepicker/datepicker.demo.ts
+++ b/src/app/datepicker/datepicker.demo.ts
@@ -82,7 +82,7 @@ export class DatepickerDemoComponent implements OnInit {
   }
 
   clear() {
-    this.model.standard = new Date(0);
+    this.datepicker?.setValue('', true, true);
   }
 
   onChange(event: SohoDatePickerEvent) {

--- a/src/app/datepicker/datepicker.demo.ts
+++ b/src/app/datepicker/datepicker.demo.ts
@@ -13,6 +13,7 @@ import { SohoDatePickerComponent } from 'ids-enterprise-ng';
 export class DatepickerDemoComponent implements OnInit {
 
   @ViewChild(SohoDatePickerComponent, { static: true }) datepicker?: SohoDatePickerComponent;
+  @ViewChild('rangedate', { static: true }) rdatepicker?: SohoDatePickerComponent;
 
   public model = {
     standard: new Date(),
@@ -83,6 +84,7 @@ export class DatepickerDemoComponent implements OnInit {
 
   clear() {
     this.datepicker?.setValue('', true, true);
+    this.rdatepicker?.setValue('', true, true);
   }
 
   onChange(event: SohoDatePickerEvent) {
@@ -91,17 +93,20 @@ export class DatepickerDemoComponent implements OnInit {
 
   setEnable() {
     (this.datepicker as any).disabled = false;
+    (this.rdatepicker as any).disabled = false;
     this.datepickerDisabled = (this.datepicker as any).disabled;
     this.datepickerReadOnly = (this.datepicker as any).readonly;
   }
 
   setDisable() {
     (this.datepicker as any).disabled = true;
+    (this.rdatepicker as any).disabled = true;
     this.datepickerDisabled = (this.datepicker as any).disabled;
   }
 
   setReadonly() {
     (this.datepicker as any).readonly = true;
+    (this.rdatepicker as any).readonly = true;
     this.datepickerReadOnly = (this.datepicker as any).readonly;
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix datepicker presentation and clearing datepicker with range dates using the clear button

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1256

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datepicker
- Notice there are now two state change date pickers, the one is for single date and the other one is for range date.
- Click the `Clear` button.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

