### PR TITLE
1349 - popupmenu get selected

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 14.3.0 Fixes
 
 - `[Button]` Added notification badges for buttons with labels. ([#1347](https://github.com/infor-design/enterprise-ng/issues/1347))
+- `[Popupmenu]` Updated popupmenu demo for getSelected() example. ([#1349](https://github.com/infor-design/enterprise-ng/issues/1349))
 
 ## 14.2.0
 

--- a/src/app/popupmenu/popupmenu.demo.html
+++ b/src/app/popupmenu/popupmenu.demo.html
@@ -102,7 +102,7 @@
       <span>Words</span>
       <svg soho-icon icon="dropdown"></svg>
     </button>
-    <ul soho-popupmenu [isMultiselectable]="true" id="filter-options">
+    <ul soho-popupmenu [isMultiselectable]="true" id="filter-options" #popmenutrigger>
       <li
         soho-popupmenu-item
         *ngFor="let option of suiteOptions; let i = index"

--- a/src/app/popupmenu/popupmenu.demo.html
+++ b/src/app/popupmenu/popupmenu.demo.html
@@ -87,3 +87,35 @@
     </div>
   </div>
 </div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <span class="label">Popup Menu Get Selected</span>
+    <button
+      class="btn-menu"
+      soho-context-menu
+      menu="filter-options"
+      trigger="click"
+      (selected)="onClick($event)"
+    >
+      <svg class="project-sort-filter-icon" soho-icon icon="filter"></svg>
+      <span>Words</span>
+      <svg soho-icon icon="dropdown"></svg>
+    </button>
+    <ul soho-popupmenu [isMultiselectable]="true" id="filter-options">
+      <li
+        soho-popupmenu-item
+        *ngFor="let option of suiteOptions; let i = index"
+      >
+        <a [id]="'suiteValue' + i" soho-popupmenu-label>
+          {{ option }}
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+<div class="row">
+  <div class="twelve columns">
+    <button soho-button="primary" (click)="onClick()">Selected Items</button>
+  </div>
+</div>

--- a/src/app/popupmenu/popupmenu.demo.ts
+++ b/src/app/popupmenu/popupmenu.demo.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { SohoContextMenuDirective, SohoPopupMenuComponent } from 'ids-enterprise-ng';
+import { SohoPopupMenuComponent } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'app-popupmenu-demo',
@@ -23,20 +23,12 @@ export class PopupMenuDemoComponent implements OnInit {
 
   public suiteOptions: string[] = ['Hello', 'World', 'Team'];
 
-  @ViewChild(SohoPopupMenuComponent, { static: true })
+  @ViewChild('popmenutrigger', { static: true })
   public popupMenu!: SohoPopupMenuComponent;
 
-  @ViewChild(SohoContextMenuDirective, { static: true })
-  public contextMenu!: SohoContextMenuDirective;
-
-  ngOnInit(): void {
-    console.log(this.popupMenu);
-    console.log(this.contextMenu);
-  }
+  ngOnInit(): void { }
 
   public onClick($event?: any): void {
-    const popupMenuAPI: SohoPopupMenuComponent = (this.contextMenu as any).contextMenu;
-    console.log(`popupMenuAPI selected items`, popupMenuAPI.getSelected().length);
     console.log(`Popupmenu isMultiSelectable: ${this.popupMenu.isMultiselectable}`);
     console.log(`Popupmenu Selected: ${this.popupMenu.getSelected().length}`);
     console.log(`event: ${$event}`);

--- a/src/app/popupmenu/popupmenu.demo.ts
+++ b/src/app/popupmenu/popupmenu.demo.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { SohoContextMenuDirective, SohoPopupMenuComponent } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'app-popupmenu-demo',
@@ -19,6 +20,22 @@ export class PopupMenuDemoComponent {
     showAxis: false,
     autoScale: false,
   };
+
+  public suiteOptions: string[] = ['Hello', 'World', 'Team'];
+
+  @ViewChild(SohoPopupMenuComponent, { static: true })
+  public popupMenu!: SohoPopupMenuComponent;
+
+  @ViewChild(SohoContextMenuDirective, { static: true })
+  public contextMenu!: SohoContextMenuDirective;
+
+  public onClick($event?: any): void {
+    const popupMenuAPI: SohoPopupMenuComponent = (this.contextMenu as any).contextMenu;
+    console.log(`popupMenuAPI selected items`, popupMenuAPI.getSelected().length);
+    console.log(`Popupmenu isMultiSelectable: ${this.popupMenu.isMultiselectable}`);
+    console.log(`Popupmenu Selected: ${this.popupMenu.getSelected().length}`);
+    console.log(`event: ${$event}`);
+  }
 
   onMenu(item: number) {
     if (item === 3) {

--- a/src/app/popupmenu/popupmenu.demo.ts
+++ b/src/app/popupmenu/popupmenu.demo.ts
@@ -1,11 +1,11 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { SohoContextMenuDirective, SohoPopupMenuComponent } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'app-popupmenu-demo',
   templateUrl: 'popupmenu.demo.html',
 })
-export class PopupMenuDemoComponent {
+export class PopupMenuDemoComponent implements OnInit {
 
   public isInsertCommentDisabled = true;
   public isInsertNoteDisabled = true;
@@ -28,6 +28,11 @@ export class PopupMenuDemoComponent {
 
   @ViewChild(SohoContextMenuDirective, { static: true })
   public contextMenu!: SohoContextMenuDirective;
+
+  ngOnInit(): void {
+    console.log(this.popupMenu);
+    console.log(this.contextMenu);
+  }
 
   public onClick($event?: any): void {
     const popupMenuAPI: SohoPopupMenuComponent = (this.contextMenu as any).contextMenu;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in popupmenu where getSelected() is not working on multiselectable.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1349

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/popupmenu
- Hit the `Popup Menu` and select some items.
- Open `Developer Console`
- Hit the `Get Selected` Button
- See the Selected Items in the `Console`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

