### PR TITLE
1272 - Added test modal for time/datepicker

### DIFF
--- a/src/app/modal-dialog/modal-dialog-picker.component.html
+++ b/src/app/modal-dialog/modal-dialog-picker.component.html
@@ -1,0 +1,11 @@
+<div class="column">
+    <div class="field">
+        <label>Time</label>
+        <input soho-timepicker/>
+    </div>
+    <div class="field">
+        <label>Date</label>
+        <input soho-datepicker/>
+    </div>
+    <p>The popup should be in front of the modal</p>
+</div>

--- a/src/app/modal-dialog/modal-dialog-picker.component.ts
+++ b/src/app/modal-dialog/modal-dialog-picker.component.ts
@@ -1,0 +1,19 @@
+import {
+    Component,
+    ViewChild,
+    ViewContainerRef
+  } from '@angular/core';
+  import {
+    SohoModalDialogService
+  } from 'ids-enterprise-ng';
+  
+  /**
+   * This is an example of a dialog component with picker, that can be instantiated
+   * numerous times using the SohoModalDialogService.
+   */
+  @Component({
+    templateUrl: 'modal-dialog-picker.component.html'
+  })
+  export class ModalDialogPickerComponent {
+  }
+  

--- a/src/app/modal-dialog/modal-dialog.demo.html
+++ b/src/app/modal-dialog/modal-dialog.demo.html
@@ -8,6 +8,7 @@
       <button id="open-vetoable-btn" soho-button (click)="openVetoable()">Vetoable</button>
       <button id="open-dialog-result-btn" soho-button (click)="openDialogResult()">Dialog Result</button>
       <button id="open-dialog-datagrid-btn" soho-button (click)="openDialogDataGrid()">Dialog with DataGrid</button>
+      <button id="open-dialog-picker-btn" soho-button (click)="openDialogPicker()">Dialog with Picker</button>
     </div>
   </div>
 </div>

--- a/src/app/modal-dialog/modal-dialog.demo.module.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.module.ts
@@ -14,6 +14,7 @@ import { NestedModalDialogComponent } from './nested-modal-dialog.component';
 import { VetoableModalDialogComponent } from './vetoable-modal-dialog.component';
 import { ModalDialogDataGridComponent } from './modal-dialog-datagrid.component';
 import { FullSizeModalDialogComponent } from './example-fullsize-modal.component';
+import { ModalDialogPickerComponent } from './modal-dialog-picker.component';
 
 @NgModule({
     declarations: [
@@ -22,7 +23,8 @@ import { FullSizeModalDialogComponent } from './example-fullsize-modal.component
         ExampleModalDialogComponent,
         ModalDialogDemoComponent,
         VetoableModalDialogComponent,
-        ModalDialogDataGridComponent
+        ModalDialogDataGridComponent,
+        ModalDialogPickerComponent
     ],
     exports: [],
     imports: [

--- a/src/app/modal-dialog/modal-dialog.demo.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.ts
@@ -12,6 +12,7 @@ import { FullSizeModalDialogComponent } from './example-fullsize-modal.component
 import { NestedModalDialogComponent } from './nested-modal-dialog.component';
 import { VetoableModalDialogComponent } from './vetoable-modal-dialog.component';
 import { ModalDialogDataGridComponent } from './modal-dialog-datagrid.component';
+import { ModalDialogPickerComponent } from './modal-dialog-picker.component';
 
 @Component({
   selector: 'app-modal-dialog-demo',
@@ -196,7 +197,7 @@ export class ModalDialogDemoComponent {
       });
   }
 
-  public openDialogDataGrid() {
+  openDialogDataGrid() {
     const dialogRef = this.modalService
       .modal(ModalDialogDataGridComponent, this.placeholder)
       .buttons(
@@ -215,5 +216,18 @@ export class ModalDialogDemoComponent {
       .afterClose((result: any) => {
         this.closeResult = result;
       });
+  }
+
+  openDialogPicker() {
+    const dialogRef = this.modalService
+    .modal<ModalDialogPickerComponent>(ModalDialogPickerComponent, this.placeholder)
+    .title(this.title)
+    .buttons(
+      [{
+        text: 'Cancel', click: () => {
+          dialogRef.close();
+        }
+      }])
+    .open();
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added modal that includes date and time picker to test if popup appears in front of modal.

Requires this PR for the fix to work: https://github.com/infor-design/enterprise/pull/6479

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1272 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Update IDS
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/modal-dialog
- Click on "Dialog with Picker"
- Click on the date and time pickers
- Popup should be in front

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
