### PR TITLE
Add missing built-in pager events to datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Datagrid]` Remove unnecessary role on datagrid. ([#1378](https://github.com/infor-design/enterprise-ng/issues/1378))
 - `[Datagrid]` Added Example Page for Add Row in Datagrid. ([EP#6730](https://github.com/infor-design/enterprise/issues/6730))
 - `[Pager]` Added dataset option in pager. ([#1389](https://github.com/infor-design/enterprise-ng/issues/1389))
+- `[Datagrid]` Added events from built-in pager. ([EP#1419](https://github.com/infor-design/enterprise-ng/issues/1419))
 
 ## 14.4.0
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -1281,6 +1281,21 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   sorted = new EventEmitter<SohoDataGridSortedEvent>();
 
   @Output()
+  nextPage = new EventEmitter<SohoPagerPagingInfo>();
+
+  @Output()
+  previousPage = new EventEmitter<SohoPagerPagingInfo>();
+
+  @Output()
+  firstPage = new EventEmitter<SohoPagerPagingInfo>();
+
+  @Output()
+  lastPage = new EventEmitter<SohoPagerPagingInfo>();
+
+  @Output()
+  pageSizeChange = new EventEmitter<SohoPagerPagingInfo>();
+
+  @Output()
   beforePaging = new EventEmitter<SohoPagerPagingInfo>();
 
   @Output()
@@ -2506,6 +2521,51 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   /**
+   * Event fired when using built-in pager to next page.
+   */
+  private onNextPage(args: SohoPagerPagingInfo) {
+    this.ngZone.run(() => {
+      this.nextPage.next(args);
+    });
+  }
+
+  /**
+     * Event fired when using built-in pager to previous page.
+     */
+  private onPreviousPage(args: SohoPagerPagingInfo) {
+    this.ngZone.run(() => {
+      this.previousPage.next(args);
+    });
+  }
+
+  /**
+     * Event fired when using built-in pager to first page.
+     */
+  private onFirstPage(args: SohoPagerPagingInfo) {
+    this.ngZone.run(() => {
+      this.firstPage.next(args);
+    });
+  }
+
+  /**
+     * Event fired when using built-in pager to last page.
+     */
+  private onLastPage(args: SohoPagerPagingInfo) {
+    this.ngZone.run(() => {
+      this.lastPage.next(args);
+    });
+  }
+
+  /**
+   * Event fired on paging size change
+   */
+  private onPageSizeChange(args: SohoPagerPagingInfo) {
+    this.ngZone.run(() => {
+      this.pageSizeChange.next(args);
+    });
+  }
+
+  /**
    * Event fired before paging
    */
   private onBeforePaging(args: SohoPagerPagingInfo) {
@@ -2803,6 +2863,11 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
         .on('afterpaging', (_e: any, args: SohoPagerPagingInfo) => this.onAfterPaging(args))
         .on('scroll', (_e: any, args: SohoDataGridScrollEvent) => this.onVerticalScroll(args))
         .on('filteroperatorchanged', (_e: any, args: SohoDataGridFilterOperatorChangedEvent) => this.onFilterOperatorChanged(args))
+        .on('nextpage', (_e: any, args: SohoPagerPagingInfo) => this.onNextPage(args))
+        .on('previouspage', (_e: any, args: SohoPagerPagingInfo) => this.onPreviousPage(args))
+        .on('firstpage', (_e: any, args: SohoPagerPagingInfo) => this.onFirstPage(args))
+        .on('lastpage', (_e: any, args: SohoPagerPagingInfo) => this.onLastPage(args))
+        .on('pagesizechange', (_e: any, args: SohoPagerPagingInfo) => this.onPageSizeChange(args))
     });
 
     // Initialise the SohoXi control.

--- a/src/app/datagrid/datagrid-paging-service.demo.html
+++ b/src/app/datagrid/datagrid-paging-service.demo.html
@@ -20,12 +20,18 @@
 
 <div class="row top-padding">
   <div class="twelve columns demo" role="main">
-    <div soho-datagrid
+    <div
+      soho-datagrid
       *ngIf="gridOptions"
       [gridOptions]="gridOptions"
       (rowClicked)="onRowClicked($event)"
       (beforePaging)="onBeforePaging($event)"
       (afterPaging)="onAfterPaging($event)"
+      (firstPage)="onFirstPage($event)"
+      (lastPage)="onLastPage($event)"
+      (nextPage)="onNextPage($event)"
+      (previousPage)="onPreviousPage($event)"
+      (pageSizeChange)="onPageSizeChange($event)"
       (settingsChanged)="onSettingsChanged($event)"
       (rendered)="onRendered($event)"
     ></div>

--- a/src/app/datagrid/datagrid-paging-service.demo.ts
+++ b/src/app/datagrid/datagrid-paging-service.demo.ts
@@ -114,4 +114,24 @@ export class DataGridPagingServiceDemoComponent implements OnInit {
   onAfterPaging(_event: SohoPagerPagingInfo) {
     console.log('onAfterPaging', _event);
   }
+
+  onFirstPage(_event: SohoPagerPagingInfo) {
+    console.log('onFirstPage', _event);
+  }
+
+  onLastPage(_event: SohoPagerPagingInfo) {
+    console.log('onLastPage', _event);
+  }
+
+  onNextPage(_event: SohoPagerPagingInfo) {
+    console.log('onNextPage', _event);
+  }
+
+  onPreviousPage(_event: SohoPagerPagingInfo) {
+    console.log('onPreviousPage', _event);
+  }
+
+  onPageSizeChange(_event: SohoPagerPagingInfo) {
+    console.log('onPageSizeChange', _event);
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The built-in pager on Datagrid's dont properly expose the emitted events, the current "beforePaging" and "afterPaging" events are only fired when there's a source added to the datagrid.

This requests exposes all the standard events that are exposed like the standalone-pager.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-ng/issues/1419

**Steps necessary to review your pull request (required)**:
1. Build the project
2. Go to "Datagrid Paging Service" example
3. Open console
4. Use the different paging buttons and see events being fired in console.

Extra steps:
You can also check it works without the source being attached to the datagrid, disable it by uncommenting it.
Then click the "Set Pager to Page Two" and use the paging buttons (Kind of a hacky way, but it's the easiest with fewest changes)