### PR TITLE
1399 - Example for "Frozen column header disappears on refresh"

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -109,6 +109,7 @@ import { DataGridEditorsDemoComponent } from './datagrid/datagrid-editors.demo';
 import { DataGridEmptyMessageDemoComponent } from './datagrid/datagrid-empty-message.demo';
 import { DataGridExportWithoutDataGridDemoComponent } from './datagrid/datagrid-export-without-datagrid.demo';
 import { DataGridFixedHeaderDemoComponent } from './datagrid/datagrid-fixedheader.demo';
+import { DataGridFrozenColumnRefreshDemoComponent } from "./datagrid/datagrid-frozen-column-refresh.demo";
 import { DataGridGroupableDemoComponent } from './datagrid/datagrid-groupable.demo';
 import { DataGridGroupedHeaderDemoComponent } from './datagrid/datagrid-grouped-header.demo';
 import { DataGridMixedSelectionDemoComponent } from './datagrid/datagrid-mixed-selection.demo';
@@ -368,6 +369,7 @@ import { DataGridRowSpanDemoComponent } from './datagrid/datagrid-rowspan.demo';
     DataGridEmptyMessageDemoComponent,
     DataGridExportWithoutDataGridDemoComponent,
     DataGridFixedHeaderDemoComponent,
+    DataGridFrozenColumnRefreshDemoComponent,
     DataGridGroupedHeaderDemoComponent,
     DataGridLookupDialogDemoComponent,
     DataGridLookupClickDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -76,6 +76,7 @@ import { DataGridEditorsDemoComponent } from './datagrid/datagrid-editors.demo';
 import { DataGridEmptyMessageDemoComponent } from './datagrid/datagrid-empty-message.demo';
 import { DataGridExportWithoutDataGridDemoComponent } from './datagrid/datagrid-export-without-datagrid.demo';
 import { DataGridFixedHeaderDemoComponent } from './datagrid/datagrid-fixedheader.demo';
+import { DataGridFrozenColumnRefreshDemoComponent } from './datagrid/datagrid-frozen-column-refresh.demo';
 import { DataGridGroupableDemoComponent } from './datagrid/datagrid-groupable.demo';
 import { DataGridGroupedHeaderDemoComponent } from './datagrid/datagrid-grouped-header.demo';
 import { DataGridMixedSelectionDemoComponent } from './datagrid/datagrid-mixed-selection.demo';
@@ -304,6 +305,7 @@ export const routes: Routes = [
   { path: 'datagrid-editors', component: DataGridEditorsDemoComponent },
   { path: 'datagrid-export-without-datagrid', component: DataGridExportWithoutDataGridDemoComponent },
   { path: 'datagrid-fixedheader', component: DataGridFixedHeaderDemoComponent },
+  { path: 'datagrid-frozen-column', component: DataGridFrozenColumnRefreshDemoComponent },
   { path: 'datagrid-groupedheader', component: DataGridGroupedHeaderDemoComponent },
   { path: 'datagrid-groupable', component: DataGridGroupableDemoComponent },
   { path: 'datagrid-mixed-selection', component: DataGridMixedSelectionDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -92,6 +92,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-empty-message']"><span>DataGrid - Empty Message</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-export-without-datagrid']"><span>DataGrid - Export without Datagrid</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-fixedheader']"><span>DataGrid - Fixed Header</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['datagrid-frozen-column']"><span>DataGrid - Frozen Column Refresh</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-groupedheader']"><span>DataGrid - Grouped Header</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-groupable']"><span>DataGrid - Groups</span></a></div>
 

--- a/src/app/datagrid/datagrid-frozen-column-refresh-demo.component.html
+++ b/src/app/datagrid/datagrid-frozen-column-refresh-demo.component.html
@@ -1,0 +1,17 @@
+<div class="row">
+  <div class="twelve columns" role="main">
+    <soho-toolbar>
+      <soho-toolbar-title>
+        <span soho-toolbar-section-title>Soho Data Grid - Frozen Column Refresh</span>
+      </soho-toolbar-title>
+
+      <soho-toolbar-button-set>
+        <button soho-button="icon" icon="refresh" id="validate-btn" class="btn-icon" title="Refresh" (click)="refresh()"></button>
+      </soho-toolbar-button-set>
+    </soho-toolbar>
+
+    <div soho-datagrid *ngIf="gridOptions" [gridOptions]="gridOptions"></div>
+  </div>
+</div>
+
+

--- a/src/app/datagrid/datagrid-frozen-column-refresh.demo.ts
+++ b/src/app/datagrid/datagrid-frozen-column-refresh.demo.ts
@@ -12,7 +12,7 @@ import { SohoDataGridComponent, } from 'ids-enterprise-ng';
 import { DataGridPagingIndeterminateDemoService } from './datagrid-paging-indeterminate-demo.service';
 
 @Component({
-  selector: 'datagrid-frozen-column-refresh-demo',
+  selector: 'soho-datagrid-frozen-column-refresh-demo',
   templateUrl: 'datagrid-frozen-column-refresh-demo.component.html',
   providers: [ DataGridPagingIndeterminateDemoService ],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/datagrid/datagrid-frozen-column-refresh.demo.ts
+++ b/src/app/datagrid/datagrid-frozen-column-refresh.demo.ts
@@ -1,0 +1,71 @@
+import {
+  AfterViewChecked,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  NgZone,
+  OnInit,
+  ViewChild
+} from '@angular/core';
+
+import { SohoDataGridComponent, } from 'ids-enterprise-ng';
+import { DataGridPagingIndeterminateDemoService } from './datagrid-paging-indeterminate-demo.service';
+
+@Component({
+  selector: 'datagrid-frozen-column-refresh-demo',
+  templateUrl: 'datagrid-frozen-column-refresh-demo.component.html',
+  providers: [ DataGridPagingIndeterminateDemoService ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DataGridFrozenColumnRefreshDemoComponent implements OnInit {
+  @ViewChild(SohoDataGridComponent) sohoDataGridComponent?: SohoDataGridComponent;
+
+  gridOptions: any = null;
+
+  constructor(
+    private changeDetectorRef: ChangeDetectorRef,
+    private ngZone: NgZone,
+    private datagridPagingService: DataGridPagingIndeterminateDemoService,
+  ) {}
+
+  ngOnInit(): void {
+    this.gridOptions = this.buildGridOptions();
+  }
+
+  private buildGridOptions(): SohoDataGridOptions {
+    return {
+      columns: this.datagridPagingService.getColumns(),
+      selectable: 'single',
+      paging: true,
+      pagesize: 25,
+      pagesizes: [ 5, 10, 25, 100 ],
+      indeterminate: true,
+      rowHeight: 'small',
+      sortable: false,
+      disableClientSort: true,
+      disableClientFilter: true,
+      filterable: true,
+      source: this.dataGridSource,
+      frozenColumns: {
+        left: ['productId', 'productName'],
+      },
+    } as SohoDataGridOptions;
+  }
+
+  private dataGridSource = (request: SohoDataGridSourceRequest, response: SohoDataGridResponseFunction) => {
+    this.datagridPagingService.getData(request).subscribe((result: any) => {
+      request.firstPage = result.firstPage;
+      request.lastPage = result.lastPage;
+
+      /* Put the data into the data grid */
+      this.ngZone.runOutsideAngular(() => response(result.data, request));
+      this.changeDetectorRef.markForCheck();
+    });
+  }
+
+  // Mock refresh
+  // Grid options are rebuilt on refresh in a real world application
+  public refresh() {
+    this.gridOptions = this.buildGridOptions();
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This example demonstrates the issue found in https://github.com/infor-design/enterprise-ng/issues/1399

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise-ng/issues/1399

**Steps necessary to review your pull request (required)**:
1. Checkout example at 1399-frozen-column-issue
2. Run ng serve
3. Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-frozen-column

