### PR TITLE
EP5785 - Week View Number Datepicker

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -231,6 +231,16 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
   }
 
   /**
+   * Indicates if the month and year will render as dropdowns.
+   */
+  @Input() set showWeekNumber(showWeekNumber: boolean) {
+    this._options.showWeekNumber = showWeekNumber;
+    if (this.datepicker) {
+      this.markForRefresh();
+    }
+  }
+
+  /**
    * Indicates if the days portion of the calendar will be hidden.
    */
   @Input() set hideDays(hideDays: boolean) {

--- a/projects/ids-enterprise-typings/lib/datepicker/soho-datepicker.d.ts
+++ b/projects/ids-enterprise-typings/lib/datepicker/soho-datepicker.d.ts
@@ -51,6 +51,9 @@ interface SohoDatePickerOptions {
   /** If true the month and year will render as dropdowns. */
   showMonthYearPicker?: boolean;
 
+  /** If true the week number will show. */
+  showWeekNumber?: boolean;
+
   /** The number of years ahead to show in the month/year picker should total 9 with yearsBack. */
   hideDays?: boolean;
 

--- a/src/app/datepicker/datepicker.demo.html
+++ b/src/app/datepicker/datepicker.demo.html
@@ -192,4 +192,12 @@
       </div>
     </div>
   </div>
+  <div class="row">
+    <div class="four columns">
+      <div class="field">
+        <label for="statechange" class="label">Show Week Number</label>
+        <input soho-datepicker id="weekNumberDatePicker" name="weekNumberDatePicker" [showWeekNumber]="true" dateFormat="MM/dd/yyyy" mode="standard" [(ngModel)]="model.standard2" (change)="onChange($event)"/>
+      </div>
+    </div>
+  </div>
 </form>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will add weekview number on the monthview in datepicker. Use `showWeekNumber` to enable it.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5785

**Steps necessary to review your pull request (required)**:
- Get first the current 4.81 in EP, build paste it in node_modules (for PR review/testing)
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datepicker
- Under label `Show Week Number`, Open datepicker
- See the week number beside

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

