### PR TITLE
1429 - textarea toggle dirty

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # What's New with Enterprise-NG
 
+## 15.2.0
+
+### 15.2.0 Features
+
+### 15.2.0 Fixes
+
+- `[Textarea]` Added Example Page with Textarea Toggle Dirty. ([#1429](https://github.com/infor-design/enterprise/issues/1429))
+
 ## 15.1.0
 
 ### 15.1.0 Features

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -235,6 +235,7 @@ import { TabsVerticalDemoComponent } from './tabs/tabs-vertical.demo';
 import { TagDemoComponent } from './tag/tag.demo';
 import { TestTabsBasicComponent } from './tabs/test-tabs-basic.demo';
 import { TextareaDemoComponent } from './textarea/textarea.demo';
+import { TextAreaDirtyDemoComponent } from './textarea/textarea-dirty.demo';
 import { TimePickerDemoComponent } from './timepicker/timepicker.demo';
 import { ToastDemoComponent } from './toast/toast.demo';
 import { ToolbarAllIconsDemoComponent } from './toolbar/toolbar-all-icons.demo';
@@ -519,6 +520,7 @@ import { DonutColorsDemoComponent } from './donut/donut-colors.demo';
     TagDemoComponent,
     TestTabsBasicComponent,
     TextareaDemoComponent,
+    TextAreaDirtyDemoComponent,
     TimePickerDemoComponent,
     ToastDemoComponent,
     ToolbarAllIconsDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -189,6 +189,7 @@ import { TabsVerticalDemoComponent } from './tabs/tabs-vertical.demo';
 import { TagDemoComponent } from './tag/tag.demo';
 import { TestTabsBasicComponent } from './tabs/test-tabs-basic.demo';
 import { TextareaDemoComponent } from './textarea/textarea.demo';
+import { TextAreaDirtyDemoComponent } from './textarea/textarea-dirty.demo';
 import { TimePickerDemoComponent } from './timepicker/timepicker.demo';
 import { ToastDemoComponent } from './toast/toast.demo';
 import { ToolbarAllIconsDemoComponent } from './toolbar/toolbar-all-icons.demo';
@@ -452,6 +453,7 @@ export const routes: Routes = [
   { path: 'tags', component: TagDemoComponent },
   { path: 'test-tabs-basic', component: TestTabsBasicComponent },
   { path: 'textarea', component: TextareaDemoComponent },
+  { path: 'textarea-dirty', component: TextAreaDirtyDemoComponent },
   { path: 'timepicker', component: TimePickerDemoComponent },
   { path: 'toast', component: ToastDemoComponent },
   { path: 'toolbar-all-icons', component: ToolbarAllIconsDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -287,6 +287,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['tabs-vertical']"><span>Tabs - Vertical</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['tags']"><span>Tags</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['textarea']"><span>Text Area</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['textarea-dirty']"><span>Text Area - Dirty</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['timepicker']"><span>Time Picker</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['toast']"><span>Toast</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['toolbar-basic']"><span>Toolbar - Basic</span></a></div>

--- a/src/app/textarea/textarea-dirty.demo.html
+++ b/src/app/textarea/textarea-dirty.demo.html
@@ -1,0 +1,61 @@
+<div class="example-section">
+  <form>
+    <div class="row">
+      <h1>Track Dirty Textarea Readonly On Load</h1>
+      <h4>Testing tract dirty on textarea with initial state of readonly that can be toggled to editable field</h4>
+      <hr />
+      <br />
+
+      <div class="row">
+        <div class="two columns">
+          <div class="field">
+            <label soho-label for="textbox">Textbox</label>
+            <input name="textbox" [(ngModel)]="model.textbox"
+              soho-trackdirty
+                (pristine)="onPristine($event)"
+                (dirty)="onDirty($event)"
+                (afterResetDirty)="onAfterResetDirty($event)"/>
+          </div>
+        </div>
+
+        <div class="two columns">
+          <div class="field">
+            <label soho-label for="textarea2">Textarea</label>
+            <textarea name="textarea2" [(ngModel)]="model.textarea2"
+              soho-textarea
+                [characterCounter]="false"
+                [maxlength]="500"
+                [rows]="5"
+              soho-trackdirty
+                (pristine)="onPristine($event)"
+                (dirty)="onDirty($event)"
+                (afterResetDirty)="onAfterResetDirty($event)"
+              (input)="onInput($event)"
+              ></textarea>
+          </div>
+        </div>
+
+        <div class="four columns">
+          <div class="field">
+            <label soho-label for="textarea">Textarea Readonly Initial</label>
+            <textarea [(ngModel)]="model.textarea"
+              [readonly]="isReadOnly"
+              soho-textarea
+                [characterCounter]="false"
+                [maxlength]="500"
+                [rows]="5"
+              soho-trackdirty
+                (pristine)="onPristine($event)"
+                (dirty)="onDirty($event)"
+                (afterResetDirty)="onAfterResetDirty($event)"
+              (input)="onInput($event)"
+              #readDirty
+              ></textarea>
+          </div>
+        </div>
+      </div>
+      <button soho-button (click)="toggleEdit()">Toggle Textarea Readonly</button>
+      <button soho-button (click)="resetForm()">Reset</button>
+    </div>
+  </form>
+</div>

--- a/src/app/textarea/textarea-dirty.demo.ts
+++ b/src/app/textarea/textarea-dirty.demo.ts
@@ -1,0 +1,65 @@
+import { Component, OnInit, QueryList, ViewChild, ViewChildren } from "@angular/core";
+
+import { SohoTrackDirtyDirective } from "ids-enterprise-ng";
+
+@Component({
+  selector: "app-textarea-dirty-demo",
+  templateUrl: "textarea-dirty.demo.html",
+})
+export class TextAreaDirtyDemoComponent implements OnInit {
+  @ViewChildren(SohoTrackDirtyDirective)
+  trackDirtyComponents?: QueryList<SohoTrackDirtyDirective>;
+
+  @ViewChild('readDirty', { static: true }) textReadDirty?: SohoTrackDirtyDirective;
+
+  public model = {
+    textbox: "",
+    textarea2: "",
+    textarea: "",
+  };
+
+  public isReadOnly = true;
+
+  constructor() { }
+
+  ngOnInit() { }
+
+  resetForm() {
+    this.trackDirtyComponents?.forEach(
+      (trackDirty: SohoTrackDirtyDirective) => {
+        console.log(trackDirty);
+        trackDirty.resetDirty();
+      }
+    );
+
+    this.model = {
+      textbox: "",
+      textarea2: "",
+      textarea: "",
+    };
+  }
+
+  toggleEdit() {
+    this.isReadOnly = !this.isReadOnly;
+  }
+
+  onInput(event: Event) {
+    this.trackDirtyComponents?.forEach(
+      (trackDirty: SohoTrackDirtyDirective) => {
+        trackDirty.changeDirty();
+      }
+    );
+  }
+
+  onAfterResetDirty(_event: SohoTrackDirtyEvent) {
+    console.log("TrackDirtyDemoComponent.onAfterResetDirty");
+  }
+
+  onDirty(_event: SohoTrackDirtyEvent) {
+    console.log("TrackDirtyDemoComponent.onDirty");
+  }
+
+  onPristine(_event: SohoTrackDirtyEvent) {
+    console.log("TrackDirtyDemoComponent.onPristine");
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request fix track dirty when updated() method was triggered (EP).

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1429

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/textarea-dirty
- Click on `Toggle Textarea Readonly`
- Enter some characters on the textarea `Textarea Readonly Initial` field

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

