### PR TITLE
Publish property minify from enterprise to ng projects.

### DIFF
--- a/projects/ids-enterprise-typings/lib/locale/soho-locale.d.ts
+++ b/projects/ids-enterprise-typings/lib/locale/soho-locale.d.ts
@@ -85,6 +85,7 @@ interface SohoLocaleStatic {
   defaultLocales: any;
   supportedLocales: any;
   defaultLocale: string;
+  minify: boolean;
 
   /**
    * Internally stores a new culture file for future use.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
I want to solve the problem that's currently not possible to choose the minified cultures in Typescript. As setting the cultures path it should be possible to set which "version" of culture files is used like
```Typescript
Soho.Locale.culturesPath = 'assets/ids-enterprise/js/cultures/';
Soho.Locale.minify = true;
```

**Related github/jira issue (required)**:
See issue https://github.com/infor-cloud/m3-h5-sdk/issues/118 and PR https://github.com/infor-cloud/m3-h5-sdk/pull/149.

**Steps necessary to review your pull request (required)**:
This is a minimal change. The only question is if the property is more of a private one in enterprise project.
