### PR TITLE
1500 - Extend Tooltip to allow forcing close with keepOpen set to true

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/tooltip/soho-tooltip.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/tooltip/soho-tooltip.directive.ts
@@ -245,9 +245,9 @@ export class SohoTooltipDirective implements AfterViewInit, OnDestroy, OnChanges
   /**
    * Hides the tooltip.
    */
-  public hide(): void {
+  public hide(force?: boolean): void {
     if (this.tooltip) {
-      this.tooltip.hide();
+      this.tooltip.hide(force);
     }
   }
 

--- a/projects/ids-enterprise-typings/lib/tooltip/soho-tooltip.d.ts
+++ b/projects/ids-enterprise-typings/lib/tooltip/soho-tooltip.d.ts
@@ -53,7 +53,7 @@ interface SohoTooltipEvent extends JQuery.TriggeredEvent {
 interface SohoTooltipStatic {
   settings: SohoTooltipOptions;
   destroy(): void;
-  hide(): void;
+  hide(force?: boolean): void;
   show(): void;
   updated(): void;
 }

--- a/src/app/tooltip/tooltip.demo.html
+++ b/src/app/tooltip/tooltip.demo.html
@@ -68,3 +68,16 @@
     </button>
   </div>
 </div>
+
+
+<div class="row">
+  <div class="six columns">
+    <h2 class="fieldset-title">Popover with keep open. Click to force close</h2>
+    <button soho-button class="btn" id="test3" type="button"
+      soho-tooltip #keepOpenTooltip [popover]="true" [closebutton]="true" extraClass="alternate"
+      [content]="popoverMarkup" [title]="popoverTitle" [keepOpen]="true" trigger="click"
+      placement="bottom">Popover Content
+    </button>
+    <button soho-button title="Force Close" (click)="forceClose()">Force Close</button>
+  </div>
+</div>

--- a/src/app/tooltip/tooltip.demo.ts
+++ b/src/app/tooltip/tooltip.demo.ts
@@ -2,7 +2,8 @@ import {
   Component,
   OnInit,
   ViewChildren,
-  QueryList
+  QueryList,
+  ViewChild
 } from '@angular/core';
 
 import { SohoTooltipDirective } from 'ids-enterprise-ng';
@@ -14,6 +15,7 @@ import { SohoTooltipDirective } from 'ids-enterprise-ng';
 export class TooltipDemoComponent implements OnInit {
 
   @ViewChildren(SohoTooltipDirective) tooltips?: QueryList<SohoTooltipDirective>;
+  @ViewChild('keepOpenTooltip', { read: SohoTooltipDirective }) keepOpenTooltip?: SohoTooltipDirective;
 
   public normalTooltipText = 'Tooltips Provide<br> Additional Information';
 
@@ -59,5 +61,9 @@ export class TooltipDemoComponent implements OnInit {
   changeTooltip() {
     this.standardTooltipText = 'CHANGED';
     this.normalTooltipText = 'CHANGED';
+  }
+
+  forceClose() {
+    this.keepOpenTooltip?.hide(true);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR extends hide method of SohoTooltip to allow programatically closing it when keepOpen flag is set to true.

**Related github/jira issue (required)**:
Closes #1500

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open http://localhost:4200/ids-enterprise-ng-demo/tooltip
- Open the popover under 'Popover with keep open'.
- Click outside of popover to check that it will not close (keepOpen set to true).
- Click 'Force Close' button to close it programatically

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
