### PR TITLE
Update soho-monthview.component.ts, exposed showMonth() method

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/monthview/soho-monthview.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/monthview/soho-monthview.component.ts
@@ -645,8 +645,13 @@ export class SohoMonthViewComponent implements AfterViewChecked, AfterViewInit, 
     });
   }
   
+  /**
+  * Shows the given month and year.
+  */
   showMonth(month: number, year: number) {
-    this.monthview.showMonth(month, year);
+    if (this.monthview) {
+      (this.monthview as any).showMonth(month, year);
+    }
   }
 
   /**

--- a/projects/ids-enterprise-ng/src/lib/monthview/soho-monthview.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/monthview/soho-monthview.component.ts
@@ -644,6 +644,10 @@ export class SohoMonthViewComponent implements AfterViewChecked, AfterViewInit, 
       }
     });
   }
+  
+  showMonth(month: number, year: number) {
+    this.monthview.showMonth(month, year);
+  }
 
   /**
    * Cleanup just before Angular destroys the component.

--- a/projects/ids-enterprise-ng/src/lib/monthview/soho-monthview.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/monthview/soho-monthview.component.ts
@@ -646,8 +646,8 @@ export class SohoMonthViewComponent implements AfterViewChecked, AfterViewInit, 
   }
   
   /**
-  * Shows the given month and year.
-  */
+   * Shows the given month and year.
+   */
   showMonth(month: number, year: number) {
     if (this.monthview) {
       (this.monthview as any).showMonth(month, year);


### PR DESCRIPTION
Added public showMonth() method to allow the month to be manually set.

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This allows us to manually set the month and year of the monthview component.

**Related github/jira issue (required)**:


**Steps necessary to review your pull request (required)**:
Create a monthview component and call the showMonth() method through the viewchild accessor. Confirm that the month is changed to the value that was set.
