### PR TITLE
1333 - datagrid missing timeformat

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 14.2.0 Fixes
 
 - `[Button]` Added setting `iconAlign` for right side icon buttons. Fixed a regression where all buttons changed the icons to the right side instead of the left. ([#1340](https://github.com/infor-design/enterprise-ng/issues/1340))
+- `[Datagrid]` Added setting `timeFormat` for datagrid column model. ([#1333](https://github.com/infor-design/enterprise-ng/issues/1333))
 
 ## 14.1.2
 

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -907,6 +907,9 @@ interface SohoDataGridColumn {
   /** special display formatting for a numeric column */
   numberFormat?: SohoDataGridColumnNumberFormat;
 
+  /** specified time format for a time column */
+  timeFormat?: string;
+
   /** false = prevent user drag/drop this column order i.e. a drilldown column */
   reorderable?: boolean;
 
@@ -1307,7 +1310,7 @@ interface SohoDataGridStatic {
    * @param settings The settings you would like to modify.
    * @returns This component's API.
    */
-   updated(settings: SohoDataGridOptions): SohoDataGridStatic;
+  updated(settings: SohoDataGridOptions): SohoDataGridStatic;
 
   /**
    * Destructor,

--- a/src/app/datagrid/datagrid-editors.demo.ts
+++ b/src/app/datagrid/datagrid-editors.demo.ts
@@ -17,6 +17,7 @@ export const EDITORS_DATA: any[] = [
     price: 210.99,
     orderDate: '2015-01-01T06:00:00.000Z',
     action: 'Action',
+    time: '1:30:45 AM',
     favorite: true
   },
   {
@@ -26,6 +27,7 @@ export const EDITORS_DATA: any[] = [
     price: 209.99,
     orderDate: '2015-01-02T06:00:00.000Z',
     action: 'Action',
+    time: '2:00 AM',
     favorite: false
   },
   {
@@ -38,6 +40,7 @@ export const EDITORS_DATA: any[] = [
     status: 'Active',
     orderDate: '2015-01-03T06:00:00.000Z',
     action: 'Action',
+    time: '1:40:00 AM',
     favorite: true
   },
   {
@@ -49,6 +52,7 @@ export const EDITORS_DATA: any[] = [
     status: 'Inactive',
     orderDate: '2015-01-04T06:00:00.000Z',
     action: 'Action',
+    time: '5:00:45 PM',
     favorite: true
   },
   {
@@ -61,6 +65,7 @@ export const EDITORS_DATA: any[] = [
     status: 'Inactive',
     orderDate: '2015-01-05T06:00:00.000Z',
     action: 'Action',
+    time: '5:30 PM',
     favorite: false
   },
   {
@@ -73,6 +78,7 @@ export const EDITORS_DATA: any[] = [
     status: 'Inactive',
     orderDate: '2015-01-06T06:00:00.000Z',
     action: 'Action',
+    time: '1:30:45 AM',
     favorite: false
   },
   {
@@ -85,6 +91,7 @@ export const EDITORS_DATA: any[] = [
     status: 'On Hold',
     orderDate: '2015-01-07T06:00:00.000Z',
     action: 'Action',
+    time: '11:59:59 PM',
     favorite: true
   },
   {
@@ -97,6 +104,7 @@ export const EDITORS_DATA: any[] = [
     status: 'On Hold',
     orderDate: '2015-01-08T06:00:00.000Z',
     action: 'Action',
+    time: '1:31 PM',
     favorite: true
   },
   {
@@ -109,6 +117,7 @@ export const EDITORS_DATA: any[] = [
     status: 'On Hold',
     orderDate: '2015-01-09T06:00:00.000Z',
     action: 'Action',
+    time: '4:30 PM',
     favorite: false
   },
   {
@@ -121,6 +130,7 @@ export const EDITORS_DATA: any[] = [
     status: 'On Hold',
     orderDate: '2015-01-10T06:00:00.000Z',
     action: 'Action',
+    time: '10:28 PM',
     favorite: false
   }
 ];
@@ -231,6 +241,21 @@ export const EDITORS_COLUMNS: any[] = [
     filterType: 'number',
     width: 105,
     editor: Soho.Editors.Input,
+    required: true,
+    validate: 'required'
+  },
+
+  {
+    id: 'time',
+    name: 'Time',
+    field: 'time',
+    sortable: false,
+    // filterType: 'number',
+    width: 105,
+    formatter: Soho.Formatters.Time,
+    editor: Soho.Editors.Time,
+    editorOptions: { 'timeFormat': 'HH:mm:ss' },
+    timeFormat: 'HH:mm:ss',
     required: true,
     validate: 'required'
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will add missing `timeFormat` setting on datagrid column model.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1333

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-editors
- Check the `Time` field

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

