### PR TITLE
1477 - Implement Component Wrappers for Module Nav

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion-header.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion-header.component.ts
@@ -27,6 +27,7 @@ export class SohoAccordionHeaderComponent implements AfterViewInit {
   @HostBinding('style.display') isBlockDisplay = 'block';
   @HostBinding('class.accordion-header') isAccordionHeader = true;
   @HostBinding('class.is-expanded') @Input() isExpanded = false;
+  @HostBinding('class.module-nav-item') @Input() moduleNavItem = false;
 
   /**
    * Constructor.

--- a/projects/ids-enterprise-ng/src/lib/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/index.ts
@@ -52,6 +52,8 @@ export * from './masthead/index';
 export * from './menu-button/index';
 export * from './message/index';
 export * from './modal-dialog/index';
+export * from './module-nav/index';
+export * from './module-nav-container/index';
 export * from './monthview/index';
 export * from './notification/index';
 export * from './notification-badge/index';

--- a/projects/ids-enterprise-ng/src/lib/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/index.ts
@@ -54,6 +54,8 @@ export * from './message/index';
 export * from './modal-dialog/index';
 export * from './module-nav/index';
 export * from './module-nav-container/index';
+export * from './module-nav-settings/index';
+export * from './module-nav-switcher/index';
 export * from './monthview/index';
 export * from './notification/index';
 export * from './notification-badge/index';

--- a/projects/ids-enterprise-ng/src/lib/module-nav-container/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-container/index.ts
@@ -1,0 +1,2 @@
+export * from './soho-module-nav-container.module';
+export * from './soho-module-nav-container.component';

--- a/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.component.css
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.component.css
@@ -1,0 +1,3 @@
+soho-module-nav-container {
+  display: contents;
+}

--- a/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.component.html
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.component.html
@@ -1,0 +1,1 @@
+<ng-content [ngClass]="{ 'module-nav-container': true }"></ng-content>

--- a/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.component.ts
@@ -9,7 +9,8 @@ import {
  * This Component attaches to an element annotated with the `soho-module-nav-container` attribute,
  */
 @Component({
-  selector: 'soho-module-nav-container',
+  selector: 'soho-module-nav-container, [soho-module-nav-container]',
+  styleUrls: ['./soho-module-nav-container.component.css'],
   templateUrl: 'soho-module-nav-container.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.component.ts
@@ -1,0 +1,18 @@
+// tslint:disable-next-line:no-unused-variable
+import {
+  ChangeDetectionStrategy,
+  Component
+} from '@angular/core';
+
+/**
+ * Angular Wrapper for the Soho Module Nav Container element.
+ * This Component attaches to an element annotated with the `soho-module-nav-container` attribute,
+ */
+@Component({
+  selector: 'soho-module-nav-container',
+  templateUrl: 'soho-module-nav-container.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SohoModuleNavContainerComponent {
+
+}

--- a/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-container/soho-module-nav-container.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SohoModuleNavContainerComponent } from './soho-module-nav-container.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+  declarations: [
+    SohoModuleNavContainerComponent,
+  ],
+  exports: [
+    SohoModuleNavContainerComponent,
+  ]
+})
+export class SohoModuleNavContainerModule { }

--- a/projects/ids-enterprise-ng/src/lib/module-nav-settings/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-settings/index.ts
@@ -1,0 +1,2 @@
+export * from './soho-module-nav-settings.module';
+export * from './soho-module-nav-settings.component';

--- a/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.css
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.css
@@ -1,0 +1,3 @@
+soho-module-nav-settings {
+  display: contents;
+}

--- a/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.html
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.ts
@@ -1,0 +1,30 @@
+// tslint:disable-next-line:no-unused-variable
+import {
+  ChangeDetectionStrategy,
+  Component
+} from '@angular/core';
+
+/**
+ * Angular Wrapper for the Soho Module Nav Settings element.
+ * This Component attaches to an element annotated with the `soho-module-nav-settings` attribute,
+ */
+@Component({
+  selector: 'soho-module-nav-settings, [soho-module-nav-settings]',
+  styleUrls: ['./soho-module-nav-settings.component.css'],
+  templateUrl: 'soho-module-nav-settings.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SohoModuleNavSettingsComponent {
+
+  /** Reference to the jQuery element. */
+  private jQueryElement?: JQuery;
+
+  /** Reference to the annotated SoHoXi control */
+  private modulenavsettings?: SohoModuleNavSettingsStatic | null;
+
+  /** Stored settings */
+  private _options: SohoModuleNavSettingsOptions = {
+    displayMode: false,
+  };
+
+}

--- a/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.ts
@@ -1,7 +1,12 @@
 // tslint:disable-next-line:no-unused-variable
 import {
+  AfterViewInit,
+  AfterViewChecked,
   ChangeDetectionStrategy,
-  Component
+  Component,
+  ElementRef,
+  NgZone,
+  OnDestroy
 } from '@angular/core';
 
 /**
@@ -14,7 +19,7 @@ import {
   templateUrl: 'soho-module-nav-settings.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SohoModuleNavSettingsComponent {
+export class SohoModuleNavSettingsComponent implements AfterViewInit, AfterViewChecked, OnDestroy {
 
   /** Reference to the jQuery element. */
   private jQueryElement?: JQuery;
@@ -27,4 +32,83 @@ export class SohoModuleNavSettingsComponent {
     displayMode: false,
   };
 
+  /** Internal use flags */
+  private _updateRequired: boolean = false;
+
+  /** Constructor. */
+  constructor(
+    private elementRef: ElementRef,
+    private ngZone: NgZone,
+  ) { }
+
+  // -------------------------------------------
+  // Public API
+  // -------------------------------------------
+
+  public accordionAPI(): SohoAccordionStatic | undefined {
+    return this.modulenavsettings?.accordionAPI;
+  }
+
+  public accordionEl(): HTMLElement | undefined {
+    return this.modulenavsettings?.accordionEl;
+  }
+
+  public menuAPI(): SohoPopupMenuStatic | undefined {
+    return this.modulenavsettings?.menuAPI;
+  }
+
+  public init() {
+    this.modulenavsettings?.init();
+  }
+
+  /** Triggers a UI Resync. */
+  public updated(val?: SohoModuleNavSettingsOptions) {
+    if (val) {
+      this._options = jQuery.extend({}, this._options, val);
+      if (this.modulenavsettings) {
+        this.ngZone.runOutsideAngular(() => {
+          this.modulenavsettings?.updated(this._options);
+        });
+      }
+    }
+  }
+
+  public teardown() {
+    this.modulenavsettings?.teardown();
+  }
+
+  // ------------------------------------------
+  // Lifecycle Events
+  // ------------------------------------------
+
+  ngAfterViewInit() {
+    this.ngZone.runOutsideAngular(() => {
+      // Initialize/store instance
+      this.jQueryElement = jQuery(this.elementRef.nativeElement);
+      this.jQueryElement.modulenav(this._options);
+      this.modulenavsettings = this.jQueryElement.data('modulenavsettings');
+    });
+  }
+
+  ngAfterViewChecked() {
+    if (this.modulenavsettings && this._updateRequired) {
+      this.ngZone.runOutsideAngular(() => this.modulenavsettings?.updated());
+      this._updateRequired = false;
+    }
+  }
+
+  ngOnDestroy() {
+    // call outside the angular zone so change detection
+    // isn't triggered by the soho component.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.jQueryElement) {
+        this.jQueryElement.off();
+        this.jQueryElement = undefined;
+      }
+      if (this.modulenavsettings) {
+        this.modulenavsettings.destroy();
+        this.modulenavsettings = null;
+      }
+    });
+  }
 }

--- a/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SohoModuleNavSettingsComponent } from './soho-module-nav-settings.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+  declarations: [
+    SohoModuleNavSettingsComponent,
+  ],
+  exports: [
+    SohoModuleNavSettingsComponent,
+  ]
+})
+export class SohoModuleNavSettingsModule { }

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/index.ts
@@ -1,0 +1,2 @@
+export * from './soho-module-nav-switcher.module';
+export * from './soho-module-nav-switcher.component';

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.css
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.css
@@ -1,0 +1,3 @@
+soho-module-nav-switcher {
+  display: contents;
+}

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.html
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.html
@@ -1,0 +1,5 @@
+<ng-container [ngClass]="{ 'module-nav-header': true, 'accordion-section': true }">
+  <div class="module-nav-switcher">
+    <ng-content></ng-content>
+  </div>
+<ng-container>

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
@@ -1,0 +1,30 @@
+// tslint:disable-next-line:no-unused-variable
+import {
+  ChangeDetectionStrategy,
+  Component
+} from '@angular/core';
+
+/**
+ * Angular Wrapper for the Soho Module Nav Switcher element.
+ * This Component attaches to an element annotated with the `soho-module-nav-switcher` attribute,
+ */
+@Component({
+  selector: 'soho-module-nav-switcher, [soho-module-nav-switcher]',
+  styleUrls: ['./soho-module-nav-switcher.component.css'],
+  templateUrl: 'soho-module-nav-switcher.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SohoModuleNavSwitcherComponent {
+
+  /** Reference to the jQuery element. */
+  private jQueryElement?: JQuery;
+
+  /** Reference to the annotated SoHoXi control */
+  private modulenavswitcher?: SohoModuleNavSwitcherStatic | null;
+
+  /** Stored settings */
+  private _options: SohoModuleNavSwitcherOptions = {
+    displayMode: false,
+  };
+
+}

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
@@ -1,7 +1,13 @@
 // tslint:disable-next-line:no-unused-variable
 import {
+  AfterViewInit,
+  AfterViewChecked,
   ChangeDetectionStrategy,
-  Component
+  Component,
+  ElementRef,
+  Input,
+  NgZone,
+  OnDestroy
 } from '@angular/core';
 
 /**
@@ -14,7 +20,7 @@ import {
   templateUrl: 'soho-module-nav-switcher.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SohoModuleNavSwitcherComponent {
+export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewChecked, OnDestroy {
 
   /** Reference to the jQuery element. */
   private jQueryElement?: JQuery;
@@ -25,6 +31,119 @@ export class SohoModuleNavSwitcherComponent {
   /** Stored settings */
   private _options: SohoModuleNavSwitcherOptions = {
     displayMode: false,
+    icon: undefined,
+    roles: []
   };
 
+  /** Internal use flags */
+  private _updateRequired: boolean = false;
+
+  /** Constructor. */
+  constructor(
+    private elementRef: ElementRef,
+    private ngZone: NgZone,
+  ) { }
+
+  // -------------------------------------------
+  // Inputs
+  // -------------------------------------------
+
+  @Input() set displayMode(val: SohoModuleNavDisplayMode | undefined) {
+    this._options.displayMode = val;
+    this.updated({ displayMode: this._options.displayMode });
+  }
+  public get displayMode(): SohoModuleNavDisplayMode | undefined {
+    return this.modulenavswitcher?.settings.displayMode || this._options.displayMode;
+  }
+
+  @Input() set icon(val: SohoModuleNavSwitcherIconSetting) {
+    this._options.icon = val;
+    this.updated({ icon: this._options.icon });
+  }
+  public get icon(): SohoModuleNavSwitcherIconSetting {
+    return this.modulenavswitcher?.settings.icon || this._options.icon;
+  }
+
+  @Input() set roles(val: Array<SohoModuleNavSwitcherRoleRecord> | undefined) {
+    this._options.roles = val;
+    this.updated({ roles: this._options.roles });
+  }
+  public get roles(): Array<SohoModuleNavSwitcherRoleRecord> | undefined {
+    return this.modulenavswitcher?.settings.roles || this._options.roles;
+  }
+
+  // -------------------------------------------
+  // Public API
+  // -------------------------------------------
+
+  public accordionAPI(): SohoAccordionStatic | undefined {
+    return this.modulenavswitcher?.accordionAPI;
+  }
+
+  public accordionEl() {
+    return this.modulenavswitcher?.accordionEl;
+  }
+
+  public moduleButtonAPI() {
+    return this.modulenavswitcher?.moduleButtonAPI;
+  }
+
+  public roleDropdownAPI() {
+    return this.modulenavswitcher?.roleDropdownAPI;
+  }
+
+  public init() {
+    this.modulenavswitcher?.init();
+  }
+
+  /** Triggers a UI Resync. */
+  public updated(val?: SohoModuleNavSwitcherOptions) {
+    if (val) {
+      this._options = jQuery.extend({}, this._options, val);
+      if (this.modulenavswitcher) {
+        this.ngZone.runOutsideAngular(() => {
+          this.modulenavswitcher?.updated(this._options);
+        });
+      }
+    }
+  }
+
+  public teardown() {
+    this.modulenavswitcher?.teardown();
+  }
+
+  // ------------------------------------------
+  // Lifecycle Events
+  // ------------------------------------------
+
+  ngAfterViewInit() {
+    this.ngZone.runOutsideAngular(() => {
+      // Initialize/store instance
+      this.jQueryElement = jQuery(this.elementRef.nativeElement);
+      this.jQueryElement.modulenav(this._options);
+      this.modulenavswitcher = this.jQueryElement.data('modulenavswitcher');
+    });
+  }
+
+  ngAfterViewChecked() {
+    if (this.modulenavswitcher && this._updateRequired) {
+      this.ngZone.runOutsideAngular(() => this.modulenavswitcher?.updated());
+      this._updateRequired = false;
+    }
+  }
+
+  ngOnDestroy() {
+    // call outside the angular zone so change detection
+    // isn't triggered by the soho component.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.jQueryElement) {
+        this.jQueryElement.off();
+        this.jQueryElement = undefined;
+      }
+      if (this.modulenavswitcher) {
+        this.modulenavswitcher.destroy();
+        this.modulenavswitcher = null;
+      }
+    });
+  }
 }

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SohoModuleNavSwitcherComponent } from './soho-module-nav-switcher.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+  declarations: [
+    SohoModuleNavSwitcherComponent,
+  ],
+  exports: [
+    SohoModuleNavSwitcherComponent,
+  ]
+})
+export class SohoModuleNavSwitcherModule { }

--- a/projects/ids-enterprise-ng/src/lib/module-nav/index.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/index.ts
@@ -1,0 +1,2 @@
+export * from './soho-module-nav.module';
+export * from './soho-module-nav.component';

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.css
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.css
@@ -1,0 +1,3 @@
+soho-module-nav {
+  display: contents;
+}

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.html
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.html
@@ -1,0 +1,1 @@
+<ng-content id="nav" [ngClass]="{ 'module-nav': true }"></ng-content>

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
@@ -24,7 +24,8 @@ type SohoModuleNavDisplayModeAccessor = SohoModuleNavDisplayMode | undefined;
  * This Component attaches to an element annotated with the `soho-module-nav` attribute,
  */
 @Component({
-  selector: 'soho-module-nav',
+  selector: 'soho-module-nav, [soho-module-nav]',
+  styleUrls: ['./soho-module-nav.component.css'],
   templateUrl: 'soho-module-nav.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
@@ -1,0 +1,161 @@
+// tslint:disable-next-line:no-unused-variable
+import {
+  AfterViewChecked,
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ContentChildren,
+  ElementRef,
+  EventEmitter,
+  Input, NgZone,
+  OnDestroy,
+  Output,
+  QueryList,
+  forwardRef,
+} from '@angular/core';
+
+// import { SohoAccordionHeaderComponent } from './soho-accordion-header.component';
+// import { SohoAccordionPaneComponent } from './soho-accordion-pane.component';
+
+type SohoModuleNavDisplayModeAccessor = SohoModuleNavDisplayMode | undefined;
+
+/**
+ * Angular Wrapper for the Soho Module Nav control.
+ * This Component attaches to an element annotated with the `soho-module-nav` attribute,
+ */
+@Component({
+  selector: 'soho-module-nav',
+  templateUrl: 'soho-module-nav.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, OnDestroy {
+
+  /** Reference to the jQuery element. */
+  private jQueryElement?: JQuery;
+
+  /** Reference to the annotated SoHoXi control */
+  private modulenav?: SohoModuleNavStatic | null;
+
+  /** Stored settings */
+  private _options: SohoModuleNavOptions = {
+    displayMode: false,
+    filterable: false,
+    pinSections: false,
+    showDetailView: false,
+  };
+
+  /** Internal use flags */
+  private _updateRequired: boolean = false;
+
+  /** Constructor. */
+  constructor(
+    private elementRef: ElementRef,
+    private ngZone: NgZone,
+  ) { }
+
+  // -------------------------------------------
+  // Inputs
+  // -------------------------------------------
+
+  @Input() set displayMode(val: SohoModuleNavDisplayModeAccessor) {
+    this._options.displayMode = val;
+    this.updated({ displayMode: this._options.displayMode });
+    if (this.modulenav) this.modulenav.settings.displayMode = this._options.displayMode;
+  }
+  public get displayMode(): SohoModuleNavDisplayModeAccessor {
+    return this.modulenav?.settings.displayMode || this._options.displayMode;
+  }
+
+  // -------------------------------------------
+  // Public API
+  // -------------------------------------------
+
+  public accordionAPI(): SohoAccordionStatic | undefined {
+    return this.modulenav?.accordionAPI;
+  }
+
+  public containerEl(): HTMLElement | undefined {
+    return this.modulenav?.containerEl;
+  }
+
+  public switcherAPI(): SohoModuleNavSwitcherStatic | undefined {
+    return this.modulenav?.switcherAPI;
+  }
+
+  public searchAPI(): SohoSearchFieldStatic | undefined {
+    return this.modulenav?.searchAPI;
+  }
+
+  public settingsAPI(): SohoModuleNavSettingsStatic | undefined {
+    return this.modulenav?.switcherAPI;
+  }
+
+  public init() {
+    this.modulenav?.init();
+  }
+
+  /** Triggers a UI Resync. */
+  public updated(val?: SohoModuleNavOptions) {
+    if (val) {
+      this._options = val;
+      if (this.modulenav) {
+        this.ngZone.runOutsideAngular(() => {
+          this.modulenav?.updated(this._options);
+        });
+      }
+    }
+  }
+
+  public teardown() {
+    this.modulenav?.teardown();
+  }
+
+  // ------------------------------------------
+  // Lifecycle Events
+  // ------------------------------------------
+
+  ngAfterViewInit() {
+    this.ngZone.runOutsideAngular(() => {
+      // Initialize/store instance
+      this.jQueryElement = jQuery(this.elementRef.nativeElement);
+      this.jQueryElement.modulenav(this._options);
+      this.modulenav = this.jQueryElement.data('modulenav');
+
+      // Initialise any event handlers.
+      /*
+      this.jQueryElement
+        .on('expand', (_e, results: any[]) => this.ngZone.run(() => this.accordionExpand.next(results)))
+        .on('collapse', () => this.ngZone.run(() => this.accordionCollapse.next(true)))
+        .on('expand', () => this.ngZone.run(() => this.visibility.next(true)))
+        .on('collapse', () => this.ngZone.run(() => this.visibility.next(false)))
+        .on('filtered', (_e, results: any[]) => this.ngZone.run(() => this.filtered.next(results)))
+        .on('applicationmenuopen', () => this.ngZone.run(() => this.menuVisibility.next(true)))
+        .on('applicationmenuclose', () => this.ngZone.run(() => this.menuVisibility.next(false)));
+        */
+    });
+  }
+
+  /** */
+  ngAfterViewChecked() {
+    if (this.modulenav && this._updateRequired) {
+      this.ngZone.runOutsideAngular(() => this.modulenav?.updated());
+      this._updateRequired = false;
+    }
+  }
+
+  /** Destructor. */
+  ngOnDestroy() {
+    // call outside the angular zone so change detection
+    // isn't triggered by the soho component.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.jQueryElement) {
+        this.jQueryElement.off();
+        this.jQueryElement = undefined;
+      }
+      if (this.modulenav) {
+        this.modulenav.destroy();
+        this.modulenav = null;
+      }
+    });
+  }
+}

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
@@ -14,11 +14,6 @@ import {
   forwardRef,
 } from '@angular/core';
 
-// import { SohoAccordionHeaderComponent } from './soho-accordion-header.component';
-// import { SohoAccordionPaneComponent } from './soho-accordion-pane.component';
-
-type SohoModuleNavDisplayModeAccessor = SohoModuleNavDisplayMode | undefined;
-
 /**
  * Angular Wrapper for the Soho Module Nav control.
  * This Component attaches to an element annotated with the `soho-module-nav` attribute,
@@ -58,17 +53,15 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   // Inputs
   // -------------------------------------------
 
-  @Input() set displayMode(val: SohoModuleNavDisplayModeAccessor) {
-    console.info('set display mode')
+  @Input() set displayMode(val: SohoModuleNavDisplayMode | undefined) {
     this._options.displayMode = val;
     this.updated({ displayMode: this._options.displayMode });
   }
-  public get displayMode(): SohoModuleNavDisplayModeAccessor {
+  public get displayMode(): SohoModuleNavDisplayMode | undefined {
     return this.modulenav?.settings.displayMode || this._options.displayMode;
   }
 
   @Input() set filterable(val: boolean) {
-    console.info('set filterable')
     this._options.filterable = val;
     this.updated({ filterable: this._options.filterable });
   }
@@ -77,7 +70,6 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   }
 
   @Input() set pinSections(val: boolean) {
-    console.info('set pin sections')
     this._options.pinSections = val;
     this.updated({ pinSections: this._options.pinSections });
   }
@@ -86,7 +78,6 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   }
 
   @Input() set showDetailView(val: boolean) {
-    console.info('set show detail view')
     this._options.showDetailView = val;
     this.updated({ showDetailView: this._options.showDetailView });
   }

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
@@ -58,12 +58,39 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   // -------------------------------------------
 
   @Input() set displayMode(val: SohoModuleNavDisplayModeAccessor) {
+    console.info('set display mode')
     this._options.displayMode = val;
     this.updated({ displayMode: this._options.displayMode });
-    if (this.modulenav) this.modulenav.settings.displayMode = this._options.displayMode;
   }
   public get displayMode(): SohoModuleNavDisplayModeAccessor {
     return this.modulenav?.settings.displayMode || this._options.displayMode;
+  }
+
+  @Input() set filterable(val: boolean) {
+    console.info('set filterable')
+    this._options.filterable = val;
+    this.updated({ filterable: this._options.filterable });
+  }
+  public get filterable(): boolean {
+    return this.modulenav?.settings.filterable || this._options.filterable || false;
+  }
+
+  @Input() set pinSections(val: boolean) {
+    console.info('set pin sections')
+    this._options.pinSections = val;
+    this.updated({ pinSections: this._options.pinSections });
+  }
+  public get pinSections(): boolean {
+    return this.modulenav?.settings.pinSections || this._options.pinSections || false;
+  }
+
+  @Input() set showDetailView(val: boolean) {
+    console.info('set show detail view')
+    this._options.showDetailView = val;
+    this.updated({ showDetailView: this._options.showDetailView });
+  }
+  public get showDetailView(): boolean {
+    return this.modulenav?.settings.showDetailView || this._options.showDetailView || false;
   }
 
   // -------------------------------------------
@@ -97,7 +124,7 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   /** Triggers a UI Resync. */
   public updated(val?: SohoModuleNavOptions) {
     if (val) {
-      this._options = val;
+      this._options = jQuery.extend({}, this._options, val);
       if (this.modulenav) {
         this.ngZone.runOutsideAngular(() => {
           this.modulenav?.updated(this._options);
@@ -120,22 +147,9 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
       this.jQueryElement = jQuery(this.elementRef.nativeElement);
       this.jQueryElement.modulenav(this._options);
       this.modulenav = this.jQueryElement.data('modulenav');
-
-      // Initialise any event handlers.
-      /*
-      this.jQueryElement
-        .on('expand', (_e, results: any[]) => this.ngZone.run(() => this.accordionExpand.next(results)))
-        .on('collapse', () => this.ngZone.run(() => this.accordionCollapse.next(true)))
-        .on('expand', () => this.ngZone.run(() => this.visibility.next(true)))
-        .on('collapse', () => this.ngZone.run(() => this.visibility.next(false)))
-        .on('filtered', (_e, results: any[]) => this.ngZone.run(() => this.filtered.next(results)))
-        .on('applicationmenuopen', () => this.ngZone.run(() => this.menuVisibility.next(true)))
-        .on('applicationmenuclose', () => this.ngZone.run(() => this.menuVisibility.next(false)));
-        */
     });
   }
 
-  /** */
   ngAfterViewChecked() {
     if (this.modulenav && this._updateRequired) {
       this.ngZone.runOutsideAngular(() => this.modulenav?.updated());
@@ -143,7 +157,6 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
     }
   }
 
-  /** Destructor. */
   ngOnDestroy() {
     // call outside the angular zone so change detection
     // isn't triggered by the soho component.

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SohoModuleNavComponent } from './soho-module-nav.component';
+
+// @TODO do we need to import Soho Accordion/Search/Dropdown/Popupmenu here?
+// import { SohoAccordionHeaderComponent } from './soho-accordion-header.component';
+// import { SohoAccordionPaneComponent } from './soho-accordion-pane.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+  declarations: [
+    SohoModuleNavComponent
+  ],
+  exports: [
+    SohoModuleNavComponent
+  ]
+})
+export class SohoModuleNavModule { }

--- a/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
@@ -52,6 +52,8 @@ import { SohoMastheadModule } from './masthead/soho-masthead.module';
 import { SohoMenuButtonModule } from './menu-button/soho-menu-button.module';
 import { SohoMessageModule } from './message/soho-message.module';
 import { SohoModalDialogModule } from './modal-dialog/soho-modal-dialog.module';
+import { SohoModuleNavModule } from './module-nav/soho-module-nav.module';
+import { SohoModuleNavContainerModule } from './module-nav-container/soho-module-nav-container.module';
 import { SohoMonthViewModule } from './monthview/soho-monthview.module';
 import { SohoNotificationModule } from './notification/soho-notification.module';
 import { SohoNotificationBadgeModule } from './notification-badge/soho-notification-badge.module';
@@ -146,6 +148,8 @@ import { SohoListBuilderModule } from './listbuilder';
     SohoMenuButtonModule,
     SohoMessageModule,
     SohoModalDialogModule,
+    SohoModuleNavModule,
+    SohoModuleNavContainerModule,
     SohoMonthViewModule,
     SohoNotificationModule,
     SohoNotificationBadgeModule,
@@ -237,6 +241,8 @@ import { SohoListBuilderModule } from './listbuilder';
     SohoMastheadModule,
     SohoMenuButtonModule,
     SohoModalDialogModule,
+    SohoModuleNavModule,
+    SohoModuleNavContainerModule,
     SohoMonthViewModule,
     SohoNotificationModule,
     SohoNotificationBadgeModule,

--- a/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
+++ b/projects/ids-enterprise-ng/src/lib/soho-components.module.ts
@@ -54,6 +54,8 @@ import { SohoMessageModule } from './message/soho-message.module';
 import { SohoModalDialogModule } from './modal-dialog/soho-modal-dialog.module';
 import { SohoModuleNavModule } from './module-nav/soho-module-nav.module';
 import { SohoModuleNavContainerModule } from './module-nav-container/soho-module-nav-container.module';
+import { SohoModuleNavSettingsModule } from './module-nav-settings/soho-module-nav-settings.module';
+import { SohoModuleNavSwitcherModule } from './module-nav-switcher/soho-module-nav-switcher.module';
 import { SohoMonthViewModule } from './monthview/soho-monthview.module';
 import { SohoNotificationModule } from './notification/soho-notification.module';
 import { SohoNotificationBadgeModule } from './notification-badge/soho-notification-badge.module';
@@ -150,6 +152,8 @@ import { SohoListBuilderModule } from './listbuilder';
     SohoModalDialogModule,
     SohoModuleNavModule,
     SohoModuleNavContainerModule,
+    SohoModuleNavSettingsModule,
+    SohoModuleNavSwitcherModule,
     SohoMonthViewModule,
     SohoNotificationModule,
     SohoNotificationBadgeModule,
@@ -243,6 +247,8 @@ import { SohoListBuilderModule } from './listbuilder';
     SohoModalDialogModule,
     SohoModuleNavModule,
     SohoModuleNavContainerModule,
+    SohoModuleNavSettingsModule,
+    SohoModuleNavSwitcherModule,
     SohoMonthViewModule,
     SohoNotificationModule,
     SohoNotificationBadgeModule,

--- a/projects/ids-enterprise-typings/index.d.ts
+++ b/projects/ids-enterprise-typings/index.d.ts
@@ -54,6 +54,7 @@
 /// <reference path='lib/menu-button/soho-menu-button.d.ts' />
 /// <reference path='lib/message/soho-message.d.ts' />
 /// <reference path='lib/modal-dialog/soho-modal-dialog.d.ts' />
+/// <reference path='lib/module-nav/index.d.ts' />
 /// <reference path='lib/monthview/soho-monthview.d.ts' />
 /// <reference path='lib/notification/soho-notification.d.ts' />
 /// <reference path='lib/notification-badge/soho-notification-badge.d.ts' />

--- a/projects/ids-enterprise-typings/lib/accordion/soho-accordion.d.ts
+++ b/projects/ids-enterprise-typings/lib/accordion/soho-accordion.d.ts
@@ -8,10 +8,56 @@
 
 type SohoAccordionExpanderType = 'classic' | 'plus-minus' | 'chevron';
 
+type SohoAccordionDefaultFocusBehaviorCallback = () => void;
+
+type SohoAccordionHeaderGroup = any; // JQuery<HTMLElement>
+
+type SohoAccordionHeaderExpanderButtonGroup = any; // JQuery<HTMLElement>
+
+type SohoAccordionHeaderAnchorGroup = any; // JQuery<HTMLElement>
+
+type SohoAccordionHeaderAnyGroup = SohoAccordionHeaderGroup | SohoAccordionHeaderExpanderButtonGroup | SohoAccordionHeaderAnchorGroup;
+
+type SohoAccordionNavDirection = 0 | -1 | 1;
+
 /**
-* Soho Accordion Control Options
-*/
+ * Soho Accordion data representation types
+ * These can be used to work with the results of `.toData()`
+ */
+
+type SohoAccordionData = Array<SohoAccordionSectionData> | Array<SohoAccordionHeaderData>;
+
+type SohoAccordionSectionData = {
+  index: string,
+  type: 'section',
+  children?: Array<SohoAccordionHeaderData | SohoAccordionContentData>,
+};
+
+type SohoAccordionContentData = {
+  index: string,
+  type: 'content',
+  content?: string,
+  contentText?: string
+};
+
+type SohoAccordionHeaderData = {
+  index: string,
+  type: 'header',
+  text?: string,
+  icon?: string,
+  children?: Array<SohoAccordionHeaderData | SohoAccordionContentData>
+};
+
+/**
+ * Soho Accordion Control Options
+ */
 interface SohoAccordionOptions {
+  /**
+   * Provides a mechanism for controlling the behavior of accordion header focus.
+   * By default, the built-in behavior is used (ability to focus headers/expanders independently).
+   */
+  accordionFocusCallback?: (header: JQuery<HTMLElement>, defaultFocusBehaviorCallback?: SohoAccordionDefaultFocusBehaviorCallback) => void;
+
   /**
    * If set to true, allows only one pane of the Accordion to be open at a time.
    * If an Accordion pane is open, and that pane contains sub-headers,
@@ -68,12 +114,14 @@ interface SohoAccordionOptions {
 }
 
 /**
- * This interface represents the public API exposed by the
- * busy indicator.
+ * This interface represents the public API exposed by the Soho Accordion
  */
 interface SohoAccordionStatic {
   /** Access to the control's options block. */
   settings: SohoAccordionOptions;
+
+  /** Calls the `source` method passed via settings */
+  callSource(anchor: SohoAccordionHeaderAnchorGroup, animationCallback: () => void): void;
 
   /** Collapses all panels. */
   collapseAll(): void;
@@ -81,9 +129,11 @@ interface SohoAccordionStatic {
   /** Expands all panels. */
   expandAll(): void;
 
-  expand(header: any | string): void;
+  /** Expands one or a group of panels */
+  expand(header: SohoAccordionHeaderGroup | string): void;
 
-  collapse(header: any | string): void;
+  /** Collapses one or a group of panels */
+  collapse(header: SohoAccordionHeaderGroup | string): void;
 
   /** Disables the accordion from reacting to events. */
   disable(): void;
@@ -92,18 +142,63 @@ interface SohoAccordionStatic {
   enable(): void;
 
   /** Checks if a particular header is disabled, or if the entire accordion is disabled. */
-  isDisabled(jQuery: any): boolean;
+  isDisabled(header: SohoAccordionHeaderGroup): boolean;
 
   /** Checks if an Accordion Section is currently expanded. */
-  isExpanded(jQuery: any): boolean;
+  isExpanded(header: SohoAccordionHeaderGroup): boolean;
 
   /** Toggles the exanded state of the selected header. */
-  toggle(jQuery: any): void;
+  toggle(header: SohoAccordionHeaderGroup): boolean;
+
+  /**
+   * Gets the current contents of this accordion and creates a JSON-like representation of the structure.
+   * For full JSON compatibility, don't use the `addElementReference` flag.
+   **/
+  toData(flatten?: boolean, addElementReference?: boolean): SohoAccordionData;
+
+  /** Makes an accordion header appear with a "selected" state */
+  select(element?: SohoAccordionHeaderAnyGroup): void;
+
+  /** Gets a reference to currently-selected accordion headers */
+  getSelected(): SohoAccordionHeaderGroup;
+
+  /** Determines if an Accordion Header is disabled */
+  isDisabled(header: SohoAccordionHeaderGroup): boolean;
+
+  /** "Visually" filters accordion headers (elements are not added/removed but temporarily hidden by CSS if filtered out) */
+  filter(headers?: SohoAccordionHeaderGroup): void;
+
+  /** Resets a previously-applied filter */
+  unfilter(headers?: SohoAccordionHeaderGroup): void;
+
+  /** Determines if an Accordion Header is currently visually filtered out */
+  isFiltered(header: SohoAccordionHeaderGroup): boolean;
+
+  /** Determines if animation is currently happening on accordion panes (controls some behavior internally) */
+  isAnimating: boolean;
+
+  /** Programmatically navigates to the next-available accordion header (down) */
+  nextHeader(element: SohoAccordionHeaderAnyGroup, noDescend?: boolean): void;
+
+  /** Programmatically navigates to the previous-available accordion header (up) */
+  prevHeader(element: SohoAccordionHeaderAnyGroup, noDescend?: boolean): void;
+
+  /** Programmatically navigates to the next-available accordion header (down) */
+  ascend(element: SohoAccordionHeaderGroup, direction?: SohoAccordionNavDirection): void;
+
+  /** Programmatically navigates to the previous-available accordion header (up) */
+  descend(element: SohoAccordionHeaderGroup, direction?: SohoAccordionNavDirection): void;
+
+  /** Programmatically focuses the correct element within an accordion header (based on previously-focused elements) */
+  focusOriginalType(header: SohoAccordionHeaderGroup): void;
 
   /** Updates the accordion with any new settings. */
-  updated(headers?: JQuery[], settings?: SohoAccordionOptions): void;
+  updated(headers?: SohoAccordionHeaderGroup, settings?: SohoAccordionOptions): void;
 
-  /** Destroys the control on completion. */
+  /** Performs a teardown of the jQuery component API (does not remove the component instance) */
+  teardown(): void;
+
+  /** Destroys the control on completion. (Tears down and removes the component instance) */
   destroy(): void;
 }
 

--- a/projects/ids-enterprise-typings/lib/application-menu/soho-application-menu.d.ts
+++ b/projects/ids-enterprise-typings/lib/application-menu/soho-application-menu.d.ts
@@ -1,3 +1,6 @@
+/// <reference path='../accordion/soho-accordion.d.ts' />
+/// <reference path='../searchfield/soho-searchfield.d.ts' />
+
 /**
  * Soho Application Menu.
  *
@@ -62,6 +65,15 @@ interface SohoApplicationMenuOptions {
 interface SohoApplicationMenuStatic {
   /** Control settings. */
   settings: SohoApplicationMenuOptions;
+
+  /** Accordion element */
+  accordionEl: HTMLElement;
+
+  /** Searchfield element, if present */
+  searchEl?: HTMLElement | null;
+
+  /** Searchfield API, if present */
+  searchAPI?: SohoSearchFieldStatic;
 
   /**
    * Opens the application menu.

--- a/projects/ids-enterprise-typings/lib/dropdown/soho-dropdown.d.ts
+++ b/projects/ids-enterprise-typings/lib/dropdown/soho-dropdown.d.ts
@@ -28,6 +28,16 @@ interface SohoDropDownOptions {
   cssClass?: string;
 
   /**
+   * Controls the style of the icon representing the Dropdown's "open/close" functionality.
+   */
+  dropdownIcon?: string;
+
+  /**
+   * If true, adds an extra wrapping element in the Dropdown List (in some situations used for styling/scrolling behavior changes)
+   */
+  extraListWrapper?: boolean;
+
+  /**
    * Search mode to use between 'contains',  'keyword',  'wordStartsWith', 'phraseStartsWith false will not allow client side filter
    */
   filterMode?: SohoDropDownFilterModeOptions;
@@ -124,6 +134,11 @@ interface SohoDropDownOptions {
   width?: number;
 
   /**
+   * CSS selector representing an element that the Dropdown component can use to define the list's width
+   */
+  widthTarget?: string;
+
+  /**
    * Show the select all text/option.
    */
   showSelectAll?: boolean;
@@ -217,7 +232,9 @@ interface SohoDropDownStatic {
    */
   disable(): void;
 
-  /** Enable the control. */
+  /**
+   * Enable the control.
+   */
   enable(): void;
 
   /**

--- a/projects/ids-enterprise-typings/lib/module-nav/index.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/index.d.ts
@@ -1,0 +1,4 @@
+/// <reference path='soho-module-nav-common.d.ts' />
+/// <reference path='soho-module-nav-settings.d.ts' />
+/// <reference path='soho-module-nav-switcher.d.ts' />
+/// <reference path='soho-module-nav.d.ts' />

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-common.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-common.d.ts
@@ -9,3 +9,4 @@
  * In some cases this also has affects on child components and event handling
  */
 type SohoModuleNavDisplayMode = false | 'collapsed' | 'expanded';
+

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-common.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-common.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Soho Module Nav Common
+ *
+ * This file provides common types used by all Module Nav wrapper components
+ */
+
+/**
+ * Controls the visible state of the Module Nav component.
+ * In some cases this also has affects on child components and event handling
+ */
+type SohoModuleNavDisplayMode = false | 'collapsed' | 'expanded';

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-settings.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-settings.d.ts
@@ -1,0 +1,50 @@
+/// <reference path='./soho-module-nav-common.d.ts' />
+/// <reference path='../accordion/soho-accordion.d.ts' />
+/// <reference path='../popupmenu/soho-popupmenu.d.ts' />
+
+/** Defines options present in the Soho Module Nav Settings */
+interface SohoModuleNavSettingsOptions {
+  displayMode: SohoModuleNavDisplayMode;
+}
+
+/** Public API for Soho Module Nav Settings JS component */
+interface SohoModuleNavSettings {
+  /** Module Nav Switcher's current settings */
+  settings: SohoModuleNavSettingsOptions;
+
+  /** Reference to jQuery-wrapped HTML Element representing the Soho Accordion */
+  accordionEl?: HTMLElement;
+
+  /** Reference to a Soho Accordion API, if one is available */
+  accordionAPI?: SohoAccordionStatic;
+
+  /** References to specific sections/elements */
+  containerEl?: HTMLElement;
+
+  /** Reference to the element representing the settings button's menu */
+  menuEl?: HTMLElement;
+
+  /** Reference to the settings menu's Soho Popupmenu API, if one is available*/
+  menuAPI?: SohoPopupMenuStatic;
+
+  /** Changes the Module Nav Switcher's Display Mode */
+  setDisplayMode(val?: SohoModuleNavDisplayMode): void;
+
+  /** Re-renders jQuery child component APIs */
+  renderChildComponents(): void;
+
+  /** Tear down the markup for the control */
+  teardown(): void;
+
+  /** Updates the monthview with any new settings */
+  updated(): void;
+
+  /** Destroys the control on completion. */
+  destroy(): void;
+}
+
+/** jQuery interface for Module Nav Settings */
+interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
+  modulenavsettings(options?: SohoModuleNavSettingsOptions): JQuery;
+  on(events: 'updated', handler: JQuery.EventHandlerBase<any, SohoModuleNavSettingsOptions>): this;
+}

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-settings.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-settings.d.ts
@@ -4,11 +4,11 @@
 
 /** Defines options present in the Soho Module Nav Settings */
 interface SohoModuleNavSettingsOptions {
-  displayMode: SohoModuleNavDisplayMode;
+  displayMode?: SohoModuleNavDisplayMode;
 }
 
 /** Public API for Soho Module Nav Settings JS component */
-interface SohoModuleNavSettings {
+interface SohoModuleNavSettingsStatic {
   /** Module Nav Switcher's current settings */
   settings: SohoModuleNavSettingsOptions;
 
@@ -27,6 +27,9 @@ interface SohoModuleNavSettings {
   /** Reference to the settings menu's Soho Popupmenu API, if one is available*/
   menuAPI?: SohoPopupMenuStatic;
 
+  /** Initializes the jQuery component */
+  init(): void;
+
   /** Changes the Module Nav Switcher's Display Mode */
   setDisplayMode(val?: SohoModuleNavDisplayMode): void;
 
@@ -36,8 +39,8 @@ interface SohoModuleNavSettings {
   /** Tear down the markup for the control */
   teardown(): void;
 
-  /** Updates the monthview with any new settings */
-  updated(): void;
+  /** Updates the Module Nav Settings with any new settings */
+  updated(newSettings?: SohoModuleNavSettingsOptions): void;
 
   /** Destroys the control on completion. */
   destroy(): void;

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
@@ -10,11 +10,11 @@ type SohoModuleNavSwitcherRoleRecord = Record<string, unknown>;
 
 /** Defines options present in the Soho Module Nav Switcher */
 interface SohoModuleNavSwitcherOptions {
-  displayMode: SohoModuleNavDisplayMode;
+  displayMode?: SohoModuleNavDisplayMode;
 }
 
 /** Public API for Soho Module Nav Switcher JS component */
-interface SohoModuleNavSwitcher {
+interface SohoModuleNavSwitcherStatic {
   /** Module Nav Switcher's current settings */
   settings: SohoModuleNavSwitcherOptions;
 
@@ -45,6 +45,9 @@ interface SohoModuleNavSwitcher {
   /** Reference to the Module Button's Soho Button API, if one is available */
   roleDropdownAPI?: SohoButtonStatic;
 
+  /** Initializes the jQuery component */
+  init(): void;
+
   /** Changes the Module Nav Switcher's Display Mode */
   setDisplayMode(val?: SohoModuleNavDisplayMode): void;
 
@@ -57,8 +60,8 @@ interface SohoModuleNavSwitcher {
   /** Tear down the markup for the control */
   teardown(): void;
 
-  /** Updates the monthview with any new settings */
-  updated(): void;
+  /** Updates the Module Nav Switcher with any new settings */
+  updated(newSettings?: SohoModuleNavSwitcherOptions): void;
 
   /** Destroys the control on completion. */
   destroy(): void;

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
@@ -1,0 +1,71 @@
+/// <reference path='./soho-module-nav-common.d.ts' />
+/// <reference path='../accordion/soho-accordion.d.ts' />
+/// <reference path='../button/soho-button.d.ts' />
+/// <reference path='../dropdown/soho-dropdown.d.ts' />
+
+/** Defines a Module Nav Switcher Role Record
+ * (Takes the same arguments as items present in the Soho Dropdown JSON notation)
+ */
+type SohoModuleNavSwitcherRoleRecord = Record<string, unknown>;
+
+/** Defines options present in the Soho Module Nav Switcher */
+interface SohoModuleNavSwitcherOptions {
+  displayMode: SohoModuleNavDisplayMode;
+}
+
+/** Public API for Soho Module Nav Switcher JS component */
+interface SohoModuleNavSwitcher {
+  /** Module Nav Switcher's current settings */
+  settings: SohoModuleNavSwitcherOptions;
+
+  /** Reference to jQuery-wrapped HTML Element representing the Soho Accordion */
+  accordionEl?: HTMLElement;
+
+  /** Reference to a Soho Accordion API, if one is available */
+  accordionAPI?: SohoAccordionStatic;
+
+  /** Reference to container element */
+  containerEl?: HTMLElement;
+
+  /** Reference to the Module Button's Container Element */
+  moduleButtonContainerEl?: HTMLElement;
+
+  /** Reference to the Module Button element */
+  moduleButtonEl?: HTMLElement;
+
+  /** Reference to the Module Button's Soho Button API, if one is available */
+  moduleButtonAPI?: SohoButtonStatic;
+
+  /** Reference to the Role Dropdown's container element */
+  roleDropdownContainerEl?: HTMLElement;
+
+  /** Reference to the Role Dropdown's element */
+  roleDropdownEl?: HTMLElement;
+
+  /** Reference to the Module Button's Soho Button API, if one is available */
+  roleDropdownAPI?: SohoButtonStatic;
+
+  /** Changes the Module Nav Switcher's Display Mode */
+  setDisplayMode(val?: SohoModuleNavDisplayMode): void;
+
+  /** Sets visible */
+  setRoles(val?: SohoModuleNavSwitcherRoleRecord[], doUpdate?: boolean): void;
+
+  /** Re-renders jQuery child component APIs */
+  renderChildComponents(): void;
+
+  /** Tear down the markup for the control */
+  teardown(): void;
+
+  /** Updates the monthview with any new settings */
+  updated(): void;
+
+  /** Destroys the control on completion. */
+  destroy(): void;
+}
+
+/** jQuery interface for Module Nav Switcher */
+interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
+  modulenavswitcher(options?: SohoModuleNavSwitcherOptions): JQuery;
+  on(events: 'updated', handler: JQuery.EventHandlerBase<any, SohoModuleNavSwitcherOptions>): this;
+}

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
@@ -3,14 +3,14 @@
 
 /** Defines options present in the Soho Module Nav */
 interface SohoModuleNavOptions {
-  displayMode: SohoModuleNavDisplayMode;
-  filterable: boolean;
-  pinSections: boolean;
-  showDetailView: boolean;
+  displayMode?: SohoModuleNavDisplayMode;
+  filterable?: boolean;
+  pinSections?: boolean;
+  showDetailView?: boolean;
 }
 
 /** Public API for Soho Module Nav JS component */
-interface SohoModuleNav {
+interface SohoModuleNavStatic {
   /** Module Nav's current settings */
   settings: SohoModuleNavOptions;
 
@@ -30,19 +30,22 @@ interface SohoModuleNav {
   settingsEl?: HTMLElement;
 
   /** Reference to a Soho Module Nav Settings API, if one is available */
-  settingAPI?: SohoModuleNavSettings;
+  settingAPI?: SohoModuleNavSettingsStatic;
 
   /** Reference to a Soho Module Nav Switcher container element, if one is available */
   switcherEl?: HTMLElement;
 
   /** Reference to a Soho Module Nav Settings API, if one is available */
-  switcherAPI?: SohoModuleNavSwitcher;
+  switcherAPI?: SohoModuleNavSwitcherStatic;
 
   /** Misc. references to specific sections/elements */
   containerEl?: HTMLElement;
   detailViewEl?: HTMLElement;
   itemMenuEl?: HTMLElement;
   footerEl?: HTMLElement;
+
+  /** Initializes the jQuery component */
+  init(): void;
 
   /** Changes the Module Nav's Display Mode */
   setDisplayMode(val?: SohoModuleNavDisplayMode): void;
@@ -59,8 +62,8 @@ interface SohoModuleNav {
   /** Tear down the markup for the control */
   teardown(): void;
 
-  /** Updates the monthview with any new settings */
-  updated(): void;
+  /** Updates the Module Nav with any new settings */
+  updated(newSettings?: SohoModuleNavOptions): void;
 
   /** Destroys the control on completion. */
   destroy(): void;

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
@@ -1,0 +1,73 @@
+/// <reference path='./soho-module-nav-common.d.ts' />
+/// <reference path='../accordion/soho-accordion.d.ts' />
+
+/** Defines options present in the Soho Module Nav */
+interface SohoModuleNavOptions {
+  displayMode: SohoModuleNavDisplayMode;
+  filterable: boolean;
+  pinSections: boolean;
+  showDetailView: boolean;
+}
+
+/** Public API for Soho Module Nav JS component */
+interface SohoModuleNav {
+  /** Module Nav's current settings */
+  settings: SohoModuleNavOptions;
+
+  /** Reference to element representing accordion, if one is available */
+  accordionEl?: HTMLElement;
+
+  /** Reference to a Soho Accordion API, if one is available */
+  accordionAPI?: SohoAccordionStatic;
+
+  /** Reference to element representing searchfield, if one is available */
+  searchEl?: HTMLElement;
+
+  /** Reference to a Soho SearchField API, if one is available */
+  searchAPI?: SohoSearchFieldStatic;
+
+  /** Reference to element representing settings button, if one is available */
+  settingsEl?: HTMLElement;
+
+  /** Reference to a Soho Module Nav Settings API, if one is available */
+  settingAPI?: SohoModuleNavSettings;
+
+  /** Reference to a Soho Module Nav Switcher container element, if one is available */
+  switcherEl?: HTMLElement;
+
+  /** Reference to a Soho Module Nav Settings API, if one is available */
+  switcherAPI?: SohoModuleNavSwitcher;
+
+  /** Misc. references to specific sections/elements */
+  containerEl?: HTMLElement;
+  detailViewEl?: HTMLElement;
+  itemMenuEl?: HTMLElement;
+  footerEl?: HTMLElement;
+
+  /** Changes the Module Nav's Display Mode */
+  setDisplayMode(val?: SohoModuleNavDisplayMode): void;
+
+  /** Enables (true)/Disables (false) optional pinning of header/footer Module Nav regions */
+  setPinSections(val?: boolean): void;
+
+  /** Updates accordion section scroll state based on size changes */
+  setScrollable(): void;
+
+  /** Enables (true)/Disables (false) visibility of detail view pane used for sub modules */
+  setShowDetailView(val: boolean): void;
+
+  /** Tear down the markup for the control */
+  teardown(): void;
+
+  /** Updates the monthview with any new settings */
+  updated(): void;
+
+  /** Destroys the control on completion. */
+  destroy(): void;
+}
+
+/** jQuery interface for Module Nav */
+interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
+  modulenav(options?: SohoModuleNavOptions): JQuery;
+  on(events: 'updated', handler: JQuery.EventHandlerBase<any, SohoModuleNavOptions>): this;
+}

--- a/projects/ids-enterprise-typings/lib/popupmenu/soho-popupmenu.d.ts
+++ b/projects/ids-enterprise-typings/lib/popupmenu/soho-popupmenu.d.ts
@@ -57,6 +57,9 @@ interface SohoPopupMenuOptions {
 
   /** Add extra attributes like id's to the component **/
   attributes?: Array<Object> | Object;
+
+  /** Appends an optional css class to `.popupmenu-wrapper/popupmenu` elements  */
+  cssClass?: string | null;
 }
 
 /**
@@ -74,6 +77,9 @@ interface SohoPopupMenuStatic {
 
   /** Configuration options. */
   settings?: SohoPopupMenuOptions;
+
+  /** Gets the Popupmenu's ID string (can be used to query the DOM for the menu element) */
+  idString: string | undefined;
 
   /** Returns the selected html element. */
   getSelected(): any;

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -2,9 +2,12 @@ soho-masthead {
   display: block;
 }
 
-demoapp-nav-container,
-module-nav-demo {
+demoapp-nav-container {
   display: block;
+}
+
+module-nav-demo {
+  display: contents;
 }
 
 app-masthead-demo + demoapp-nav-container {

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -2,6 +2,15 @@ soho-masthead {
   display: block;
 }
 
+demoapp-nav-container,
+module-nav-demo {
+  display: block;
+}
+
+app-masthead-demo + demoapp-nav-container {
+  height: calc(100vh - 38px); /* 38px = masthead height */
+}
+
 .code-tag {
   font-size: 12px;
   font-size: 1.2rem;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,19 +7,11 @@
 
 <app-masthead-demo></app-masthead-demo>
 
-<nav soho-application-menu class="is-personalizable" [filterable]="true" [openOnLarge]="false"
-  [dismissOnClickMobile]="true" (menuVisibility)="onMenuVisibility($event)" [resizable]="true"
-  [savePosition]="true">
-  <div soho-searchfield-wrapper>
-    <label class="audible" for="application-menu-searchfield">Search</label>
-    <input soho-searchfield id="application-menu-searchfield" [clearable]="true" />
-  </div>
-  <application-menu-demo></application-menu-demo>
-</nav>
-<div class="page-container no-scroll">
+<demoapp-nav-container>
   <app-header-dynamic-demo></app-header-dynamic-demo>
   <div id="maincontent" class="page-container scrollable" role="main">
-      <router-outlet></router-outlet>
+    <router-outlet></router-outlet>
   </div>
-</div>
+</demoapp-nav-container>
+
 <div soho-personalize (changetheme)="onChangeTheme($event)"></div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,30 +7,28 @@ import {
 } from '@angular/core';
 
 import { HeaderDynamicDemoRefService } from './header/header-dynamic-demo-ref.service';
+import { DemoappNavContainerComponent } from './demoapp-nav-container/demoapp-nav-container';
+
 // @ts-ignore
-import { SohoPersonalizeDirective, SohoRenderLoopService, SohoApplicationMenuComponent } from 'ids-enterprise-ng';
+import {
+  SohoPersonalizeDirective,
+  SohoRenderLoopService,
+  SohoApplicationMenuComponent
+} from 'ids-enterprise-ng';
 
 @Component({
   selector: 'body', // eslint-disable-line
   templateUrl: 'app.component.html',
-  styleUrls: ['./app.component.css'],
-  providers: [HeaderDynamicDemoRefService],
+  styleUrls: [
+    './app.component.css'
+  ],
+  providers: [
+    HeaderDynamicDemoRefService
+  ],
   encapsulation: ViewEncapsulation.None
 })
 export class AppComponent implements AfterViewInit {
-  /**
-   * Local Storage Key
-   */
-  private static IS_APPLICATION_MENU_OPEN_KEY = 'is-application-menu-open';
-
-  @ViewChild(SohoApplicationMenuComponent, { static: true })
-  public applicationMenu?: SohoApplicationMenuComponent;
-
   @ViewChild(SohoPersonalizeDirective, { static: true }) personalize?: SohoPersonalizeDirective;
-
-  @HostBinding('class.no-scroll') get isNoScroll() {
-    return true;
-  }
 
   /**
    * Include the new icons only if required by the current theme, this
@@ -49,27 +47,6 @@ export class AppComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
 
-    /**
-     * Note: If using an input like [triggers]="[ '.application-menu-trigger' ]"
-     * hookup the app menu trigger once the afterViewInit is called. This will
-     * ensure that the toolbar has had a chance to create the application-menu-trugger
-     * button.
-     * this.applicationMenu.triggers = [ '.application-menu-trigger' ];
-     */
-    if (this.isApplicationMenuOpen) {
-      this.applicationMenu?.openMenu(true, true);
-    } else {
-      this.applicationMenu?.closeMenu();
-    }
-  }
-
-  public get isApplicationMenuOpen(): boolean {
-    const valueString = localStorage.getItem(AppComponent.IS_APPLICATION_MENU_OPEN_KEY);
-    return valueString ? (valueString === 'true') : true;
-  }
-
-  public set isApplicationMenuOpen(open: boolean) {
-    localStorage.setItem(AppComponent.IS_APPLICATION_MENU_OPEN_KEY, open ? 'true' : 'false');
   }
 
   onChangeTheme(ev: SohoPersonalizeEvent) {
@@ -79,11 +56,5 @@ export class AppComponent implements AfterViewInit {
       || ev.data.theme === 'theme-new-light'
       || ev.data.theme === 'theme-new-dark'
       || ev.data.theme === 'theme-new-contrast';
-  }
-
-  public onMenuVisibility(visible: boolean): void {
-    if (this.isApplicationMenuOpen !== visible) {
-      this.isApplicationMenuOpen = visible;
-    }
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -186,6 +186,7 @@ import { MaskDemoComponent } from './mask/mask.demo';
 import { MenuButtonDemoComponent } from './menu-button/menu-button.demo';
 import { MessageDemoComponent } from './message/message.demo';
 import { ModalDialogDemoModule } from './modal-dialog/modal-dialog.demo.module';
+import { ModuleNavDemoComponent } from './module-nav/module-nav.demo';
 import { MonthViewDemoComponent } from './monthview/monthview.demo';
 import { MonthViewDemoInPageComponent } from './monthview/monthview-inpage.demo';
 import { NotificationDemoComponent } from './notification/notification.demo';
@@ -291,6 +292,7 @@ import { ListBuilderDemoComponent } from './listbuilder/listbuilder.demo';
 import { MonthViewLegendDemoComponent } from './monthview/monthview-legend.demo';
 import { DataGridRowSpanDemoComponent } from './datagrid/datagrid-rowspan.demo';
 import { DonutColorsDemoComponent } from './donut/donut-colors.demo';
+import { DemoappNavContainerComponent } from './demoapp-nav-container/demoapp-nav-container';
 
 @NgModule({
   declarations: [
@@ -408,6 +410,7 @@ import { DonutColorsDemoComponent } from './donut/donut-colors.demo';
     DataGridSummaryRowDemoComponent,
     DataGridRowSpanDemoComponent,
     DatepickerDemoComponent,
+    DemoappNavContainerComponent,
     DemoCellInputEditorComponent,
     DemoCellFormatterComponent,
     DemoCellIntegerFormatterComponent,
@@ -470,6 +473,7 @@ import { DonutColorsDemoComponent } from './donut/donut-colors.demo';
     MaskDemoComponent,
     MenuButtonDemoComponent,
     MessageDemoComponent,
+    ModuleNavDemoComponent,
     MonthViewDemoComponent,
     MonthViewDemoInPageComponent,
     MonthViewLegendDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -144,6 +144,7 @@ import { MaskDemoComponent } from './mask/mask.demo';
 import { MenuButtonDemoComponent } from './menu-button/menu-button.demo';
 import { MessageDemoComponent } from './message/message.demo';
 import { ModalDialogDemoComponent } from './modal-dialog/modal-dialog.demo';
+import { ModuleNavDemoComponent } from './module-nav/module-nav.demo';
 import { MonthViewDemoComponent } from './monthview/monthview.demo';
 import { MonthViewDemoInPageComponent } from './monthview/monthview-inpage.demo';
 import { NotificationDemoComponent } from './notification/notification.demo';
@@ -407,6 +408,7 @@ export const routes: Routes = [
   { path: 'menu-button', component: MenuButtonDemoComponent },
   { path: 'message', component: MessageDemoComponent },
   { path: 'modal-dialog', component: ModalDialogDemoComponent },
+  { path: 'module-nav', component: ModuleNavDemoComponent },
   { path: 'monthview', component: MonthViewDemoComponent },
   { path: 'monthview-inpage', component: MonthViewDemoInPageComponent },
   { path: 'monthview-legend', component: MonthViewLegendDemoComponent },

--- a/src/app/application-menu/application-menu.demo.html
+++ b/src/app/application-menu/application-menu.demo.html
@@ -215,6 +215,7 @@
     <div class="accordion-header list-item"><a [routerLink]="['menu-button']"><span>Menu Button</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['message']"><span>Message</span></a></div>
     <div class="accordion-header list-item"><a [routerLink]="['modal-dialog']"><span>Modal Dialog</span></a></div>
+    <div class="accordion-header list-item"><a [routerLink]="['module-nav']">Module Nav</a></div>
     <div class="accordion-header list-item"><a [routerLink]="['monthview']">Monthview</a></div>
     <div class="accordion-header list-item"><a [routerLink]="['monthview-inpage']">Monthview - In Page</a></div>
     <div class="accordion-header list-item"><a [routerLink]="['monthview-legend']">Monthview - Legend</a></div>

--- a/src/app/demoapp-nav-container/README.md
+++ b/src/app/demoapp-nav-container/README.md
@@ -1,0 +1,3 @@
+# NOTE
+
+This component should NOT be used in production.  It is for demo purposes only.

--- a/src/app/demoapp-nav-container/demoapp-nav-container.html
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.html
@@ -30,7 +30,9 @@
       [ngClass]="{ 'module-nav-container': true }">
     <soho-module-nav
       [ngClass]="{ 'module-nav': true }"
-      [displayMode]="moduleNavDisplayMode">
+      [displayMode]="'expanded'"
+      [filterable]="true"
+      [pinSections]="true">
       <module-nav-demo></module-nav-demo>
     </soho-module-nav>
     <div class="page-container no-scroll">

--- a/src/app/demoapp-nav-container/demoapp-nav-container.html
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.html
@@ -32,7 +32,8 @@
       [ngClass]="{ 'module-nav': true }"
       [displayMode]="'expanded'"
       [filterable]="true"
-      [pinSections]="true">
+      [pinSections]="true"
+      (appMenuTriggerClick)="toggleModuleNavDisplayMode()">
       <module-nav-demo></module-nav-demo>
     </soho-module-nav>
     <div class="page-container no-scroll has-module-nav-offset">

--- a/src/app/demoapp-nav-container/demoapp-nav-container.html
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.html
@@ -1,0 +1,40 @@
+<!-- Either an App Menu or Module Nav will be rendered -->
+<ng-container
+  *ngIf="menuType === 'application-menu'; then useAppMenu; else useModuleNav">
+</ng-container>
+
+<ng-template #useAppMenu>
+  <!-- App Menu is rendered (default) -->
+  <nav soho-application-menu
+    class="is-personalizable"
+    [filterable]="true"
+    [openOnLarge]="false"
+    [dismissOnClickMobile]="true"
+    (menuVisibility)="onMenuVisibility($event)"
+    [resizable]="true"
+    [savePosition]="true">
+    <div soho-searchfield-wrapper>
+      <label class="audible" for="application-menu-searchfield">Search</label>
+      <input soho-searchfield id="application-menu-searchfield" [clearable]="true" />
+    </div>
+    <application-menu-demo></application-menu-demo>
+  </nav>
+  <div class="page-container no-scroll">
+    <ng-content></ng-content>
+  </div>
+</ng-template>
+
+<ng-template #useModuleNav>
+  <!-- Module Nav is rendered -->
+  <soho-module-nav-container
+      [ngClass]="{ 'module-nav-container': true }">
+    <soho-module-nav
+      [ngClass]="{ 'module-nav': true }"
+      [displayMode]="moduleNavDisplayMode">
+      <module-nav-demo></module-nav-demo>
+    </soho-module-nav>
+    <div class="page-container no-scroll">
+      <ng-content></ng-content>
+    </div>
+  </soho-module-nav-container>
+</ng-template>

--- a/src/app/demoapp-nav-container/demoapp-nav-container.html
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.html
@@ -35,7 +35,7 @@
       [pinSections]="true">
       <module-nav-demo></module-nav-demo>
     </soho-module-nav>
-    <div class="page-container no-scroll">
+    <div class="page-container no-scroll has-module-nav-offset">
       <ng-content></ng-content>
     </div>
   </soho-module-nav-container>

--- a/src/app/demoapp-nav-container/demoapp-nav-container.ts
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.ts
@@ -69,7 +69,7 @@ export class DemoappNavContainerComponent implements AfterViewInit {
    */
   public get menuType(): DemoappMenuStyle {
     const menuType = localStorage.getItem(this.MENU_TYPE_KEY) as DemoappMenuStyle | undefined;
-    return menuType ? menuType : APP_MENU;
+    return menuType ? menuType : MODULE_NAV;
   }
 
   /**

--- a/src/app/demoapp-nav-container/demoapp-nav-container.ts
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.ts
@@ -166,6 +166,15 @@ export class DemoappNavContainerComponent implements AfterViewInit {
 
   }
 
+  /**
+   * Runs after a captured app menu trigger is clicked
+   */
+  toggleModuleNavDisplayMode() {
+    console.info('event captured')
+    const isCurrentlyCollapsed = this.moduleNavDisplayMode === 'collapsed';
+    this.moduleNavDisplayMode = isCurrentlyCollapsed ? 'expanded' : 'collapsed';
+  }
+
   public onMenuVisibility(visible: boolean): void {
     if (this.isApplicationMenuOpen !== visible) {
       this.isApplicationMenuOpen = visible;

--- a/src/app/demoapp-nav-container/demoapp-nav-container.ts
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.ts
@@ -1,0 +1,174 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostBinding,
+  NgZone,
+  Output,
+  ViewEncapsulation,
+  ViewChild
+} from '@angular/core';
+
+// @ts-ignore
+import {
+  SohoApplicationMenuComponent,
+  SohoModuleNavContainerComponent,
+  SohoModuleNavComponent
+} from 'ids-enterprise-ng';
+
+import {
+  ApplicationMenuDemoComponent
+} from '../application-menu/application-menu.demo';
+
+import {
+  ModuleNavDemoComponent
+} from '../module-nav/module-nav.demo';
+
+type DemoappMenuStyle = 'application-menu' | 'module-nav';
+
+const APP_MENU = 'application-menu';
+const MODULE_NAV = 'module-nav';
+
+@Component({
+  selector: 'demoapp-nav-container', // eslint-disable-line
+  templateUrl: 'demoapp-nav-container.html',
+  encapsulation: ViewEncapsulation.None
+})
+export class DemoappNavContainerComponent implements AfterViewInit {
+  /** Local Storage Keys */
+  private static IS_APPLICATION_MENU_OPEN_KEY = 'is-application-menu-open';
+  private readonly MENU_TYPE_KEY = 'ids-ng-demoapp-menu-type';
+  private readonly MODULE_NAV_DISPLAY_MODE_KEY = 'ids-ng-demoapp-module-nav-display-mode';
+
+  private jQueryElement!: JQuery | undefined;
+
+  @Output() moduleNavIsExpanded = new EventEmitter<boolean>();
+
+  /** App Menu component refs */
+  @ViewChild(SohoApplicationMenuComponent, { static: true })
+  public applicationMenu?: SohoApplicationMenuComponent;
+
+  /** Module Nav component refs */
+  @ViewChild(SohoModuleNavContainerComponent, { static: true })
+  public moduleNavContainer?: SohoModuleNavContainerComponent;
+  @ViewChild(SohoModuleNavComponent, { static: true })
+  public moduleNav?: SohoModuleNavComponent;
+
+  @HostBinding('class.no-scroll') get isNoScroll() {
+    return true;
+  }
+
+  constructor(private element: ElementRef, private ngZone: NgZone) {
+    this.moduleNavDisplayMode = 'expanded';
+  }
+
+  /**
+   * Returns the currently selected main menu component type,
+   * defaulting to a sensible default color if one is not yet set.
+   */
+  public get menuType(): DemoappMenuStyle {
+    const menuType = localStorage.getItem(this.MENU_TYPE_KEY) as DemoappMenuStyle | undefined;
+    return menuType ? menuType : APP_MENU;
+  }
+
+  /**
+   * Set the current main menu component type,
+   * storing it such that it perists between sessions.
+   */
+  public set menuType(menuType: DemoappMenuStyle | string) {
+    if (menuType === '') {
+      localStorage.removeItem(this.MENU_TYPE_KEY);
+      return;
+    }
+    localStorage.setItem(this.MENU_TYPE_KEY, menuType);
+  }
+
+  /**
+   * Returns the currently selected Module Nav Display Mode,
+   * defaulting to a sensible default setting if one is not yet set.
+   */
+  public get moduleNavDisplayMode(): SohoModuleNavDisplayMode {
+    const displayMode = localStorage.getItem(this.MODULE_NAV_DISPLAY_MODE_KEY) as SohoModuleNavDisplayMode;
+    if (displayMode && ['collapsed', 'expanded'].includes(displayMode)) {
+      return displayMode;
+    }
+    return false;
+  }
+
+  /**
+   * Set the current Module Nav display mode,
+   * storing it such that it perists between sessions.
+   */
+  public set moduleNavDisplayMode(displayMode: SohoModuleNavDisplayMode) {
+    if (!displayMode) {
+      localStorage.removeItem(this.MODULE_NAV_DISPLAY_MODE_KEY);
+    } else {
+      localStorage.setItem(this.MODULE_NAV_DISPLAY_MODE_KEY, displayMode);
+    }
+
+    if (this.moduleNavContainer) {
+      this.moduleNav?.updated({ displayMode });
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.ngZone.runOutsideAngular(() => {
+      this.jQueryElement = jQuery(this.element.nativeElement);
+
+      // Module Nav Component events
+      if (this.moduleNavContainer) {
+        this.jQueryElement
+          .on('click', '.application-menu-trigger', (e: any) => {
+            debugger;
+            const target = (e.target);
+            if (this.moduleNavDisplayMode === 'collapsed') this.moduleNavDisplayMode = 'expanded';
+            else this.moduleNavDisplayMode = 'collapsed';
+          });
+      }
+    });
+
+    /**
+     * Note: If using an input like [triggers]="[ '.application-menu-trigger' ]"
+     * hookup the app menu trigger once the afterViewInit is called. This will
+     * ensure that the toolbar has had a chance to create the application-menu-trugger
+     * button.
+     * this.applicationMenu.triggers = [ '.application-menu-trigger' ];
+     */
+    if (this.applicationMenu) {
+      if (this.isApplicationMenuOpen) {
+        this.applicationMenu?.openMenu(true, true);
+      } else {
+        this.applicationMenu?.closeMenu();
+      }
+    }
+
+    /**
+     * Configures the demo app's Module Nav, if one is present
+     */
+    if (this.moduleNavContainer) {
+      if (this.moduleNavDisplayMode) {
+        this.moduleNav?.updated({ displayMode: this.moduleNavDisplayMode });
+      }
+    }
+  }
+
+  public get isApplicationMenuOpen(): boolean {
+    const valueString = localStorage.getItem(DemoappNavContainerComponent.IS_APPLICATION_MENU_OPEN_KEY);
+    return valueString ? (valueString === 'true') : true;
+  }
+
+  public set isApplicationMenuOpen(open: boolean) {
+    localStorage.setItem(DemoappNavContainerComponent.IS_APPLICATION_MENU_OPEN_KEY, open ? 'true' : 'false');
+  }
+
+  onChangeTheme(ev: SohoPersonalizeEvent) {
+
+  }
+
+  public onMenuVisibility(visible: boolean): void {
+    if (this.isApplicationMenuOpen !== visible) {
+      this.isApplicationMenuOpen = visible;
+    }
+  }
+}

--- a/src/app/header/header-dynamic.demo.html
+++ b/src/app/header/header-dynamic.demo.html
@@ -12,7 +12,7 @@
 
     <soho-toolbar-flex #appDynamicHeaderToolbar maxVisibleButtons="5" hasMoreButton="!currentToolbarOptions">
 
-      <button soho-toolbar-flex-nav-button>Show Navigation</button>
+      <button soho-toolbar-flex-nav-button (click)="onAppMenuTriggerClick()">Show Navigation</button>
 
       <soho-toolbar-flex-section [isTitle]="true">
         <h1>

--- a/src/app/header/header-dynamic.demo.html
+++ b/src/app/header/header-dynamic.demo.html
@@ -9,28 +9,28 @@
 </ng-template>
 <ng-template [ngIf]="getRoute() === 'default'">
   <soho-header [hasTabs]="hasHeaderTabs" [hasToolbar]="hasHeaderToolbar">
-  
+
     <soho-toolbar-flex #appDynamicHeaderToolbar maxVisibleButtons="5" hasMoreButton="!currentToolbarOptions">
-  
-      <button soho-toolbar-flex-nav-button>Show Navigation</button>
-  
+
+      <button (click)='onAppMenuTriggerClick()' soho-toolbar-flex-nav-button>Show Navigation</button>
+
       <soho-toolbar-flex-section [isTitle]="true">
         <h1>
           <span soho-toolbar-flex-page-title>IDS Enterprise Angular Components</span>
           <span soho-toolbar-flex-section-title *ngIf="sectionTitle">{{sectionTitle}}</span>
         </h1>
       </soho-toolbar-flex-section>
-  
+
       <!-- If the currentToolbarOptions are NOT null/undefined then display the toolbar buttons
            using the toolbarOptions input. -->
       <!-- todo ppatton - for some reason if I put the ngIf='false' in the soho-toolbar-button-set
            then some div seems to be automatically created for me or something. Something in soho perhaps? -->
       <soho-toolbar-flex-section [isButtonSet]="true">
-  
+
         <ng-template [ngIf]="currentToolbarOptions">
           <ng-template ngFor let-button [ngForOf]="currentToolbarOptions?.toolbarButtons">
             <button *ngIf="!button.menu" soho-button="{{button?.type}}" isToggle="{{button?.istoggle}}" icon="{{button?.icon}}" id="{{button?.id}}" attr.data-button="{{button?.data}}" toggleOnIcon="{{button?.toggleOnIcon}}" toggleOffIcon="{{button?.toggleOffIcon}}">{{button?.text}}</button>
-  
+
             <ng-template [ngIf]="button.menu">
               <button soho-menu-button id="{{button?.id}}" menu="buttonPopupMenu" icon="{{button?.icon}}"  attr.data-button="{{button?.data}}" >
                 {{button?.text}}</button>
@@ -44,17 +44,17 @@
             </ng-template>
           </ng-template>
         </ng-template>
-  
+
       </soho-toolbar-flex-section>
-  
+
       <!-- If the currentToolbarOptions are null/undefined then display the "default" toolbar buttons
            and more menu. -->
       <soho-toolbar-flex-more-button [isPageChanger]="true">
         <app-personalize-menu ></app-personalize-menu>
       </soho-toolbar-flex-more-button>
-  
+
     </soho-toolbar-flex>
-  
+
     <div soho-tabs *ngIf="currentTabsOptions" #appDynamicHeaderTabs [containerElement]="currentTabsOptions.containerElementSelector">
       <div soho-tab-list-container>
         <ul soho-tab-list>
@@ -64,6 +64,6 @@
         </ul>
       </div>
     </div>
-  
+
   </soho-header>
 </ng-template>

--- a/src/app/header/header-dynamic.demo.html
+++ b/src/app/header/header-dynamic.demo.html
@@ -12,7 +12,7 @@
 
     <soho-toolbar-flex #appDynamicHeaderToolbar maxVisibleButtons="5" hasMoreButton="!currentToolbarOptions">
 
-      <button (click)='onAppMenuTriggerClick()' soho-toolbar-flex-nav-button>Show Navigation</button>
+      <button soho-toolbar-flex-nav-button>Show Navigation</button>
 
       <soho-toolbar-flex-section [isTitle]="true">
         <h1>

--- a/src/app/header/header-dynamic.demo.ts
+++ b/src/app/header/header-dynamic.demo.ts
@@ -143,7 +143,6 @@ export class SohoHeaderDynamicDemoComponent {
   }
 
   onAppMenuTriggerClick() {
-    console.info('does it work?');
-    console.dir(this);
+    console.info('App Menu trigger click');
   }
 }

--- a/src/app/header/header-dynamic.demo.ts
+++ b/src/app/header/header-dynamic.demo.ts
@@ -1,7 +1,10 @@
 import {
   Component,
+  EventEmitter,
   HostBinding,
   Input,
+  NgZone,
+  Output,
   ViewChild
 } from '@angular/core';
 import {
@@ -79,6 +82,11 @@ export class SohoHeaderDynamicDemoComponent {
     });
   }
 
+  /**
+   * Triggers NG events that can be picked up by a navigation container
+   */
+  @Output() appMenuTriggerClick = new EventEmitter();
+
   get toolbarSearchField(): ToolbarSearchField {
     return this._toolbarSearchField;
   }
@@ -105,7 +113,11 @@ export class SohoHeaderDynamicDemoComponent {
   public defaultPersonalizeColor?: string | null;
   public defaultPersonalizeTheme?: string | null;
 
-  constructor(private headerRef: HeaderDynamicDemoRefService, public router: Router) {
+  constructor(
+    private headerRef: HeaderDynamicDemoRefService,
+    private ngZone: NgZone,
+    public router: Router,
+  ) {
     this.headerRef.instance = this;
     this.defaultPersonalizeColor = this.getDefaultColor();
     this.defaultPersonalizeTheme = this.getDefaultTheme();
@@ -142,7 +154,11 @@ export class SohoHeaderDynamicDemoComponent {
     return 'default';
   }
 
-  onAppMenuTriggerClick() {
+  onAppMenuTriggerClick(args: MouseEvent) {
     console.info('App Menu trigger click');
+
+    this.ngZone.run(() => {
+      this.appMenuTriggerClick.next(args);
+    });
   }
 }

--- a/src/app/header/header-dynamic.demo.ts
+++ b/src/app/header/header-dynamic.demo.ts
@@ -141,4 +141,9 @@ export class SohoHeaderDynamicDemoComponent {
     }
     return 'default';
   }
+
+  onAppMenuTriggerClick() {
+    console.info('does it work?');
+    console.dir(this);
+  }
 }

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -1,20 +1,52 @@
 <div class="module-nav-bar">
   <soho-accordion
-    [ngClass]="{ 'accordion': true, 'panel': true, 'module-nav-accordion': true }"
+    [ngClass]="{
+      'accordion': true,
+      'panel': true,
+      'module-nav-accordion': true
+    }"
     [allowOnePane]="false"
     [rerouteOnLinkClick]="false">
 
-    <div class="module-nav-switcher accordion-section">
-
+    <div class="module-nav-header accordion-section">
+      <div class="module-nav-switcher">
+        <div class="module-nav-section role-dropdown">
+          <label for="module-nav-role-switcher" class="label audible">Roles</label>
+          <select id="module-nav-role-switcher" name="module-nav-role-switcher" class="dropdown"
+            data-automation-id="custom-automation-dropdown-id">
+            <option value="admin" data-icon="{icon: 'database'}">Admin</option>
+            <option value="job-console" data-icon="{icon: 'database'}">Job Console</option>
+            <option value="landing-page-designer" data-icon="{icon: 'database'}">Landing Page Designer</option>
+            <option value="process-server-admin" data-icon="{icon: 'database'}">Process Server Administrator</option>
+            <option value="proxy-management" data-icon="{icon: 'database'}">Proxy Management</option>
+            <option value="security-system-management" data-icon="{icon: 'database'}">Security System Management</option>
+            <option value="user-management" data-icon="{icon: 'database'}">User Management</option>
+          </select>
+        </div>
+      </div>
     </div>
 
-    <div class="module-nav-search accordion-section">
-
+    <div class="module-nav-search-container accordion-section">
+      <label for="module-nav-searchfield" class="audible">Search</label>
+      <input soho-searchfield
+        id="module-nav-searchfield"
+        name="module-nav-searchfield"
+        placeholder="Search"
+        [ngClass]="{
+          'searchfield': true,
+          'module-nav-search': true
+        }"
+        [options]="searchfieldOptions"
+        (change)="onChange($event)" />
     </div>
 
     <div class="module-nav-main accordion-section">
       <!-- A -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>A</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>A</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['about']"><span>About</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['about-nested']"><span>About (Nested)</span></a></soho-accordion-header>
@@ -36,7 +68,11 @@
       </soho-accordion-pane>
 
       <!-- B -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>B</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>B</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['bar']"><span>Bar Chart</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['bar-grouped']"><span>Bar Chart-Grouped</span></a></soho-accordion-header>
@@ -60,7 +96,11 @@
       </soho-accordion-pane>
 
       <!-- C -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>C</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>C</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['calendar-monthview']"><span>Calendar Monthview</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['calendar-monthview-legend']"><span>Calendar Monthview and Legend</span></a></soho-accordion-header>
@@ -93,7 +133,11 @@
       </soho-accordion-pane>
 
       <!-- D -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>D</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>D</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['datagrid-sandbox']"><span>DataGrid - Sandbox</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['datagrid-add-row']"><span>DataGrid - Add Row</span></a></soho-accordion-header>
@@ -155,7 +199,11 @@
       </soho-accordion-pane>
 
       <!-- E -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>E</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>E</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['emptymessage']"><span>Empty Message</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['error']"><span>Error</span></a></soho-accordion-header>
@@ -164,7 +212,11 @@
       </soho-accordion-pane>
 
       <!-- F -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>F</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>F</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['field-filter']"><span>Field Filter</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['field-options']"><span>Field Options</span></a></soho-accordion-header>
@@ -177,7 +229,11 @@
       </soho-accordion-pane>
 
       <!-- H -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>H</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>H</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['header-toolbar']"><span>Header - Toolbar</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['header-tabs']"><span>Header - Tabs</span></a></soho-accordion-header>
@@ -198,14 +254,22 @@
       </soho-accordion-pane>
 
       <!-- I -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>I</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>I</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['icon']"><span>Icon</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['input-clearable']"><span>Input - Clear</span></a></soho-accordion-header>
       </soho-accordion-pane>
 
       <!-- L -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>L</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>L</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['label']"><span>Label</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['line']"><span>Line Chart</span></a></soho-accordion-header>
@@ -222,7 +286,11 @@
       </soho-accordion-pane>
 
       <!-- M -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>M</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>M</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['mask']"><span>Mask</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['mask-legacy']"><span>Mask Legacy</span></a></soho-accordion-header>
@@ -236,7 +304,11 @@
       </soho-accordion-pane>
 
       <!-- N -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>N</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>N</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['notification']"><span>Notification</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['notification-badge-placement']"><span>Notification Badge - Placement</span></a></soho-accordion-header>
@@ -244,7 +316,11 @@
       </soho-accordion-pane>
 
       <!-- P -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>P</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>P</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['pager-standalone']"><span>Pager - Standalone</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['personalize-color-api']"><span>Personalize Color API</span></a></soho-accordion-header>
@@ -255,7 +331,11 @@
       </soho-accordion-pane>
 
       <!-- R -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>R</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>R</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['radar']"><span>Radar Chart</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['radiobutton']"><span>Radio Button</span></a></soho-accordion-header>
@@ -264,7 +344,11 @@
       </soho-accordion-pane>
 
       <!-- S -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>S</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>S</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['searchfield']"><span>Search Field</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['searchfield-category']"><span>Search Field - Category</span></a></soho-accordion-header>
@@ -290,7 +374,11 @@
       </soho-accordion-pane>
 
       <!-- T -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>T</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>T</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['tabs-basic']"><span>Tabs - Basic</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['tabs-counts']"><span>Tabs - Counts</span></a></soho-accordion-header>
@@ -328,7 +416,11 @@
       </soho-accordion-pane>
 
       <!-- V -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>V</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>V</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['validation']"><span>Validation</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['validation-event']"><span>Validation - Event</span></a></soho-accordion-header>
@@ -336,7 +428,11 @@
       </soho-accordion-pane>
 
       <!-- W -->
-      <soho-accordion-header><a href="javascript:void(0);"><span>W</span></a></soho-accordion-header>
+      <soho-accordion-header>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-folder"></use>
+        </svg>
+        <a href="javascript:void(0);"><span>W</span></a></soho-accordion-header>
       <soho-accordion-pane>
         <soho-accordion-header><a [routerLink]="['week-view']"><span>Week view</span></a></soho-accordion-header>
         <soho-accordion-header><a [routerLink]="['wizard']"><span>Wizard</span></a></soho-accordion-header>
@@ -348,7 +444,93 @@
     </div>
 
     <div class="module-nav-settings accordion-section">
-
+      <div class="module-nav-settings-btn accordion-header" data-automation-id="module-nav-settings"
+        id="module-nav-settings-btn">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-settings"></use>
+        </svg>
+        <a href="#"><span>Settings</span></a>
+      </div>
+      <ul class="popupmenu module-nav-settings-menu">
+        <li>
+          <a href="#">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-observation-precautions"></use>
+            </svg>
+            <span>Jobs</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-report"></use>
+            </svg>
+            <span>Reports</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-isolation"></use>
+            </svg>
+            <span>Actions</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-edit"></use>
+            </svg>
+            <span>Personalization</span>
+          </a>
+        </li>
+        <li class="separator"></li>
+        <li>
+          <a href="#">
+            <span>Create Report</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <span>Proxy</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <span>Set "As Of Date"</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <span>User Context</span>
+          </a>
+        </li>
+        <li class="separator"></li>
+        <li>
+          <a href="#">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-settings"></use>
+            </svg>
+            <span>Settings</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-info"></use>
+            </svg>
+            <span>About</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-help"></use>
+            </svg>
+            <span>Help</span>
+          </a>
+        </li>
+      </ul>
     </div>
   </soho-accordion>
 </div>

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -1,13 +1,7 @@
 <div class="module-nav-bar">
-  <soho-accordion
-    [ngClass]="{
-      'accordion': true,
-      'panel': true,
-      'module-nav-accordion': true
-    }"
-    [allowOnePane]="false"
-    [rerouteOnLinkClick]="false">
-
+  <div soho-accordion
+    class="accordion panel module-nav-accordion"
+    data-options="{ allowOnePane: false, rerouteOnLinkClick: false }">
     <div class="module-nav-header accordion-section">
       <div class="module-nav-switcher">
         <div class="module-nav-section role-dropdown">
@@ -42,401 +36,402 @@
 
     <div class="module-nav-main accordion-section">
       <!-- A -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>A</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['about']"><span>About</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['about-nested']"><span>About (Nested)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['accordion']"><span>Accordion</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['accordion/dynamic']"><span>Accordion Dynamic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['accordion/panels']"><span>Accordion Panels</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['accordion/card']"><span>Accordion Card</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['actionsheet']"><span>Actionsheet</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['actionsheet-with-tray']"><span>Actionsheet - Tray</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['alert']"><span>Alert</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['application-lazy-menu']"><span>Application Lazy Menu</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['application-menu-roleswitcher']"><span>Application Menu Role Switcher</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['application-menu-notification-badge']"><span>Application Menu Notification Badge</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['application-menu-test-performance']"><span>Application Menu Test Performance</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['area']"><span>Area Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['arrange']"><span>Arrange</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['autocomplete']"><span>Autocomplete</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['autocomplete-templates']"><span>Autocomplete with Custom Templates</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>A</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['about']"><span>About</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['about-nested']"><span>About (Nested)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['accordion']"><span>Accordion</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['accordion/dynamic']"><span>Accordion Dynamic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['accordion/panels']"><span>Accordion Panels</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['accordion/card']"><span>Accordion Card</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['actionsheet']"><span>Actionsheet</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['actionsheet-with-tray']"><span>Actionsheet - Tray</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['alert']"><span>Alert</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['application-lazy-menu']"><span>Application Lazy Menu</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['application-menu-roleswitcher']"><span>Application Menu Role Switcher</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['application-menu-notification-badge']"><span>Application Menu Notification Badge</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['application-menu-test-performance']"><span>Application Menu Test Performance</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['area']"><span>Area Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['arrange']"><span>Arrange</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['autocomplete']"><span>Autocomplete</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['autocomplete-templates']"><span>Autocomplete with Custom Templates</span></a></div>
+      </div>
 
       <!-- B -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>B</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['bar']"><span>Bar Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['bar-grouped']"><span>Bar Chart-Grouped</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['bar-stacked']"><span>Bar Chart-Stacked</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['blockgrid-custom-content']"><span>BlockGrid - Custom Content</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['blockgrid-mixed-selection']"><span>BlockGrid - Mixed Selection</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['blockgrid-multi-selection']"><span>BlockGrid - Multi Selection</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['blockgrid-paging']"><span>BlockGrid - Paging</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['blockgrid-single-selection']"><span>BlockGrid - Single Selection</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['breadcrumb']"><span>Breadcrumb</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['breadcrumb-change-contents']"><span>Breadcrumb - Change Contents</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['breadcrumb-css-only']"><span>Breadcrumb - CSS Only</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['breadcrumb-gauntlet']"><span>Breadcrumb Gauntlet</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['bubble']"><span>Bubble Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['bullet']"><span>Bullet Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['button']"><span>Button</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['button-badge']"><span>Button Badge</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['buttonset']"><span>Buttonset</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['busyindicator']"><span>Busy Indicator</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['busyindicatorbody']"><span>Busy Indicator Body</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>B</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['bar']"><span>Bar Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['bar-grouped']"><span>Bar Chart-Grouped</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['bar-stacked']"><span>Bar Chart-Stacked</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['blockgrid-custom-content']"><span>BlockGrid - Custom Content</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['blockgrid-mixed-selection']"><span>BlockGrid - Mixed Selection</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['blockgrid-multi-selection']"><span>BlockGrid - Multi Selection</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['blockgrid-paging']"><span>BlockGrid - Paging</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['blockgrid-single-selection']"><span>BlockGrid - Single Selection</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['breadcrumb']"><span>Breadcrumb</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['breadcrumb-change-contents']"><span>Breadcrumb - Change Contents</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['breadcrumb-css-only']"><span>Breadcrumb - CSS Only</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['breadcrumb-gauntlet']"><span>Breadcrumb Gauntlet</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['bubble']"><span>Bubble Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['bullet']"><span>Bullet Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['button']"><span>Button</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['button-badge']"><span>Button Badge</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['buttonset']"><span>Buttonset</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['busyindicator']"><span>Busy Indicator</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['busyindicatorbody']"><span>Busy Indicator Body</span></a></div>
+      </div>
 
       <!-- C -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>C</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['calendar-monthview']"><span>Calendar Monthview</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['calendar-monthview-legend']"><span>Calendar Monthview and Legend</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['calendar-monthview-hide-legend']"><span>Calendar Hide Legend</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['calendar-updated']"><span>Calendar - using updated()</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['calendar-range']"><span>Calendar - using display range</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['cards']"><span>Cards</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['cards-actionable']"> Cards - Actionable</a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['cards-expandable']"><span>Cards - Expandable</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['cards-multi-select']"><span>Cards - Multi Select</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['cards-single-select']"><span>Cards - Single Select</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['cards-workspace-widgets']"><span>Cards - Workspace Widgets</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['chart']"><span>Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['checkbox']"><span>Checkbox</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['circlepager']"><span>Circle Pager</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['code-block']"><span>Code Block</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['colorpicker']"><span>Color Picker</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['column']"><span>Column Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['column-yaxis-format']"><span>Column Chart Yaxis Formatter</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['column-grouped']"><span>Column Chart-Grouped</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['column-grouped-xaxis-twoline']"><span>Column Chart-Grouped-xAxis-Twoline</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['column-stacked']"><span>Column Chart-Stacked</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['completion-chart']"><span>Completion Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['context-menu']"><span>Context Menu</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['context-menu-lazy-load']"><span>Context Menu (lazy load)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['context-menu-nested']"><span>Context Menu (nested)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['context-menu-shared']"><span>Context Menu (shared)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['context-menu-toggle']"><span>Context Menu (toggle)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['contextual-action-panel']"><span>Contextual Action Panel</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>C</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['calendar-monthview']"><span>Calendar Monthview</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['calendar-monthview-legend']"><span>Calendar Monthview and Legend</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['calendar-monthview-hide-legend']"><span>Calendar Hide Legend</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['calendar-updated']"><span>Calendar - using updated()</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['calendar-range']"><span>Calendar - using display range</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['cards']"><span>Cards</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['cards-actionable']"> Cards - Actionable</a></div>
+        <div class="accordion-header"><a [routerLink]="['cards-expandable']"><span>Cards - Expandable</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['cards-multi-select']"><span>Cards - Multi Select</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['cards-single-select']"><span>Cards - Single Select</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['cards-workspace-widgets']"><span>Cards - Workspace Widgets</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['chart']"><span>Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['checkbox']"><span>Checkbox</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['circlepager']"><span>Circle Pager</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['code-block']"><span>Code Block</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['colorpicker']"><span>Color Picker</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['column']"><span>Column Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['column-yaxis-format']"><span>Column Chart Yaxis Formatter</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['column-grouped']"><span>Column Chart-Grouped</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['column-grouped-xaxis-twoline']"><span>Column Chart-Grouped-xAxis-Twoline</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['column-stacked']"><span>Column Chart-Stacked</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['completion-chart']"><span>Completion Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['context-menu']"><span>Context Menu</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['context-menu-lazy-load']"><span>Context Menu (lazy load)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['context-menu-nested']"><span>Context Menu (nested)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['context-menu-shared']"><span>Context Menu (shared)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['context-menu-toggle']"><span>Context Menu (toggle)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['contextual-action-panel']"><span>Contextual Action Panel</span></a></div>
+      </div>
 
       <!-- D -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>D</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['datagrid-sandbox']"><span>DataGrid - Sandbox</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-add-row']"><span>DataGrid - Add Row</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-angular-editor']"><span>DataGrid - Angular Editors</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-angular-formatter']"><span>DataGrid - Angular Formatters</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-angular-card-formatter']"><span>DataGrid - Angular Card Formatter</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-code-block-formatter']"><span>DataGrid - Code Block Formatter</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-code-block-editor']"><span>DataGrid - Code Block Editor</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-custom-formatter']"><span>DataGrid - Custom Formatter</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-custom-formatter-service']"><span>DataGrid - Custom Formatter Service</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-dirty-indication']"><span>DataGrid - Dirty Indication</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-dynamic']"><span>DataGrid - Dynamic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-editors']"><span>DataGrid - Editors</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-empty-message']"><span>DataGrid - Empty Message</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-export-without-datagrid']"><span>DataGrid - Export without Datagrid</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-fixedheader']"><span>DataGrid - Fixed Header</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-frozen-column']"><span>DataGrid - Frozen Column Refresh</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-groupedheader']"><span>DataGrid - Grouped Header</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-groupable']"><span>DataGrid - Groups</span></a></soho-accordion-header>
+        <a href="#"><span>D</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['datagrid-sandbox']"><span>DataGrid - Sandbox</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-add-row']"><span>DataGrid - Add Row</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-angular-editor']"><span>DataGrid - Angular Editors</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-angular-formatter']"><span>DataGrid - Angular Formatters</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-angular-card-formatter']"><span>DataGrid - Angular Card Formatter</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-code-block-formatter']"><span>DataGrid - Code Block Formatter</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-code-block-editor']"><span>DataGrid - Code Block Editor</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-custom-formatter']"><span>DataGrid - Custom Formatter</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-custom-formatter-service']"><span>DataGrid - Custom Formatter Service</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-dirty-indication']"><span>DataGrid - Dirty Indication</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-dynamic']"><span>DataGrid - Dynamic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-editors']"><span>DataGrid - Editors</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-empty-message']"><span>DataGrid - Empty Message</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-export-without-datagrid']"><span>DataGrid - Export without Datagrid</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-fixedheader']"><span>DataGrid - Fixed Header</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-frozen-column']"><span>DataGrid - Frozen Column Refresh</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-groupedheader']"><span>DataGrid - Grouped Header</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-groupable']"><span>DataGrid - Groups</span></a></div>
 
-        <soho-accordion-header><a [routerLink]="['datagrid-lookup-click-function']"><span>DataGrid - Lookup Click Function</span></a></soho-accordion-header>
+        <div class="accordion-header"><a [routerLink]="['datagrid-lookup-click-function']"><span>DataGrid - Lookup Click Function</span></a></div>
 
-        <soho-accordion-header><a [routerLink]="['datagrid-mixed-selection']"><span>DataGrid - Mixed Selection Mode</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-paging-service']"><span>DataGrid - Paging Service</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-paging-indeterminate']"><span>DataGrid - Paging Indeterminate</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-popupmenu-toolbar']"><span>DataGrid - Popup Menu Toolbar</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-rowreorder']"><span>DataGrid - Row Reorder</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-save-user-settings']"><span>DataGrid - Save User Settings</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-standalone-pager']"><span>DataGrid - Standalone Pager</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-standard-formatter']"><span>DataGrid - Standard Formatter</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-service']"><span>DataGrid - Service</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-tab']"><span>DataGrid - Tab</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-test-settings']"><span>DataGrid - Test Settings</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-breadcrumb']"><span>DataGrid - Toolbar and Breadcrumb</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-treegrid']"><span>DataGrid - TreeGrid</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-treegrid-cube']"><span>DataGrid - TreeGridCube</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-treegrid-lazy']"><span>DataGrid - TreeGrid Lazy</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-treegrid-dynamicfilter']"><span>DataGrid - TreeGrid Dynamic Filter</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-settings']"><span>DataGrid - Updatable Settings</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-vertical-scroll']"><span>DataGrid - Vertical Scroll</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-expandable-row']"><span>DataGrid - Expandable Row</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-expandable-row-dynamic']"><span>DataGrid - Expandable Row (dynamic component)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-expandable-row-nested']"><span>DataGrid - Expandable Row (Nested)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-summary-row']"><span>DataGrid - Summary Row</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datagrid-rowspan']"><span>DataGrid - Row Span</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['datepicker']"><span>Date Picker</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['donut']"><span>Donut Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['donut-colors']"><span>Donut Chart - Colors</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['drag']"><span>Drag</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['dropdown-async']"><span>Dropdown - Async</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['dropdown-async-busy']"><span>Dropdown - Async Busy</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['dropdown-multi']"><span>Dropdown - Multi-Select</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['dropdown-multi-landmark']"><span>Dropdown - Multi-Select (Keep Selected)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['dropdown-multi-attributes']"><span>Dropdown - Multi-Select (Attributes)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['dropdown-reactive']"><span>Dropdown - Reactive Form</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['dropdown']"><span>Dropdown - Single-Select</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['dropdown-simple']"><span>Dropdown - Simple</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['dropdown-typeahead']"><span>Dropdown - Typeahead</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <div class="accordion-header"><a [routerLink]="['datagrid-mixed-selection']"><span>DataGrid - Mixed Selection Mode</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-paging-service']"><span>DataGrid - Paging Service</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-paging-indeterminate']"><span>DataGrid - Paging Indeterminate</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-popupmenu-toolbar']"><span>DataGrid - Popup Menu Toolbar</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-rowreorder']"><span>DataGrid - Row Reorder</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-save-user-settings']"><span>DataGrid - Save User Settings</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-standalone-pager']"><span>DataGrid - Standalone Pager</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-standard-formatter']"><span>DataGrid - Standard Formatter</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-service']"><span>DataGrid - Service</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-tab']"><span>DataGrid - Tab</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-test-settings']"><span>DataGrid - Test Settings</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-breadcrumb']"><span>DataGrid - Toolbar and Breadcrumb</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-treegrid']"><span>DataGrid - TreeGrid</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-treegrid-cube']"><span>DataGrid - TreeGridCube</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-treegrid-lazy']"><span>DataGrid - TreeGrid Lazy</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-treegrid-dynamicfilter']"><span>DataGrid - TreeGrid Dynamic Filter</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-settings']"><span>DataGrid - Updatable Settings</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-vertical-scroll']"><span>DataGrid - Vertical Scroll</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-expandable-row']"><span>DataGrid - Expandable Row</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-expandable-row-dynamic']"><span>DataGrid - Expandable Row (dynamic component)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-expandable-row-nested']"><span>DataGrid - Expandable Row (Nested)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-summary-row']"><span>DataGrid - Summary Row</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datagrid-rowspan']"><span>DataGrid - Row Span</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['datepicker']"><span>Date Picker</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['donut']"><span>Donut Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['donut-colors']"><span>Donut Chart - Colors</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['drag']"><span>Drag</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown-async']"><span>Dropdown - Async</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown-async-busy']"><span>Dropdown - Async Busy</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown-multi']"><span>Dropdown - Multi-Select</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown-multi-landmark']"><span>Dropdown - Multi-Select (Keep Selected)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown-multi-attributes']"><span>Dropdown - Multi-Select (Attributes)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown-reactive']"><span>Dropdown - Reactive Form</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown']"><span>Dropdown - Single-Select</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown-simple']"><span>Dropdown - Simple</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown-typeahead']"><span>Dropdown - Typeahead</span></a></div>
+      </div>
 
       <!-- E -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>E</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['emptymessage']"><span>Empty Message</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['error']"><span>Error</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['expandablearea']"><span>Expandable Area</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['expandablearea-footer']"><span>Expandable Area With Footer</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>E</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['emptymessage']"><span>Empty Message</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['error']"><span>Error</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['expandablearea']"><span>Expandable Area</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['expandablearea-footer']"><span>Expandable Area With Footer</span></a></div>
+      </div>
 
       <!-- F -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>F</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['field-filter']"><span>Field Filter</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['field-options']"><span>Field Options</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['field-options-popdown']"><span>Field Options Popdown</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['fileupload']"><span>File Upload</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['fileupload-lm']"><span>File Upload - Landmark Example</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['fileupload-advanced']"><span>File Upload Advanced</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['form-compact']"><span>Form - Compact</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['form-reactive']"><span>Form - Reactive</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>F</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['field-filter']"><span>Field Filter</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['field-options']"><span>Field Options</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['field-options-popdown']"><span>Field Options Popdown</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['fileupload']"><span>File Upload</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['fileupload-lm']"><span>File Upload - Landmark Example</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['fileupload-advanced']"><span>File Upload Advanced</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['form-compact']"><span>Form - Compact</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['form-reactive']"><span>Form - Reactive</span></a></div>
+      </div>
 
       <!-- H -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>H</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['header-toolbar']"><span>Header - Toolbar</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['header-tabs']"><span>Header - Tabs</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['header-toggle-buttons']"><span>Header - Toggle buttons</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['header-toolbar-tabs']"><span>Header - Toolbar And Tabs</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['header-searchfield']"><span>Header - Searchfield</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['header-searchfield-flex']"><span>Header - Searchfield Flex</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['header-searchfield-category']"><span>Header - Searchfield Category</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['homepage']"><span>Homepage</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['homepage-editable']"><span>Homepage Editable</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['homepage-editable-filled']"><span>Homepage Editable Filled Widget</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['homepage-scenario-a']"><span>Homepage Scenario A</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['homepage-scenario-b']"><span>Homepage Scenario B</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['homepage-scenario-c']"><span>Homepage Scenario C</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['hierarchy']"><span>Hierarchy</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['hierarchy-paging']"><span>Hierarchy Paging</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['hyperlink']"><span>Hyperlink</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>H</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['header-toolbar']"><span>Header - Toolbar</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['header-tabs']"><span>Header - Tabs</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['header-toggle-buttons']"><span>Header - Toggle buttons</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['header-toolbar-tabs']"><span>Header - Toolbar And Tabs</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['header-searchfield']"><span>Header - Searchfield</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['header-searchfield-flex']"><span>Header - Searchfield Flex</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['header-searchfield-category']"><span>Header - Searchfield Category</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['homepage']"><span>Homepage</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['homepage-editable']"><span>Homepage Editable</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['homepage-editable-filled']"><span>Homepage Editable Filled Widget</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['homepage-scenario-a']"><span>Homepage Scenario A</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['homepage-scenario-b']"><span>Homepage Scenario B</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['homepage-scenario-c']"><span>Homepage Scenario C</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['hierarchy']"><span>Hierarchy</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['hierarchy-paging']"><span>Hierarchy Paging</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['hyperlink']"><span>Hyperlink</span></a></div>
+      </div>
 
       <!-- I -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>I</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['icon']"><span>Icon</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['input-clearable']"><span>Input - Clear</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>I</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['icon']"><span>Icon</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['input-clearable']"><span>Input - Clear</span></a></div>
+      </div>
 
       <!-- L -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>L</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['label']"><span>Label</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['line']"><span>Line Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['listbuilder']"><span>List Builder</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['listview']"><span>List View</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['listview-custom']"><span>List View - Custom Content</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['listview-context']"><span>List View - Context</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['locale-pipe']"><span>Locale - Pipes</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['lookup']"><span>Lookup</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['lookup-landmark']"><span>Lookup - Landmark Example</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['lookup-validation']"><span>Lookup - Form Control</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['lookup-source']"><span>Lookup - Source</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['lookup-desc']"><span>Lookup - Description Only</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>L</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['label']"><span>Label</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['line']"><span>Line Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['listbuilder']"><span>List Builder</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['listview']"><span>List View</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['listview-custom']"><span>List View - Custom Content</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['listview-context']"><span>List View - Context</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['locale-pipe']"><span>Locale - Pipes</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['lookup']"><span>Lookup</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['lookup-landmark']"><span>Lookup - Landmark Example</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['lookup-validation']"><span>Lookup - Form Control</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['lookup-source']"><span>Lookup - Source</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['lookup-desc']"><span>Lookup - Description Only</span></a></div>
+      </div>
 
       <!-- M -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>M</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['mask']"><span>Mask</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['mask-legacy']"><span>Mask Legacy</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['menu-button']"><span>Menu Button</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['message']"><span>Message</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['module-nav']"><span>Module Nav</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['modal-dialog']"><span>Modal Dialog</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['monthview']">Monthview</a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['monthview-inpage']">Monthview - In Page</a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['monthview-legend']">Monthview - Legend</a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>M</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['mask']"><span>Mask</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['mask-legacy']"><span>Mask Legacy</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['menu-button']"><span>Menu Button</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['message']"><span>Message</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['module-nav']"><span>Module Nav</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['modal-dialog']"><span>Modal Dialog</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['monthview']">Monthview</a></div>
+        <div class="accordion-header"><a [routerLink]="['monthview-inpage']">Monthview - In Page</a></div>
+        <div class="accordion-header"><a [routerLink]="['monthview-legend']">Monthview - Legend</a></div>
+      </div>
 
       <!-- N -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>N</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['notification']"><span>Notification</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['notification-badge-placement']"><span>Notification Badge - Placement</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['notification-badge-show-hide']"><span>Notification Badge - Show/Hide</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>N</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['notification']"><span>Notification</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['notification-badge-placement']"><span>Notification Badge - Placement</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['notification-badge-show-hide']"><span>Notification Badge - Show/Hide</span></a></div>
+      </div>
 
       <!-- P -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>P</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['pager-standalone']"><span>Pager - Standalone</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['personalize-color-api']"><span>Personalize Color API</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['pie']"><span>Pie Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['popupmenu']"><span>Popup Menu Options</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['popdown']"><span>Popdown</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['progress']"><span>Progress</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>P</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['pager-standalone']"><span>Pager - Standalone</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['personalize-color-api']"><span>Personalize Color API</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['pie']"><span>Pie Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['popupmenu']"><span>Popup Menu Options</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['popdown']"><span>Popdown</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['progress']"><span>Progress</span></a></div>
+      </div>
 
       <!-- R -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>R</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['radar']"><span>Radar Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['radiobutton']"><span>Radio Button</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['rating']"><span>Rating</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['editor']"><span>Rich Text Editor</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>R</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['radar']"><span>Radar Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['radiobutton']"><span>Radio Button</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['rating']"><span>Rating</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['editor']"><span>Rich Text Editor</span></a></div>
+      </div>
 
       <!-- S -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>S</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['searchfield']"><span>Search Field</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['searchfield-category']"><span>Search Field - Category</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['searchfield-category-update']"><span>Search Field - Category Update</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['searchfield-clear']"><span>Search Field - Clear</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['slider']"><span>Slider</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['sparkline']"><span>Sparkline Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['spinbox']"><span>Spinbox</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['splitter-vertical']"><span>Splitter - Vertical</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['splitter-horizontal']"><span>Splitter - Horizontal </span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['step-chart']"><span>Step Chart</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['step-chart-color']"><span>Step Chart - Color</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['step-process']"><span>Step Process - Basic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['step-process-btn-disble']"><span>Step Process - Disable Buttons</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['step-data-driven']"><span>Step Process - Data Driven</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['step-process-vetoable']"><span>Step Process - Vetoable</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['swaplist']"><span>Swap List - Basic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['swaplist-dynamic']"><span>Swap List - Dynamic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['swaplist-full-access']"><span>Swap List - Full Access</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['swaplist-search']"><span>Swap List - Search</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['swaplist-service']"><span>Swap List - Service</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['swipe-action']"><span>Swipe Action</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>S</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['searchfield']"><span>Search Field</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['searchfield-category']"><span>Search Field - Category</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['searchfield-category-update']"><span>Search Field - Category Update</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['searchfield-clear']"><span>Search Field - Clear</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['slider']"><span>Slider</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['sparkline']"><span>Sparkline Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['spinbox']"><span>Spinbox</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['splitter-vertical']"><span>Splitter - Vertical</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['splitter-horizontal']"><span>Splitter - Horizontal </span></a></div>
+        <div class="accordion-header"><a [routerLink]="['step-chart']"><span>Step Chart</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['step-chart-color']"><span>Step Chart - Color</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['step-process']"><span>Step Process - Basic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['step-process-btn-disble']"><span>Step Process - Disable Buttons</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['step-data-driven']"><span>Step Process - Data Driven</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['step-process-vetoable']"><span>Step Process - Vetoable</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['swaplist']"><span>Swap List - Basic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['swaplist-dynamic']"><span>Swap List - Dynamic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['swaplist-full-access']"><span>Swap List - Full Access</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['swaplist-search']"><span>Swap List - Search</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['swaplist-service']"><span>Swap List - Service</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['swipe-action']"><span>Swipe Action</span></a></div>
+      </div>
 
       <!-- T -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>T</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['tabs-basic']"><span>Tabs - Basic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tabs-counts']"><span>Tabs - Counts</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tabs-dismissible']"><span>Tabs - Dismissible</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tabs-dropdown']"><span>Tabs - Dropdown</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tabs-datadriven']"><span>Tabs - Data-driven</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tabs-dynamic']"><span>Tabs - Dynamic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tabs-resize']"><span>Tabs - Resize</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tabs-module']">Tabs - Module</a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tabs-vertical']"><span>Tabs - Vertical</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tags']"><span>Tags</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['textarea']"><span>Text Area</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['textarea-dirty']"><span>Text Area - Dirty</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['timepicker']"><span>Time Picker</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toast']"><span>Toast</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-basic']"><span>Toolbar - Basic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-all-icons']"><span>Toolbar - All Icons </span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-datadriven']"><span>Toolbar - Data-driven</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-more-actions-ajax']"><span>Toolbar - More Actions Ajax</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-state']"><span>Toolbar - State</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-right-aligned']"><span>Toolbar - No Title / Right Aligned</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-flex-basic']"><span>Toolbar Flex - Basic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-flex-datagrid']"><span>Toolbar Flex - Datagrid</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-flex-more-actions-ajax']"><span>Toolbar Flex - More Actions Ajax</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['toolbar-flex-searchfield']"><span>Toolbar Flex - Searchfield</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tooltip']"><span>Tooltip</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tooltip-nested']"><span>Tooltip (Nested)</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['trackdirty']"><span>Track Dirty</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tree-content']"><span>Tree - Content</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tree-dynamic']"><span>Tree - Dynamic</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tree-expand-target']"><span>Tree - Expand Target</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tree-service']"><span>Tree - Service</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['tree-source']"><span>Tree - Source</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['treemap']"><span>Tree Map</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>T</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['tabs-basic']"><span>Tabs - Basic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tabs-counts']"><span>Tabs - Counts</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tabs-dismissible']"><span>Tabs - Dismissible</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tabs-dropdown']"><span>Tabs - Dropdown</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tabs-datadriven']"><span>Tabs - Data-driven</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tabs-dynamic']"><span>Tabs - Dynamic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tabs-resize']"><span>Tabs - Resize</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tabs-module']">Tabs - Module</a></div>
+        <div class="accordion-header"><a [routerLink]="['tabs-vertical']"><span>Tabs - Vertical</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tags']"><span>Tags</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['textarea']"><span>Text Area</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['textarea-dirty']"><span>Text Area - Dirty</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['timepicker']"><span>Time Picker</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toast']"><span>Toast</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-basic']"><span>Toolbar - Basic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-all-icons']"><span>Toolbar - All Icons </span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-datadriven']"><span>Toolbar - Data-driven</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-more-actions-ajax']"><span>Toolbar - More Actions Ajax</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-state']"><span>Toolbar - State</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-right-aligned']"><span>Toolbar - No Title / Right Aligned</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-flex-basic']"><span>Toolbar Flex - Basic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-flex-datagrid']"><span>Toolbar Flex - Datagrid</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-flex-more-actions-ajax']"><span>Toolbar Flex - More Actions Ajax</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['toolbar-flex-searchfield']"><span>Toolbar Flex - Searchfield</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tooltip']"><span>Tooltip</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tooltip-nested']"><span>Tooltip (Nested)</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['trackdirty']"><span>Track Dirty</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tree-content']"><span>Tree - Content</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tree-dynamic']"><span>Tree - Dynamic</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tree-expand-target']"><span>Tree - Expand Target</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tree-service']"><span>Tree - Service</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['tree-source']"><span>Tree - Source</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['treemap']"><span>Tree Map</span></a></div>
+      </div>
 
       <!-- V -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>V</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['validation']"><span>Validation</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['validation-event']"><span>Validation - Event</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['validation-group']"><span>Validation - FormGroup & Mask</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>V</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['validation']"><span>Validation</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['validation-event']"><span>Validation - Event</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['validation-group']"><span>Validation - FormGroup & Mask</span></a></div>
+      </div>
 
       <!-- W -->
-      <soho-accordion-header>
+      <div class="accordion-header">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-folder"></use>
         </svg>
-        <a href="javascript:void(0);"><span>W</span></a></soho-accordion-header>
-      <soho-accordion-pane>
-        <soho-accordion-header><a [routerLink]="['week-view']"><span>Week view</span></a></soho-accordion-header>
-        <soho-accordion-header><a [routerLink]="['wizard']"><span>Wizard</span></a></soho-accordion-header>
-      </soho-accordion-pane>
+        <a href="#"><span>W</span></a></div>
+      <div class="accordion-pane">
+        <div class="accordion-header"><a [routerLink]="['week-view']"><span>Week view</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['wizard']"><span>Wizard</span></a></div>
+      </div>
     </div>
 
     <div class="module-nav-footer accordion-section">
@@ -532,7 +527,7 @@
         </li>
       </ul>
     </div>
-  </soho-accordion>
+  </div>
 </div>
 <div class="module-nav-detail">
   <!-- Reports pane, etc -->

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -434,99 +434,101 @@
       </div>
     </div>
 
-    <div class="module-nav-footer accordion-section">
-
-    </div>
+    <!-- Remove comments to enable footer area
+    <div class="module-nav-footer accordion-section"></div>
+    -->
 
     <div class="module-nav-settings accordion-section">
-      <div class="module-nav-settings-btn accordion-header" data-automation-id="module-nav-settings"
-        id="module-nav-settings-btn">
-        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-          <use href="#icon-settings"></use>
-        </svg>
-        <a href="#"><span>Settings</span></a>
-      </div>
-      <ul class="popupmenu module-nav-settings-menu">
-        <li>
-          <a href="#">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-observation-precautions"></use>
-            </svg>
-            <span>Jobs</span>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-report"></use>
-            </svg>
-            <span>Reports</span>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-isolation"></use>
-            </svg>
-            <span>Actions</span>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-edit"></use>
-            </svg>
-            <span>Personalization</span>
-          </a>
-        </li>
-        <li class="separator"></li>
-        <li>
-          <a href="#">
-            <span>Create Report</span>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <span>Proxy</span>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <span>Set "As Of Date"</span>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <span>User Context</span>
-          </a>
-        </li>
-        <li class="separator"></li>
-        <li>
-          <a href="#">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-settings"></use>
-            </svg>
-            <span>Settings</span>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-info"></use>
-            </svg>
-            <span>About</span>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-help"></use>
-            </svg>
-            <span>Help</span>
-          </a>
-        </li>
-      </ul>
+      <soho-module-nav-settings>
+        <div class="module-nav-settings-btn accordion-header" id="module-nav-settings-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-settings"></use>
+          </svg>
+          <a href="#"><span>Settings</span></a>
+        </div>
+        <ul soho-popupmenu class="popupmenu module-nav-settings-menu">
+          <li>
+            <a href="#">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-observation-precautions"></use>
+              </svg>
+              <span>Jobs</span>
+            </a>
+          </li>
+          <li>
+            <a href="#">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-report"></use>
+              </svg>
+              <span>Reports</span>
+            </a>
+          </li>
+          <li>
+            <a href="#">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-isolation"></use>
+              </svg>
+              <span>Actions</span>
+            </a>
+          </li>
+          <li>
+            <a href="#">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-edit"></use>
+              </svg>
+              <span>Personalization</span>
+            </a>
+          </li>
+          <li class="separator"></li>
+          <li>
+            <a href="#">
+              <span>Create Report</span>
+            </a>
+          </li>
+          <li>
+            <a href="#">
+              <span>Proxy</span>
+            </a>
+          </li>
+          <li>
+            <a href="#">
+              <span>Set "As Of Date"</span>
+            </a>
+          </li>
+          <li>
+            <a href="#">
+              <span>User Context</span>
+            </a>
+          </li>
+          <li class="separator"></li>
+          <li>
+            <a href="#">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-settings"></use>
+              </svg>
+              <span>Settings</span>
+            </a>
+          </li>
+          <li>
+            <a href="#">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-info"></use>
+              </svg>
+              <span>About</span>
+            </a>
+          </li>
+          <li>
+            <a href="#">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-help"></use>
+              </svg>
+              <span>Help</span>
+            </a>
+          </li>
+        </ul>
+      </soho-module-nav-settings>
     </div>
+
   </div>
 </div>
 <div class="module-nav-detail">

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -1,0 +1,357 @@
+<div class="module-nav-bar">
+  <soho-accordion
+    [ngClass]="{ 'accordion': true, 'panel': true, 'module-nav-accordion': true }"
+    [allowOnePane]="false"
+    [rerouteOnLinkClick]="false">
+
+    <div class="module-nav-switcher accordion-section">
+
+    </div>
+
+    <div class="module-nav-search accordion-section">
+
+    </div>
+
+    <div class="module-nav-main accordion-section">
+      <!-- A -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>A</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['about']"><span>About</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['about-nested']"><span>About (Nested)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['accordion']"><span>Accordion</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['accordion/dynamic']"><span>Accordion Dynamic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['accordion/panels']"><span>Accordion Panels</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['accordion/card']"><span>Accordion Card</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['actionsheet']"><span>Actionsheet</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['actionsheet-with-tray']"><span>Actionsheet - Tray</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['alert']"><span>Alert</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['application-lazy-menu']"><span>Application Lazy Menu</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['application-menu-roleswitcher']"><span>Application Menu Role Switcher</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['application-menu-notification-badge']"><span>Application Menu Notification Badge</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['application-menu-test-performance']"><span>Application Menu Test Performance</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['area']"><span>Area Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['arrange']"><span>Arrange</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['autocomplete']"><span>Autocomplete</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['autocomplete-templates']"><span>Autocomplete with Custom Templates</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- B -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>B</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['bar']"><span>Bar Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['bar-grouped']"><span>Bar Chart-Grouped</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['bar-stacked']"><span>Bar Chart-Stacked</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['blockgrid-custom-content']"><span>BlockGrid - Custom Content</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['blockgrid-mixed-selection']"><span>BlockGrid - Mixed Selection</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['blockgrid-multi-selection']"><span>BlockGrid - Multi Selection</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['blockgrid-paging']"><span>BlockGrid - Paging</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['blockgrid-single-selection']"><span>BlockGrid - Single Selection</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['breadcrumb']"><span>Breadcrumb</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['breadcrumb-change-contents']"><span>Breadcrumb - Change Contents</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['breadcrumb-css-only']"><span>Breadcrumb - CSS Only</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['breadcrumb-gauntlet']"><span>Breadcrumb Gauntlet</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['bubble']"><span>Bubble Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['bullet']"><span>Bullet Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['button']"><span>Button</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['button-badge']"><span>Button Badge</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['buttonset']"><span>Buttonset</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['busyindicator']"><span>Busy Indicator</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['busyindicatorbody']"><span>Busy Indicator Body</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- C -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>C</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['calendar-monthview']"><span>Calendar Monthview</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['calendar-monthview-legend']"><span>Calendar Monthview and Legend</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['calendar-monthview-hide-legend']"><span>Calendar Hide Legend</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['calendar-updated']"><span>Calendar - using updated()</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['calendar-range']"><span>Calendar - using display range</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['cards']"><span>Cards</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['cards-actionable']"> Cards - Actionable</a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['cards-expandable']"><span>Cards - Expandable</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['cards-multi-select']"><span>Cards - Multi Select</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['cards-single-select']"><span>Cards - Single Select</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['cards-workspace-widgets']"><span>Cards - Workspace Widgets</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['chart']"><span>Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['checkbox']"><span>Checkbox</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['circlepager']"><span>Circle Pager</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['code-block']"><span>Code Block</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['colorpicker']"><span>Color Picker</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['column']"><span>Column Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['column-yaxis-format']"><span>Column Chart Yaxis Formatter</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['column-grouped']"><span>Column Chart-Grouped</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['column-grouped-xaxis-twoline']"><span>Column Chart-Grouped-xAxis-Twoline</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['column-stacked']"><span>Column Chart-Stacked</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['completion-chart']"><span>Completion Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['context-menu']"><span>Context Menu</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['context-menu-lazy-load']"><span>Context Menu (lazy load)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['context-menu-nested']"><span>Context Menu (nested)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['context-menu-shared']"><span>Context Menu (shared)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['context-menu-toggle']"><span>Context Menu (toggle)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['contextual-action-panel']"><span>Contextual Action Panel</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- D -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>D</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['datagrid-sandbox']"><span>DataGrid - Sandbox</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-add-row']"><span>DataGrid - Add Row</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-angular-editor']"><span>DataGrid - Angular Editors</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-angular-formatter']"><span>DataGrid - Angular Formatters</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-angular-card-formatter']"><span>DataGrid - Angular Card Formatter</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-code-block-formatter']"><span>DataGrid - Code Block Formatter</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-code-block-editor']"><span>DataGrid - Code Block Editor</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-custom-formatter']"><span>DataGrid - Custom Formatter</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-custom-formatter-service']"><span>DataGrid - Custom Formatter Service</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-dirty-indication']"><span>DataGrid - Dirty Indication</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-dynamic']"><span>DataGrid - Dynamic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-editors']"><span>DataGrid - Editors</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-empty-message']"><span>DataGrid - Empty Message</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-export-without-datagrid']"><span>DataGrid - Export without Datagrid</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-fixedheader']"><span>DataGrid - Fixed Header</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-frozen-column']"><span>DataGrid - Frozen Column Refresh</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-groupedheader']"><span>DataGrid - Grouped Header</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-groupable']"><span>DataGrid - Groups</span></a></soho-accordion-header>
+
+        <soho-accordion-header><a [routerLink]="['datagrid-lookup-click-function']"><span>DataGrid - Lookup Click Function</span></a></soho-accordion-header>
+
+        <soho-accordion-header><a [routerLink]="['datagrid-mixed-selection']"><span>DataGrid - Mixed Selection Mode</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-paging-service']"><span>DataGrid - Paging Service</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-paging-indeterminate']"><span>DataGrid - Paging Indeterminate</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-popupmenu-toolbar']"><span>DataGrid - Popup Menu Toolbar</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-rowreorder']"><span>DataGrid - Row Reorder</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-save-user-settings']"><span>DataGrid - Save User Settings</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-standalone-pager']"><span>DataGrid - Standalone Pager</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-standard-formatter']"><span>DataGrid - Standard Formatter</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-service']"><span>DataGrid - Service</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-tab']"><span>DataGrid - Tab</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-test-settings']"><span>DataGrid - Test Settings</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-breadcrumb']"><span>DataGrid - Toolbar and Breadcrumb</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-treegrid']"><span>DataGrid - TreeGrid</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-treegrid-cube']"><span>DataGrid - TreeGridCube</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-treegrid-lazy']"><span>DataGrid - TreeGrid Lazy</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-treegrid-dynamicfilter']"><span>DataGrid - TreeGrid Dynamic Filter</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-settings']"><span>DataGrid - Updatable Settings</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-vertical-scroll']"><span>DataGrid - Vertical Scroll</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-expandable-row']"><span>DataGrid - Expandable Row</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-expandable-row-dynamic']"><span>DataGrid - Expandable Row (dynamic component)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-expandable-row-nested']"><span>DataGrid - Expandable Row (Nested)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-summary-row']"><span>DataGrid - Summary Row</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datagrid-rowspan']"><span>DataGrid - Row Span</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['datepicker']"><span>Date Picker</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['donut']"><span>Donut Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['donut-colors']"><span>Donut Chart - Colors</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['drag']"><span>Drag</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['dropdown-async']"><span>Dropdown - Async</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['dropdown-async-busy']"><span>Dropdown - Async Busy</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['dropdown-multi']"><span>Dropdown - Multi-Select</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['dropdown-multi-landmark']"><span>Dropdown - Multi-Select (Keep Selected)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['dropdown-multi-attributes']"><span>Dropdown - Multi-Select (Attributes)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['dropdown-reactive']"><span>Dropdown - Reactive Form</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['dropdown']"><span>Dropdown - Single-Select</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['dropdown-simple']"><span>Dropdown - Simple</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['dropdown-typeahead']"><span>Dropdown - Typeahead</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- E -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>E</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['emptymessage']"><span>Empty Message</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['error']"><span>Error</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['expandablearea']"><span>Expandable Area</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['expandablearea-footer']"><span>Expandable Area With Footer</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- F -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>F</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['field-filter']"><span>Field Filter</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['field-options']"><span>Field Options</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['field-options-popdown']"><span>Field Options Popdown</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['fileupload']"><span>File Upload</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['fileupload-lm']"><span>File Upload - Landmark Example</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['fileupload-advanced']"><span>File Upload Advanced</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['form-compact']"><span>Form - Compact</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['form-reactive']"><span>Form - Reactive</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- H -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>H</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['header-toolbar']"><span>Header - Toolbar</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['header-tabs']"><span>Header - Tabs</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['header-toggle-buttons']"><span>Header - Toggle buttons</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['header-toolbar-tabs']"><span>Header - Toolbar And Tabs</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['header-searchfield']"><span>Header - Searchfield</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['header-searchfield-flex']"><span>Header - Searchfield Flex</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['header-searchfield-category']"><span>Header - Searchfield Category</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['homepage']"><span>Homepage</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['homepage-editable']"><span>Homepage Editable</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['homepage-editable-filled']"><span>Homepage Editable Filled Widget</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['homepage-scenario-a']"><span>Homepage Scenario A</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['homepage-scenario-b']"><span>Homepage Scenario B</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['homepage-scenario-c']"><span>Homepage Scenario C</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['hierarchy']"><span>Hierarchy</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['hierarchy-paging']"><span>Hierarchy Paging</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['hyperlink']"><span>Hyperlink</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- I -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>I</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['icon']"><span>Icon</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['input-clearable']"><span>Input - Clear</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- L -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>L</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['label']"><span>Label</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['line']"><span>Line Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['listbuilder']"><span>List Builder</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['listview']"><span>List View</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['listview-custom']"><span>List View - Custom Content</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['listview-context']"><span>List View - Context</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['locale-pipe']"><span>Locale - Pipes</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['lookup']"><span>Lookup</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['lookup-landmark']"><span>Lookup - Landmark Example</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['lookup-validation']"><span>Lookup - Form Control</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['lookup-source']"><span>Lookup - Source</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['lookup-desc']"><span>Lookup - Description Only</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- M -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>M</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['mask']"><span>Mask</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['mask-legacy']"><span>Mask Legacy</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['menu-button']"><span>Menu Button</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['message']"><span>Message</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['module-nav']"><span>Module Nav</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['modal-dialog']"><span>Modal Dialog</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['monthview']">Monthview</a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['monthview-inpage']">Monthview - In Page</a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['monthview-legend']">Monthview - Legend</a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- N -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>N</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['notification']"><span>Notification</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['notification-badge-placement']"><span>Notification Badge - Placement</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['notification-badge-show-hide']"><span>Notification Badge - Show/Hide</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- P -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>P</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['pager-standalone']"><span>Pager - Standalone</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['personalize-color-api']"><span>Personalize Color API</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['pie']"><span>Pie Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['popupmenu']"><span>Popup Menu Options</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['popdown']"><span>Popdown</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['progress']"><span>Progress</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- R -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>R</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['radar']"><span>Radar Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['radiobutton']"><span>Radio Button</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['rating']"><span>Rating</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['editor']"><span>Rich Text Editor</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- S -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>S</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['searchfield']"><span>Search Field</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['searchfield-category']"><span>Search Field - Category</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['searchfield-category-update']"><span>Search Field - Category Update</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['searchfield-clear']"><span>Search Field - Clear</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['slider']"><span>Slider</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['sparkline']"><span>Sparkline Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['spinbox']"><span>Spinbox</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['splitter-vertical']"><span>Splitter - Vertical</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['splitter-horizontal']"><span>Splitter - Horizontal </span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['step-chart']"><span>Step Chart</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['step-chart-color']"><span>Step Chart - Color</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['step-process']"><span>Step Process - Basic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['step-process-btn-disble']"><span>Step Process - Disable Buttons</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['step-data-driven']"><span>Step Process - Data Driven</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['step-process-vetoable']"><span>Step Process - Vetoable</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['swaplist']"><span>Swap List - Basic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['swaplist-dynamic']"><span>Swap List - Dynamic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['swaplist-full-access']"><span>Swap List - Full Access</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['swaplist-search']"><span>Swap List - Search</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['swaplist-service']"><span>Swap List - Service</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['swipe-action']"><span>Swipe Action</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- T -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>T</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['tabs-basic']"><span>Tabs - Basic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tabs-counts']"><span>Tabs - Counts</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tabs-dismissible']"><span>Tabs - Dismissible</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tabs-dropdown']"><span>Tabs - Dropdown</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tabs-datadriven']"><span>Tabs - Data-driven</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tabs-dynamic']"><span>Tabs - Dynamic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tabs-resize']"><span>Tabs - Resize</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tabs-module']">Tabs - Module</a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tabs-vertical']"><span>Tabs - Vertical</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tags']"><span>Tags</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['textarea']"><span>Text Area</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['textarea-dirty']"><span>Text Area - Dirty</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['timepicker']"><span>Time Picker</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toast']"><span>Toast</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-basic']"><span>Toolbar - Basic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-all-icons']"><span>Toolbar - All Icons </span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-datadriven']"><span>Toolbar - Data-driven</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-more-actions-ajax']"><span>Toolbar - More Actions Ajax</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-state']"><span>Toolbar - State</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-right-aligned']"><span>Toolbar - No Title / Right Aligned</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-flex-basic']"><span>Toolbar Flex - Basic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-flex-datagrid']"><span>Toolbar Flex - Datagrid</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-flex-more-actions-ajax']"><span>Toolbar Flex - More Actions Ajax</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['toolbar-flex-searchfield']"><span>Toolbar Flex - Searchfield</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tooltip']"><span>Tooltip</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tooltip-nested']"><span>Tooltip (Nested)</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['trackdirty']"><span>Track Dirty</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tree-content']"><span>Tree - Content</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tree-dynamic']"><span>Tree - Dynamic</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tree-expand-target']"><span>Tree - Expand Target</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tree-service']"><span>Tree - Service</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['tree-source']"><span>Tree - Source</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['treemap']"><span>Tree Map</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- V -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>V</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['validation']"><span>Validation</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['validation-event']"><span>Validation - Event</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['validation-group']"><span>Validation - FormGroup & Mask</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+
+      <!-- W -->
+      <soho-accordion-header><a href="javascript:void(0);"><span>W</span></a></soho-accordion-header>
+      <soho-accordion-pane>
+        <soho-accordion-header><a [routerLink]="['week-view']"><span>Week view</span></a></soho-accordion-header>
+        <soho-accordion-header><a [routerLink]="['wizard']"><span>Wizard</span></a></soho-accordion-header>
+      </soho-accordion-pane>
+    </div>
+
+    <div class="module-nav-footer accordion-section">
+
+    </div>
+
+    <div class="module-nav-settings accordion-section">
+
+    </div>
+  </soho-accordion>
+</div>
+<div class="module-nav-detail">
+  <!-- Reports pane, etc -->
+</div>

--- a/src/app/module-nav/module-nav.demo.ts
+++ b/src/app/module-nav/module-nav.demo.ts
@@ -1,0 +1,19 @@
+import {
+  Component,
+  ChangeDetectionStrategy
+} from '@angular/core';
+
+import {
+  SohoAccordionComponent,
+  SohoAccordionHeaderComponent,
+  SohoAccordionPaneComponent,
+} from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'module-nav-demo', // eslint-disable-line
+  templateUrl: 'module-nav.demo.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ModuleNavDemoComponent {
+
+}

--- a/src/app/module-nav/module-nav.demo.ts
+++ b/src/app/module-nav/module-nav.demo.ts
@@ -15,5 +15,11 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ModuleNavDemoComponent {
+  public searchfieldOptions: SohoSearchFieldOptions = {
 
+  }
+
+  onChange(e: any) {
+    console.dir(e);
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR implements the necessary component wrappers and Typescript types for enabling usage of the Module Nav component and its subcomponents in an Angular environment.

**Related github/jira issue (required)**:
Closes #1477 
Related to infor-design/enterprise#7386

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run.  Ensure the latest Enterprise version is attached (4.84.0 minimum)
- Open http://localhost:4200/ids-enterprise-ng-demo/
- See that the Module Nav component now runs the app nav, instead of the Application Menu
- Try filtering (should work)
- Review component wrappers/types for needed functionality

NOTE: This is a first pass and its possible we are missing some details. The general functionality, ability to compose the Module Nav, and basic API access should be present.
