### PR TITLE
Wizard tick missing attribute tickid

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-tick.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-tick.component.ts
@@ -40,6 +40,7 @@ export class SohoWizardTickComponent implements AfterViewInit {
   /**
    * The id, used to link back to the pages.
    */
+  @HostBinding('attr.tickid')
   @Input() public tickId!: string;
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When using dynamic assignment of soho-wizard-tick you'll have problems with the tickId property.
The soho-wizard is unable to find the ticks as it's missing the required tickid attribute when the DOM is rendered.
By adding the attr.tickid together with the Angular reflected [tickId] solves the problem.


**Related github/jira issue (required)**:
No related issue, I found it myself and just created a PR.


**Steps necessary to review your pull request (required)**:
Before the pull request this example would result in the soho-wizard-tick missing the required "tickid" attribute:
```
<div soho-wizard (activated)="onActivated($event)">
	<div soho-wizard-header>
		<a soho-wizard-tick [tickId]="wiz.tickId" *ngFor="let wiz of wizardEntries">{{ wiz.label }}</a>
	</div>
</div>
```
After the pull request, the attribute is present in the DOM and the soho-wizard can now find its "ticks" correctly.

The provided examples from Infor looks similar to this:
```
<div soho-wizard (activated)="onActivated($event)">
	<div soho-wizard-header>
		<a soho-wizard-tick tickId="myTickId">Hello</a>
	</div>
</div>
```
This example does for some reason work, as it correctly renders the tickid attribute in the DOM.
