### PR TITLE
1477 - Add accordion/module nav API for deselection/focus state control

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.ts
@@ -30,7 +30,7 @@ import { SohoAccordionPaneComponent } from './soho-accordion-pane.component';
  * category or section header, and the second level provides the associated options.
  */
 @Component({
-  selector: 'soho-accordion',
+  selector: 'soho-accordion, [soho-accordion]',
   templateUrl: 'soho-accordion.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -254,6 +254,39 @@ export class SohoAccordionComponent implements AfterViewInit, AfterViewChecked, 
   // -------------------------------------------
   // Public API
   // -------------------------------------------
+
+  /**
+   * Makes provided accordion headers appear "selected"
+   */
+  public select(header: SohoAccordionHeaderComponent | string): void {
+    if (this.accordion) {
+      this.ngZone.runOutsideAngular(() => {
+        return this.accordion.select(typeof header === 'string' ? header : header['jQueryElement']);
+      });
+    }
+  }
+
+  /**
+   * Makes provided accordion headers appear "deselected"
+   */
+  public deselect(header: SohoAccordionHeaderComponent | string): void {
+    if (this.accordion) {
+      this.ngZone.runOutsideAngular(() => {
+        return this.accordion.deselect(typeof header === 'string' ? header : header['jQueryElement']);
+      });
+    }
+  }
+
+  /**
+   * Makes all accordion headers appear "deselected"
+   */
+  public deselectAll(): void {
+    if (this.accordion) {
+      this.ngZone.runOutsideAngular(() => {
+        return this.accordion.deselectAll();
+      });
+    }
+  }
 
   /**
    * Get's the nth header from the accordion.

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
@@ -133,6 +133,10 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
     this.modulenavswitcher?.init();
   }
 
+  public toggleModuleButtonFocus(doFocus?: boolean) {
+    this.modulenavswitcher?.toggleModuleButtonFocus(doFocus);
+  }
+
   /** Triggers a UI Resync. */
   public updated(val?: SohoModuleNavSwitcherOptions) {
     if (val) {

--- a/projects/ids-enterprise-typings/lib/accordion/soho-accordion.d.ts
+++ b/projects/ids-enterprise-typings/lib/accordion/soho-accordion.d.ts
@@ -159,6 +159,12 @@ interface SohoAccordionStatic {
   /** Makes an accordion header appear with a "selected" state */
   select(element?: SohoAccordionHeaderAnyGroup): void;
 
+  /** Makes an accordion header appear with a "deselected" state */
+  deselect(element?: SohoAccordionHeaderAnyGroup): void;
+
+  /** Makes all accordion headers deselected */
+  deselectAll(): void;
+
   /** Gets a reference to currently-selected accordion headers */
   getSelected(): SohoAccordionHeaderGroup;
 

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
@@ -65,6 +65,9 @@ interface SohoModuleNavSwitcherStatic {
   /** Re-renders jQuery child component APIs */
   renderChildComponents(): void;
 
+  /** Changes the focus of the Module Button */
+  toggleModuleButtonFocus(doFocus?: boolean): void;
+
   /** Tear down the markup for the control */
   teardown(): void;
 

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -1,7 +1,8 @@
 <div class="module-nav-bar">
   <div soho-accordion
     class="accordion panel module-nav-accordion"
-    data-options="{ allowOnePane: false, rerouteOnLinkClick: false }">
+    data-options="{ allowOnePane: false, rerouteOnLinkClick: false }"
+    (click)="onModuleNavAccordionClick($event)">
     <div class="module-nav-header accordion-section">
       <soho-module-nav-switcher
         class="module-nav-switcher"

--- a/src/app/module-nav/module-nav.demo.ts
+++ b/src/app/module-nav/module-nav.demo.ts
@@ -47,6 +47,13 @@ export class ModuleNavDemoComponent implements AfterViewInit {
 
   onModuleButtonClick(e: any) {
     console.info('Module Nav Role Button clicked', e);
+    this.moduleNavSwitcher?.toggleModuleButtonFocus(true);
+    this.accordion?.deselectAll();
+  }
+
+  onModuleNavAccordionClick(e: any) {
+    console.info('Module Nav Accordion header clicked', e?.target?.textContent.trim());
+    this.moduleNavSwitcher?.toggleModuleButtonFocus(false);
   }
 
   onSearchChange(e: any) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Per discussions with the Landmark team, adding some additional API hooks for Module Button focus state control, and Accordion selected state control.  A demo of how to control this behavior is also present in the new Module Nav example (Module Switcher button/accordion headers cannot be simultaneously selected based on configuration).

**Related github/jira issue (required)**:
Related to #1477 
Related to infor-design/enterprise#7386

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run.  Ensure infor-design/enterprise#7633 is merged or linked to this branch before building.  
- When the demoapp loads, try selecting different accordion headers and the module button.  They shouldn't both become selected.
