### PR TITLE
1274 - Datagrid: Shift-click on always selects the first row

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Button]` Rearrange button layout to fix notificationBadge alignment. ([#1319](https://github.com/infor-design/enterprise-ng/issues/1319))
 - `[Datagrid]` Updated example page to test if select all checkbox is updated. ([EP#6476](https://github.com/infor-design/enterprise/issues/6476))
 - `[Datagrid]` Add multiple rows method in datagrid. ([EP#6404](https://github.com/infor-design/enterprise/issues/6404))
+- `[Datagrid]` Fixed a bug where using shift-click to multiselect on datagrid with treeGrid setting = true selects from the first row until bottom row. ([#1274](https://github.com/infor-design/enterprise-ng/issues/1274))
 - `[Datepicker]` Fix a bug where datepicker is displaying NaN in french format. ([#1273](https://github.com/infor-design/enterprise-ng/issues/1273))
 - `[Datepicker]` Add missing events: listopened, listclosed, beforemonthrendered, monthrendered. ([#1324](https://github.com/infor-design/enterprise-ng/issues/1324))
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1192,6 +1192,22 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
     return this._gridOptions.enableTooltips;
   }
 
+  @Input() set selectChildren(selectChildren: boolean | undefined) {
+    this._gridOptions.selectChildren = selectChildren;
+    if (this.jQueryElement) {
+      (this.datagrid as any).settings.selectChildren = selectChildren;
+      this.markForRefresh('selectChildren', RefreshHintFlags.RenderRows);
+    }
+  }
+
+  get selectChildren(): boolean | undefined {
+    if (this.datagrid) {
+      return this.datagrid.settings.selectChildren;
+    }
+
+    return this._gridOptions.selectChildren;
+  }
+
   /**
    * Defines the source type of the grid, either:
    *

--- a/src/app/datagrid/datagrid-treegrid-lazy.demo.html
+++ b/src/app/datagrid/datagrid-treegrid-lazy.demo.html
@@ -10,6 +10,7 @@
              (expandrow)="onExpandRow($event)"
              (collapserow)="onCollapseRow($event)"
              selectable="multiple"
+             [selectChildren]="false"
              [onExpandChildren]="onExpandChildren"
              [treeGrid]="true"
              [columns]="columns"


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the bug where using shift-click to multi-select on Datagrid with treeGrid setting = true selects from the first row until the bottom row.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1274

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-treegrid-lazy
- Click on the row with id = 11
- Do a shift-click on the row with Id=14

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
