### PR TITLE
Ep6773 - validation breaks enabling disabling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - `[Button]` Added notification badges for buttons with labels. ([#1347](https://github.com/infor-design/enterprise-ng/issues/1347))
 - `[Popupmenu]` Updated popupmenu demo for getSelected() example. ([#1349](https://github.com/infor-design/enterprise-ng/issues/1349))
+- `[Textarea]` Updated textarea demo for enabling disabling example. ([EP#6773](https://github.com/infor-design/enterprise/issues/6773))
 
 ## 14.2.0
 

--- a/src/app/textarea/textarea.demo.html
+++ b/src/app/textarea/textarea.demo.html
@@ -11,6 +11,12 @@
         </div>
         <br>
         <div class="field">
+          <label soho-label for="textToggle" class="label" [required]="true">Toggle</label>
+          <textarea soho-textarea name="textToggle" class="toggleText" data-validate="required" [(ngModel)]="model.toggleText" #toggleTextArea ></textarea>
+          <button soho-button (click)="toggleAccessibility()">Toggle</button>
+        </div>
+        <br>
+        <div class="field">
           <label for="counter" class="label">Counter</label>
           <textarea soho-textarea maxlength="90" name="counter" [(ngModel)]="model.counterText"></textarea>
         </div>

--- a/src/app/textarea/textarea.demo.ts
+++ b/src/app/textarea/textarea.demo.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit , ViewChild} from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 
 import { SohoTextAreaComponent } from 'ids-enterprise-ng';
 
@@ -10,6 +10,7 @@ import { SohoTextAreaComponent } from 'ids-enterprise-ng';
 export class TextareaDemoComponent implements OnInit {
 
   @ViewChild(SohoTextAreaComponent, { static: true }) textarea!: SohoTextAreaComponent;
+  @ViewChild('toggleTextArea', { static: true }) toggleTextArea!: SohoTextAreaComponent;
 
   public model = { // eslint-disable-line
     resizableText: 'This text is resizable',
@@ -18,26 +19,33 @@ export class TextareaDemoComponent implements OnInit {
     disableText: 'This text is disable',
     readonlyText: 'This text is readonly',
     modifiableText: 'This text is modifiable',
-     /* eslint-disable */
+    /* eslint-disable */
     growableText: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rutrum hendrerit nunc sed mollis. Quisque pharetra venenatis aliquam. Nullam egestas cursus odio eget viverra. Phasellus nec ipsum tincidunt, tincidunt nunc dapibus, mattis neque. Nulla sodales faucibus orci vitae scelerisque. Pellentesque consequat vulputate ligula. Nam nec diam sit amet leo  fringilla viverra in eget augue. Suspendisse porttitor odio bibendum nulla tristique congue a eget justo. Fusce eu tristique congue`,
-     /* eslint-enable */
+    /* eslint-enable */
     growableText2: `This text content cannot exceed 300px`,
-    editableText: 'Parameters can be updated'
+    editableText: 'Parameters can be updated',
+    toggleText: ''
   };
   public showModel = false;
+  public toggleTextDisabled = false;
   public textAreaDisabled = false;
   public textAreaReadOnly = false;
 
   public characterCounter = true;
-  public maxLength = 25 ;
+  public maxLength = 25;
   public charMaxText = this.getMaxText();
   public charRemainingText = this.getRemainingText();
 
   constructor() { }
-  ngOnInit() {}
+  ngOnInit() { }
 
   toggleModel() {
     this.showModel = !this.showModel;
+  }
+
+  toggleAccessibility() {
+    this.toggleTextDisabled = !this.toggleTextDisabled;
+    this.toggleTextArea.disabled = this.toggleTextDisabled;
   }
 
   setEnable() {
@@ -64,18 +72,18 @@ export class TextareaDemoComponent implements OnInit {
 
   }
 
-  changeText(){
+  changeText() {
     this.charRemainingText += '?';
     this.charMaxText += '!';
   }
 
-  changeLength(){
+  changeLength() {
     this.maxLength += 5;
     this.charMaxText = this.getMaxText();
     this.charRemainingText = this.getRemainingText();
   }
 
-  toggleCounter(){
+  toggleCounter() {
     this.characterCounter = !this.characterCounter;
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in textarea where validation breaks after enabling/disabling.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/6773

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/textarea
- Go Textarea named `Toggle`
- Focus the textarea and then click anywhere outside it to remove the focus. The validation error should now should up.
- Click the `Toggle` button and confirm the textarea is disabled.
- Click the `Toggle` button again to enable the textarea.
- Start typing in the textarea and notice that the validation is now okay.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

