### PR TITLE
1299 - Add missing row data

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 13.5.0 Fixes
 
+- `[Datagrid]` Add missing rowData for deselection in the selected event. ([#1299](https://github.com/infor-design/enterprise-ng/issues/1299))
 - `[Text Area]` Parameters can be updated dynamically. ([#1193](https://github.com/infor-design/enterprise-ng/issues/1193))
 - `[Tree]` The expanded and collapsed events were not working. ([#1294](https://github.com/infor-design/enterprise-ng/issues/1294))
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -2758,8 +2758,8 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
         .on('rowdeactivated', (_e: any, args: SohoDataGridRowDeactivatedEvent) => this.onRowDeactivated(args))
         .on('rowreorder', (_e: any, args: SohoDataGridRowReorderedEvent) => this.onRowReordered(args))
         .on('selected',
-          (e: any, args: SohoDataGridSelectedRow[], type?: SohoDataGridSelectedEventType) =>
-            this.onSelected({ e, rows: args, type }))
+          (e: any, args: SohoDataGridSelectedRow[], type?: SohoDataGridSelectedEventType, rowData?: SohoDataGridSelectedRow[] | SohoDataGridSelectedRow) =>
+            this.onSelected({ e, rows: args, type, rowData }))
         .on('settingschanged', (_e: any, args: SohoDataGridSettingsChangedEvent) => this.onSettingsChanged(args))
         .on('sorted', (_e: any, args: SohoDataGridSortedEvent) => this.onSorted(args))
         .on('beforepaging', (_e: any, args: SohoPagerPagingInfo) => this.onBeforePaging(args))

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -1345,9 +1345,8 @@ type SohoDataGridSelectedEventType = 'deselectall' | 'selectall' | 'select' | 'd
 interface SohoDataGridSelectedEvent {
   e: JQuery.TriggeredEvent;
   rows: SohoDataGridSelectedRow[];
-
-  /** What was the action that caused the event? */
   type: SohoDataGridSelectedEventType;
+  rowData?: SohoDataGridSelectedRow[] | SohoDataGridSelectedRow;
 }
 
 interface SohoDataGridCellChangeEvent {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The rowData (used to see what row was deselected/unselected) was not included in the events. This is now added like it is in the enterprise code

**Related github/jira issue (required)**:
Fixes #1299 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-mixed-selection
- select a row and watch the console -> in this case rowData isnull
- select a second one -> in this case rowData is also null
- deselect a row -> in this case rowData should be filled in with the data of the row that was deselected
