### PR TITLE
ED7276 - Fix notification throws errors when `closeAll` and `closeLatest`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `[General]` Added 4.80.3 with patches
 
+### 15.0.5 Fixes
+
+- `[Notification]` Fixed notification throws errors when `closeAll` and `closeLatest`. ([#7276](https://github.com/infor-design/enterprise/issues/7276))
+
 ## 15.0.4
 
 ### 15.0.4 Features

--- a/projects/ids-enterprise-ng/src/lib/notification/soho-notification.service.ts
+++ b/projects/ids-enterprise-ng/src/lib/notification/soho-notification.service.ts
@@ -27,13 +27,13 @@ export class SohoNotificationService {
    * Hide the latest notification in the list
    */
   closeLatest(): void {
-    jQuery('body').data('notification').closeLatest();
+    jQuery('body').data('notification')?.closeLatest();
   }
 
   /**
    * Hide all the notifications in the list
    */
   closeAll(): void {
-    jQuery('body').data('notification').closeAll();
+    jQuery('body').data('notification')?.closeAll();
   }
 }

--- a/src/app/notification/notification.demo.ts
+++ b/src/app/notification/notification.demo.ts
@@ -33,8 +33,9 @@ export class NotificationDemoComponent implements OnInit {
   }
 
   closeLatestNotification() {
+    this.notificationService.closeLatest();
+
     if (this.counter > 0) {
-      this.notificationService.closeLatest();
       this.counter--;
 
       if (this.counter === 0) {
@@ -44,8 +45,9 @@ export class NotificationDemoComponent implements OnInit {
   }
 
   closeAllNotification() {
+    this.notificationService.closeAll();
+
     if (this.counter > 0) {
-      this.notificationService.closeAll();
       this.counter = 0;
       this.current = 0;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds checks to `closeLatest` and `closeAll` in the notification service allows to use the methods before the EP's data initialized. Adjusts the notification example to showcase the fix

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7276

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4200/ids-enterprise-ng-demo/notification
- without adding any notifications, click  to `Close All Notifications Alert` or `Close Latest Notification Alert` 
- see the page doesn't throws any errors in browser's console

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
