### PR TITLE
Empty string check on SohoDatagrid setter

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1203,7 +1203,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
    */
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input('soho-datagrid') set sohoDatagrid(datagridType: SohoDataGridType) {
-    this.datagridType = datagridType ? datagridType : SohoDataGridComponent.AUTO;
+    this.datagridType = datagridType && datagridType != '' ? datagridType : SohoDataGridComponent.AUTO;
   }
 
   // -------------------------------------------


### PR DESCRIPTION
For some reason, the setter doesn't return SohoDataGridComponent.AUTO when the datagridType is an empty string.

This returns an error that the datagridType cannot be an empty string:
`<div soho-datagrid [gridOptions]="dataGridOptions"></div>`

This works:
`<div soho-datagrid="auto" [gridOptions]="dataGridOptions"></div>`


