### PR TITLE
Change HTML order of soho-button

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/button/soho-button.component.html
+++ b/projects/ids-enterprise-ng/src/lib/button/soho-button.component.html
@@ -1,5 +1,5 @@
-<svg soho-icon *ngIf="hasIcon" [icon]="currentIcon" [extraIconClass]="extraIconClass"></svg>
 <span>
   <ng-content></ng-content>
 </span>
+<svg soho-icon *ngIf="hasIcon" [icon]="currentIcon" [extraIconClass]="extraIconClass"></svg>
 <ng-content select="div.disabled-tooltip"></ng-content>


### PR DESCRIPTION
Reorganized HTML structure of button to place the <span> for the button text in front of the <svg> tag. This is the order that the IDS jQuery library creates the button. Without this order, the notification badge is slightly off when setting to upper-right

**Related github/jira issue (required)**:
Fixes #1319 

**Steps necessary to review your pull request (required)**:
Before: 
![image](https://user-images.githubusercontent.com/6730716/172704235-e254e9fc-d3f9-4e95-96b4-6fe2dce3c1fd.png)

After:
![image](https://user-images.githubusercontent.com/6730716/172704268-8344759c-e34e-4e16-8727-a990d8ee0718.png)
