### PR TITLE
1347 - Notification Badges for Tertiary Icons

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 14.3.0 Fixes
 
+- `[Button]` Added notification badges for buttons with labels. ([#1347](https://github.com/infor-design/enterprise-ng/issues/1347))
+
 ## 14.2.0
 
 ### 14.2.0 Fixes

--- a/src/app/button/button-badge.demo.html
+++ b/src/app/button/button-badge.demo.html
@@ -3,13 +3,13 @@
 		<br>
     <br>
     <br>
-		<h1>Button Badge</h1>
+		<h1>Button with Notification Badge</h1>
 		<div class="row">
 			<div class="eight columns">
 				<br>
         <br>
         <br>
-				<span class="label">Notification Badge Icon</span>
+				<span class="label">Icon</span>
 				<button soho-button="icon" icon="calendar" [buttonOptions]="badgeOption1" title="Date">Date</button>
         <button soho-button="icon" icon="calendar" [buttonOptions]="badgeOption2" title="Date">Date</button>
         <button soho-button="icon" icon="calendar" [buttonOptions]="badgeOption3" title="Date">Date</button>
@@ -23,6 +23,14 @@
         <button soho-toolbar-flex-nav-button [buttonOptions]="badgeOption3"></button>
         <button soho-toolbar-flex-nav-button [buttonOptions]="badgeOption4"></button>
 				<br>
+        <br>
+        <br>
+        <span class="label">Tertiary</span>
+        <button soho-button="tertiary" icon="calendar" [buttonOptions]="badgeOption1">Action Label</button>
+        <button soho-button="tertiary" icon="calendar" [buttonOptions]="badgeOption2">Action Label</button>
+        <button soho-button="tertiary" icon="calendar" [buttonOptions]="badgeOption3">Action Label</button>
+        <button soho-button="tertiary" icon="calendar" [buttonOptions]="badgeOption4">Action Label</button>
+        <br>
         <br>
         <br>
 				<span class="label">Button Badge State</span>

--- a/src/app/button/button-badge.demo.ts
+++ b/src/app/button/button-badge.demo.ts
@@ -20,23 +20,23 @@ export class ButtonBadgeDemoComponent implements OnInit {
     notificationBadge: true,
     notificationBadgeOptions: {
       position: 'upper-left',
-      color: 'alert'
+      color: 'complete'
     }
   }
 
   public badgeOption2: SohoButtonOptions = {
     notificationBadge: true,
     notificationBadgeOptions: {
-      position: 'lower-left',
-      color: 'yield'
+      position: 'upper-right',
+      color: 'alert'
     }
   }
 
   public badgeOption3: SohoButtonOptions = {
     notificationBadge: true,
     notificationBadgeOptions: {
-      position: 'lower-right',
-      color: 'complete'
+      position: 'lower-left',
+      color: 'progress'
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will add a setting that will show and hide the calendar legend below

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1347

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/button-badge
- See the `Tertiary` Section

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

