### PR TITLE
EP7051 - first tab being activated

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
@@ -597,6 +597,8 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
     // call outside the angular zone so change detection isn't triggered by the soho component.
     this.ngZone.runOutsideAngular(() => {
       const $liList = this.getTabLiList();
+      const $activateTab = this.getActivatedTab();
+
       if (!$liList) {
         return;
       }
@@ -617,6 +619,7 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
         this.tabCount = $liList.length;
         this.tabTitles = this.getTabTitles($liList);
         this.tabIds = tabIds;
+        this.activateTab($activateTab);
         return;
       }
 
@@ -625,6 +628,7 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
           this.tabs?.updated();
           this.tabIds = tabIds;
           this.tabTitles = this.getTabTitles($liList);
+          this.activateTab($activateTab);
           return;
         }
       }
@@ -679,6 +683,11 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
     return this.ngZone.runOutsideAngular(() => this.jQueryElement?.find('.tab-list').find('li'));
   }
 
+  private getActivatedTab(): JQuery | undefined {
+    // get the current selected tab outside of the angular zone
+    return this.ngZone.runOutsideAngular(() => this.jQueryElement?.find('.tab-list').find('li.is-selected'));
+  }
+
   private getTabIds(): Array<string> {
     // call outside the angular zone so change detection isn't triggered by the soho component.
     return this.ngZone.runOutsideAngular(() => {
@@ -710,6 +719,21 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
   public updated(): void {
     // call outside the angular zone so change detection isn't triggered by the soho component.
     this.ngZone.runOutsideAngular(() => this.tabs?.updated());
+  }
+
+  /**
+   * @param tab The tab element in the list that needs to be activated
+   * @returns 
+   */
+  public activateTab(tab: JQuery | undefined) {
+    return this.ngZone.runOutsideAngular(() => {
+      if (!tab) {
+        return;
+      }
+
+      const tabAnchor = tab?.children('a');
+      this.tabs?.activate(tabAnchor?.attr('href'), tabAnchor);
+    });
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
@@ -685,7 +685,7 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
 
   private getActivatedTab(): JQuery | undefined {
     // get the current selected tab outside of the angular zone
-    return this.ngZone.runOutsideAngular(() => this.jQueryElement?.find('.tab-list').find('li.is-selected'));
+    return this.ngZone.runOutsideAngular(() => this.jQueryElement?.siblings('.tab-panel-container').find('.tab-panel.is-visible'));
   }
 
   private getTabIds(): Array<string> {
@@ -731,8 +731,8 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
         return;
       }
 
-      const tabAnchor = tab?.children('a');
-      this.tabs?.activate(tabAnchor?.attr('href'), tabAnchor);
+      const tabHref = `#${tab?.attr('id')}`;
+      this.tabs?.activate(tabHref);
     });
   }
 

--- a/projects/ids-enterprise-typings/lib/tabs/soho-tabs.d.ts
+++ b/projects/ids-enterprise-typings/lib/tabs/soho-tabs.d.ts
@@ -145,7 +145,7 @@ interface SohoTabsStatic {
 
   enable(): void;
 
-  activate(href: string | undefined, anchor: JQuery | undefined): void;
+  activate(href: string | undefined): void;
 
   /** Manually refreshes the component, with an optional check to swap the component to/from responsive mode (if applicable). */
   handleResize(doResponsiveCheck?: boolean): void;

--- a/projects/ids-enterprise-typings/lib/tabs/soho-tabs.d.ts
+++ b/projects/ids-enterprise-typings/lib/tabs/soho-tabs.d.ts
@@ -145,6 +145,8 @@ interface SohoTabsStatic {
 
   enable(): void;
 
+  activate(href: string | undefined, anchor: JQuery | undefined): void;
+
   /** Manually refreshes the component, with an optional check to swap the component to/from responsive mode (if applicable). */
   handleResize(doResponsiveCheck?: boolean): void;
 

--- a/src/app/tabs/tabs-module.demo.html
+++ b/src/app/tabs/tabs-module.demo.html
@@ -1,4 +1,9 @@
-<div soho-tabs
+<div class="row">
+  <br>
+  <button soho-button="primary" (click)="addTab()">Add Tab</button>
+  <br>
+  <br>
+  <div soho-tabs
     moduleTabs="true"
 >
   <div soho-tab-list-container>
@@ -17,3 +22,5 @@
     </div>
   </div>
 </div>
+</div>
+

--- a/src/app/tabs/tabs-module.demo.ts
+++ b/src/app/tabs/tabs-module.demo.ts
@@ -1,10 +1,35 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  ViewChild
+} from '@angular/core';
+
+import { SohoTabsComponent } from 'ids-enterprise-ng';
 
 @Component({
   selector: 'app-tabs-module-demo',
   templateUrl: 'tabs-module.demo.html'
 })
-export class TabsModuleDemoComponent {
+export class TabsModuleDemoComponent implements OnInit {
+  @ViewChild(SohoTabsComponent, { static: true }) sohoTabsComponent?: SohoTabsComponent;
+  private counter = 7;
+
+  addTab() {
+    let counter = this.counter;
+    const tabId = `order-${counter}`;
+    const options = {
+      name: `Order ${counter}`,
+      isDismissible: true,
+      content: `This is the content for Tab ${counter}`
+    }
+
+    this.sohoTabsComponent?.add(tabId, options, counter);
+    this.counter++;
+  }
+
+  ngOnInit() {
+    console.log(this.sohoTabsComponent);
+  }
 
   public data: Array<any> = [
     {
@@ -21,7 +46,8 @@ export class TabsModuleDemoComponent {
       id: 'order-3',
       title: 'Order 3',
       body: 'It is a paradisematic country, in which roasted parts of sentences fly into your mouth. Even the all-powerful Pointing has no control about the blind texts it is an almost unorthographic life One day however a small line of blind text by the name of Lorem Ipsum decided to leave for the far World of Grammar. The Big Oxmox advised her not to do so, because there were thousands of bad Commas, wild Question Marks and devious Semikoli, but the Little Blind Text didn’t listen. She packed her seven versalia, put her initial into the belt and made herself on the way. When she reached the first hills of the Italic Mountains, she had a last view back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet ' // eslint-disable-line
-    },
+    }
+    ,
     {
       id: 'order-4',
       title: 'Order 4',


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in angular for tabs where the activation resets on the first tab after adding a new tab.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7051

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/tabs-module
- Click any tabs
- Add another tab (It should be on the last tab after adding)

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

