### PR TITLE
6530 - Add ariaDescribedBy in typing definition

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - `[Button]` Added setting `iconAlign` for right side icon buttons. Fixed a regression where all buttons changed the icons to the right side instead of the left. ([#1340](https://github.com/infor-design/enterprise-ng/issues/1340))
 - `[Datagrid]` Added setting `timeFormat` for datagrid column model. ([#1333](https://github.com/infor-design/enterprise-ng/issues/1333))
+- `[Datagrid]` Added `ariaDescribedBy` setting in the datagrid column. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
 - `[Datepicker]` Fixes error when legend is set before the calendar is opened. ([#1345](https://github.com/infor-design/enterprise-ng/issues/1345))
 - `[Popdown]` Updated example page to test click outside event. ([#1304](https://github.com/infor-design/enterprise-ng/issues/1304))
 

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -580,6 +580,11 @@ interface SohoDataGridCellEditor {
   focus(): void;
 }
 
+type SohoDataGridAriaDescribedByFunction = (
+  row?: any,
+  cell?: any
+) => string;
+
 type SohoDataGridColumnEditorFunction = (
   row?: any,
   cell?: any,
@@ -954,6 +959,9 @@ interface SohoDataGridColumn {
 
   /** Adds an extra class to the header for formatting */
   headerCssClass?: string;
+
+  /** Adds the ability to set/override the aria-describedby attribute on the cells. */
+  ariaDescribedBy?: SohoDataGridAriaDescribedByFunction;
 
   /** Content visible function*/
   contentVisible?: SohoDataGridColumnContentVisibleFunction;

--- a/src/app/datagrid/datagrid-tab.demo.ts
+++ b/src/app/datagrid/datagrid-tab.demo.ts
@@ -116,7 +116,8 @@ export class DataGridTabDemoComponent {
       formatter: Soho.Formatters.Tree,
       expanded: 'expanded',
       width: 150,
-      filterType: 'text'
+      filterType: 'text',
+      ariaDescribedBy: (row, cell) => `id-row-${row}-header-${cell}`
     },
     {
       id: 'status', name: 'Status', field: 'status', width: 60,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds the ariaDescribedBy setting in the typing definition.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/6530
Related PR https://github.com/infor-design/enterprise/pull/6843

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Build the EP in this PR https://github.com/infor-design/enterprise/pull/6843 and put it on ids-enteprise under node_modules
- Build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-tab
- Check the `Create Tenant` cell
- It should have aria-describedby

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
