### PR TITLE
1295 - Fix expanded event

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 13.5.0 Fixes
 
-- `[Placeholder]` Add notes here. ([#1264](https://github.com/infor-design/enterprise-ng/issues/1264))
+- `[Tree]` The expanded and collapsed events were not working. ([#1294](https://github.com/infor-design/enterprise-ng/issues/1294))
 
 ## v13.4.0
 

--- a/projects/ids-enterprise-ng/src/lib/tree/soho-tree.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tree/soho-tree.component.ts
@@ -155,13 +155,13 @@ export class SohoTreeComponent implements AfterViewInit, OnInit, OnDestroy {
    * This event is fired when a node is expanded, the SohoTreeNode
    * expanded is passed in the argument passed to the handler.
    */
-  @Output() expand = new EventEmitter<SohoTreeEvent>();
+  @Output() expanded = new EventEmitter<SohoTreeEvent>();
 
   /**
    * This event is fired when a node is collapsed, the SohoTreeNode
    * collapsed is passed in the argument passed to the handler.
    */
-  @Output() collapse = new EventEmitter<SohoTreeEvent>();
+  @Output() collapsed = new EventEmitter<SohoTreeEvent>();
 
   /**
    * This event is fired when a node is selected, the SohoTreeNode
@@ -489,8 +489,8 @@ export class SohoTreeComponent implements AfterViewInit, OnInit, OnDestroy {
       .on('contextmenu', (_e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.contextmenu?.next(args))
       .on('selected', (_e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.selected.next(args))
       .on('unselected', (_e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.unselected.next(args))
-      .on('expand', (_e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.expand.next(args))
-      .on('collapse', (_e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.collapse.next(args))
+      .on('expanded', (_e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.expanded.next(args))
+      .on('collapsed', (_e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.collapsed.next(args))
       .on('sortstart', (_e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.sortstart.next(args))
       .on('sortend', (_e: JQuery.TriggeredEvent, args: SohoTreeEvent) => this.sortend.next(args))
       .on('menuselect', (_e: JQuery.Event, args: SohoTreeEvent) => this.menuselect.next(args))

--- a/src/app/tree/tree-service.demo.html
+++ b/src/app/tree/tree-service.demo.html
@@ -15,7 +15,7 @@
 <div class="row top-padding">
   <div class="twelve columns demo" role="main">
     <section soho-busyindicator class="scrollable">
-      <ul soho-tree (selected)="onSelected($event)" (expand)="onExpand($event)" (collapse)="onCollapse($event)"></ul>
+      <ul soho-tree (selected)="onSelected($event)" (expanded)="onExpanded($event)" (collapsed)="onCollapsed($event)"></ul>
     </section>
   </div>
 </div>

--- a/src/app/tree/tree-service.demo.ts
+++ b/src/app/tree/tree-service.demo.ts
@@ -59,13 +59,13 @@ export class TreeServiceDemoComponent {
     console.log('Tree Event: ${this.selected}');
   }
 
-  onCollapse(treeEvent: SohoTreeEvent) {
+  onCollapsed(treeEvent: SohoTreeEvent) {
     this.selected = treeEvent.data;
-    console.log('Tree Event: ${this.selected}');
+    console.log('Tree Event Collapsed: ${this.selected}');
   }
 
-  onExpand(treeEvent: SohoTreeEvent) {
+  onExpanded(treeEvent: SohoTreeEvent) {
     this.selected = treeEvent.data;
-    console.log('Tree Event: ${this.selected}');
+    console.log('Tree Event Expanded: ${this.selected}');
   }
 }

--- a/src/app/tree/tree-source.demo.html
+++ b/src/app/tree/tree-source.demo.html
@@ -18,8 +18,8 @@
     <section soho-busyindicator class="scrollable">
       <ul soho-tree
           (selected)="onSelected($event)"
-          (expand)="onExpand($event)"
-          (collapse)="onCollapse($event)"
+          (expanded)="onExpanded($event)"
+          (collapsed)="onCollapsed($event)"
           [source]="source.bind(this)">
       </ul>
     </section>

--- a/src/app/tree/tree-source.demo.ts
+++ b/src/app/tree/tree-source.demo.ts
@@ -67,14 +67,14 @@ export class TreeSourceDemoComponent implements AfterViewInit {
   }
 
   onSelected(treeEvent: SohoTreeEvent) {
-    console.log(`Tree Event: ${treeEvent.data}`);
+    console.log(`Tree Event Selected: ${treeEvent.data}`);
   }
 
-  onCollapse(treeEvent: SohoTreeEvent) {
-    console.log(`Tree Event: ${treeEvent.data}`);
+  onCollapsed(treeEvent: SohoTreeEvent) {
+    console.log(`Tree Event Collapsed: ${treeEvent.data}`);
   }
 
-  onExpand(treeEvent: SohoTreeEvent) {
-    console.log(`Tree Event: ${treeEvent.data}`);
+  onExpanded(treeEvent: SohoTreeEvent) {
+    console.log(`Tree Event Expanded: ${treeEvent.data}`);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an issue mentioned in the Teams chat with tree. The expanded and collapsed events where never named correctly.

**Related github/jira issue (required)**:
Fixes #1294 

**Steps necessary to review your pull request (required)**:
- pull this branch
- build https://github.com/infor-design/enterprise/pull/6444 and put it in node_modules/ids-enterprise
- `npm run build:lib` and `npm run start`
- go to http://localhost:4200/ids-enterprise-ng-demo/tree-source
- click node to expand -> check the console that the expanded and collapsed events fire
