### PR TITLE
1312 - Add missing toggleRowDetail

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 13.5.0 Fixes
 
 - `[Datagrid]` Add missing rowData for deselection in the selected event. ([#1299](https://github.com/infor-design/enterprise-ng/issues/1299))
+- `[Datagrid]` Add missing toggleRowDetail function. ([#1312](https://github.com/infor-design/enterprise-ng/issues/1312))
 - `[Text Area]` Parameters can be updated dynamically. ([#1193](https://github.com/infor-design/enterprise-ng/issues/1193))
 - `[Tree]` The expanded and collapsed events were not working. ([#1294](https://github.com/infor-design/enterprise-ng/issues/1294))
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -2541,6 +2541,16 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
     });
   }
 
+  /**
+   * Expand Detail Row Or Tree Row
+   * @param {number} dataRowIndex The row to toggle
+   */
+  toggleRowDetail(dataRowIndex: number): void {
+    return this.ngZone.runOutsideAngular(() => {
+      return this.datagrid?.toggleRowDetail(dataRowIndex);
+    });
+  }
+
   // ------------------------------------------
   // Lifecycle Events
   // ------------------------------------------

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -1296,6 +1296,12 @@ interface SohoDataGridStatic {
   cellNode(row: number, cell: number, includeGroups: boolean): any;
 
   /**
+   * Expand Detail Row Or Tree Row
+   * @param {number} dataRowIndex The row to toggle
+   */
+  toggleRowDetail(dataRowIndex: number): void;
+
+  /**
    * Destructor,
    */
   destroy(): void;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A function `toggleRowDetail` is missing from the types so added it

**Related github/jira issue (required)**:
Fixes #1312

**Steps necessary to review your pull request (required)**:
- check inline or
- build and copy the dist folder to your apps node_modules
- and test the function