### PR TITLE
1423 - Datagrid Flex Toolbar Issue

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,8 +16,9 @@
 - `[Accordion]` Added example page to test accordion bug. ([EP#6820](https://github.com/infor-design/enterprise/issues/6820))
 - `[Datagrid]` Remove unnecessary role on datagrid. ([#1378](https://github.com/infor-design/enterprise-ng/issues/1378))
 - `[Datagrid]` Added Example Page for Add Row in Datagrid. ([EP#6730](https://github.com/infor-design/enterprise/issues/6730))
-- `[Pager]` Added dataset option in pager. ([#1389](https://github.com/infor-design/enterprise-ng/issues/1389))
 - `[Datagrid]` Added events from built-in pager. ([EP#1419](https://github.com/infor-design/enterprise-ng/issues/1419))
+- `[Datagrid]` Fixed a bug in datagrid where flex toolbar is not properly destroyed. ([#1423](https://github.com/infor-design/enterprise-ng/issues/1423))
+- `[Pager]` Added dataset option in pager. ([#1389](https://github.com/infor-design/enterprise-ng/issues/1389))
 
 ## 14.4.0
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -72,6 +72,7 @@ import { ContextMenuToggleDemoComponent } from './context-menu/context-menu-togg
 import { ContextMenuLazyLoadDemoComponent } from './context-menu/context-menu-lazy-load.demo';
 import { ContextualActionPanelDemoModule } from './contextual-action-panel/contextual-action-panel.demo.module';
 import { DataGridBreadcrumbDemoComponent } from './datagrid/datagrid-breadcrumb.demo';
+import { DataGridSandboxDemoComponent } from './datagrid/datagrid-sandbox.demo'
 import {
   DataGridAngularEditorDemoComponent,
   DemoCellInputEditorComponent,
@@ -353,6 +354,7 @@ import { DataGridRowSpanDemoComponent } from './datagrid/datagrid-rowspan.demo';
     ContextMenuToggleDemoComponent,
     ContextMenuLazyLoadDemoComponent,
     DataGridBreadcrumbDemoComponent,
+    DataGridSandboxDemoComponent,
     DataGridCardDemoComponent,
     DataGridAngularEditorDemoComponent,
     DataGridAngularFormatterDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -234,6 +234,7 @@ import { SearchFieldCategoryUpdateDemoComponent } from './searchfield/searchfiel
 import { ListBuilderDemoComponent } from './listbuilder/listbuilder.demo';
 import { MonthViewLegendDemoComponent } from './monthview/monthview-legend.demo';
 import { DataGridRowSpanDemoComponent } from './datagrid/datagrid-rowspan.demo';
+import { DataGridSandboxDemoComponent } from './datagrid/datagrid-sandbox.demo';
 
 export const routes: Routes = [
   { path: '', redirectTo: '', pathMatch: 'full' }, // default
@@ -297,6 +298,7 @@ export const routes: Routes = [
   { path: 'context-menu-toggle', component: ContextMenuToggleDemoComponent },
   { path: 'contextual-action-panel', component: ContextualActionPanelDemoComponent },
   { path: 'datagrid-breadcrumb', component: DataGridBreadcrumbDemoComponent },
+  { path: 'datagrid-sandbox', component: DataGridSandboxDemoComponent },
   { path: 'datagrid-dirty-indication', component: DataGridDirtyIndicationDemoComponent },
   { path: 'datagrid-dynamic', component: DataGridDynamicDemoComponent },
   { path: 'datagrid-add-row', component: DataGridAddRowDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -79,6 +79,7 @@
   <!-- D -->
   <div class="accordion-header"><a href="javascript:void(0);"><span>D</span></a></div>
   <div class="accordion-pane">
+    <div class="accordion-header list-item"><a [routerLink]="['datagrid-sandbox']"><span>DataGrid - Sandbox</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-add-row']"><span>DataGrid - Add Row</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-angular-editor']"><span>DataGrid - Angular Editors</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['datagrid-angular-formatter']"><span>DataGrid - Angular Formatters</span></a></div>

--- a/src/app/datagrid/datagrid-sandbox.demo.html
+++ b/src/app/datagrid/datagrid-sandbox.demo.html
@@ -1,0 +1,27 @@
+<div class="full-width full-height scrollable-flex">
+  <h2 class="fieldset-title">Soho Data Grid - Sandbox</h2>
+  <div class="field">
+    <button
+      soho-button="primary"
+      (click)="onClickGetDataset()"
+    >Get Dataset</button>
+  </div>
+  <br>
+  <div *ngIf="gridOptions$ | async as gridOptions">
+
+    <soho-toolbar-flex
+      maxVisibleButtons="5"
+      resizeContainers="true"
+      favorButtonset="true"
+    >
+
+    </soho-toolbar-flex>
+
+    <div
+      soho-datagrid="auto"
+      [gridOptions]="gridOptions"
+    >
+    </div>
+
+  </div>
+</div>

--- a/src/app/datagrid/datagrid-sandbox.demo.ts
+++ b/src/app/datagrid/datagrid-sandbox.demo.ts
@@ -1,0 +1,58 @@
+import { ChangeDetectionStrategy, Component, OnInit } from "@angular/core";
+
+import { combineLatest, map, Observable, startWith, Subject } from "rxjs";
+
+interface MyData {
+  displayName: string;
+}
+
+@Component({
+  selector: "app-datagrid-sandbox-demo",
+  templateUrl: "datagrid-sandbox.demo.html",
+  changeDetection: ChangeDetectionStrategy.Default,
+})
+export class DataGridSandboxDemoComponent implements OnInit {
+  defaultGridOptions = {
+    columns: [
+      {
+        id: "displayName",
+        name: "Name",
+        field: "displayName",
+        sortable: true,
+        formatter: Soho.Formatters.Ellipsis,
+      },
+    ],
+    dataset: [],
+  };
+
+  gridOptions$!: Observable<SohoDataGridOptions>;
+
+  dataset$ = new Subject<MyData[]>();
+
+  ngOnInit(): void {
+    const dataset$ = this.getDataset().pipe(startWith([]));
+    this.gridOptions$ = combineLatest([dataset$]).pipe(
+      map(([dataset]) => {
+        return {
+          ...this.defaultGridOptions,
+          dataset,
+          toolbar: { keywordFilter: true },
+        };
+      })
+    );
+  }
+
+  getDataset(): Observable<MyData[]> {
+    return this.dataset$;
+  }
+
+  onClickGetDataset(): void {
+    this.dataset$.next([
+      { displayName: "Hello" },
+      { displayName: "World" },
+      { displayName: "Foo" },
+      { displayName: "Bar" },
+      { displayName: "Zoo" },
+    ]);
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will add an example page in datagrid for flex toolbar.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1423

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-sandbox
- Open `Developer Console`
- Click `Get Dataset`
- Console should have no errors

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

