### PR TITLE
1477 - Module Nav component improvements

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.css
+++ b/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.css
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.html
+++ b/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.html
@@ -1,3 +1,9 @@
-<div [ngClass]="{'accordion': true, 'panel': hasPanels, 'alternate': alternate, 'inverse': inverse, 'has-subheader-separators': hasSubheaderSeparators}">
+<div [ngClass]="{
+  'accordion': true,
+  'panel': hasPanels,
+  'alternate': alternate,
+  'inverse': inverse,
+  'has-subheader-separators': hasSubheaderSeparators,
+  'module-nav-accordion': moduleNav }">
   <ng-content></ng-content>
 </div>

--- a/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.ts
@@ -31,6 +31,7 @@ import { SohoAccordionPaneComponent } from './soho-accordion-pane.component';
  */
 @Component({
   selector: 'soho-accordion, [soho-accordion]',
+  styleUrls: ['./soho-accordion.component.css'],
   templateUrl: 'soho-accordion.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -140,8 +141,6 @@ export class SohoAccordionComponent implements AfterViewInit, AfterViewChecked, 
   /**
    * Can be set to false if routing is externally handled, otherwise
    * links are handled normally.
-   *
-   *
    */
   @Input() public set rerouteOnLinkClick(rerouteOnLinkClick: boolean | undefined) {
     this.options.rerouteOnLinkClick = typeof (rerouteOnLinkClick) === 'boolean' && rerouteOnLinkClick;
@@ -242,6 +241,9 @@ export class SohoAccordionComponent implements AfterViewInit, AfterViewChecked, 
   }
 
   @Input() public hasSubheaderSeparators?: boolean;
+
+  /** Enables Module Nav variant */
+  @Input() public moduleNav?: boolean;
 
   /**
    * Constructor.

--- a/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-settings/soho-module-nav-settings.component.ts
@@ -92,7 +92,7 @@ export class SohoModuleNavSettingsComponent implements AfterViewInit, AfterViewC
 
   ngAfterViewChecked() {
     if (this.modulenavsettings && this._updateRequired) {
-      this.ngZone.runOutsideAngular(() => this.modulenavsettings?.updated());
+      this.ngZone.runOutsideAngular(() => this.modulenavsettings?.updated(this._options));
       this._updateRequired = false;
     }
   }

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
@@ -187,7 +187,7 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
 
   ngAfterViewChecked() {
     if (this.modulenavswitcher && this._updateRequired) {
-      this.ngZone.runOutsideAngular(() => this.modulenavswitcher?.updated());
+      this.ngZone.runOutsideAngular(() => this.modulenavswitcher?.updated(this._options));
       this._updateRequired = false;
     }
   }

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
@@ -34,7 +34,9 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
 
   /** Stored settings */
   private _options: SohoModuleNavOptions = {
+    accordionSettings: {},
     displayMode: false,
+    initChildren: true,
     filterable: false,
     pinSections: false,
     showDetailView: false,
@@ -53,6 +55,14 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   // Inputs
   // -------------------------------------------
 
+  @Input() set accordionSettings(val: SohoAccordionOptions | undefined) {
+    this._options.accordionSettings = val;
+    this.updated({ accordionSettings: this._options.accordionSettings });
+  }
+  public get accordionSettings(): SohoAccordionOptions | undefined {
+    return this.modulenav?.settings.accordionSettings || this._options.accordionSettings;
+  }
+
   @Input() set displayMode(val: SohoModuleNavDisplayMode | undefined) {
     this._options.displayMode = val;
     this.updated({ displayMode: this._options.displayMode });
@@ -67,6 +77,14 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   }
   public get filterable(): boolean {
     return this.modulenav?.settings.filterable || this._options.filterable || false;
+  }
+
+  @Input() set initChildren(val: boolean) {
+    this._options.initChildren = val;
+    this.updated({ initChildren: this._options.initChildren });
+  }
+  public get initChildren(): boolean {
+    return this.modulenav?.settings.initChildren || this._options.initChildren || false;
   }
 
   @Input() set pinSections(val: boolean) {
@@ -144,7 +162,7 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
 
   ngAfterViewChecked() {
     if (this.modulenav && this._updateRequired) {
-      this.ngZone.runOutsideAngular(() => this.modulenav?.updated());
+      this.ngZone.runOutsideAngular(() => this.modulenav?.updated(this._options));
       this._updateRequired = false;
     }
   }

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
@@ -51,7 +51,7 @@ interface SohoModuleNavSwitcherStatic {
   roleDropdownEl?: HTMLElement;
 
   /** Reference to the Module Button's Soho Button API, if one is available */
-  roleDropdownAPI?: SohoButtonStatic;
+  roleDropdownAPI?: SohoDropDownStatic;
 
   /** Initializes the jQuery component */
   init(): void;

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
@@ -3,8 +3,10 @@
 
 /** Defines options present in the Soho Module Nav */
 interface SohoModuleNavOptions {
+  accordionSettings?: SohoAccordionOptions;
   displayMode?: SohoModuleNavDisplayMode;
   filterable?: boolean;
+  initChildren?: boolean;
   pinSections?: boolean;
   showDetailView?: boolean;
 }

--- a/src/app/demoapp-nav-container/demoapp-nav-container.html
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.html
@@ -30,6 +30,7 @@
       [ngClass]="{ 'module-nav-container': true }">
     <soho-module-nav
       [ngClass]="{ 'module-nav': true }"
+      [accordionSettings]="{ 'rerouteOnLinkClick': false, 'expanderDisplay': 'classic' }"
       [displayMode]="'expanded'"
       [filterable]="true"
       [pinSections]="true"

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -1,7 +1,9 @@
 <div class="module-nav-bar">
-  <div soho-accordion
-    class="accordion panel module-nav-accordion"
-    data-options="{ allowOnePane: false, rerouteOnLinkClick: false }"
+  <soho-accordion
+    [allowOnePane]="false"
+    [hasPanels]="true"
+    [moduleNav]="true"
+    [rerouteOnLinkClick]="false"
     (click)="onModuleNavAccordionClick($event)">
     <div class="module-nav-header accordion-section">
       <soho-module-nav-switcher
@@ -533,7 +535,7 @@
       </soho-module-nav-settings>
     </div>
 
-  </div>
+  </soho-accordion>
 </div>
 <div class="module-nav-detail">
   <!-- Reports pane, etc -->

--- a/src/app/module-nav/module-nav.demo.ts
+++ b/src/app/module-nav/module-nav.demo.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ChangeDetectionStrategy,
   AfterViewInit,
+  NgZone,
   ViewChild
 } from '@angular/core';
 
@@ -23,6 +24,12 @@ export class ModuleNavDemoComponent implements AfterViewInit {
   @ViewChild(SohoSearchFieldComponent) searchfield?: SohoSearchFieldComponent;
   @ViewChild(SohoModuleNavSwitcherComponent) moduleNavSwitcher?: SohoModuleNavSwitcherComponent;
   @ViewChild(SohoModuleNavSettingsComponent) moduleNavSettings?: SohoModuleNavSettingsComponent;
+
+  /**
+   * Constructor.
+   * @param ngZone - zone access.
+   */
+  constructor(private ngZone: NgZone) { }
 
   public searchfieldOptions: SohoSearchFieldOptions = {}
 
@@ -77,6 +84,8 @@ export class ModuleNavDemoComponent implements AfterViewInit {
   // ------------------------------------------
 
   ngAfterViewInit() {
-    this.moduleNavSwitcher?.setRoles(this.dropdownRoles);
+    this.ngZone.runOutsideAngular(() => {
+      this.moduleNavSwitcher?.setRoles(this.dropdownRoles);
+    });
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR further improves the NG Module Nav API and adds some missing pieces as reported by the Landmark team:
- Fixes an incorrect Module Nav Switcher type
- Adds inputs for new EP module nav settings (see infor-design/enterprise#7672)
- Changes our demoapp's usage of the `[soho-accordion]` to a full `soho-accordion` component to take advantage of new settings, and to fix a double-accordion bug.

**Related github/jira issue (required)**:
Closes #1521 
Related to  #1477 
Related to infor-design/enterprise#7386

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run.  Ensure the branch from  [EP #7672](infor-design/enterprise#7672) has been merged, or is `npm link`-ed to your local copy.
- Open http://localhost:4200/ids-enterprise-ng-demo/
- Ensure the Accordion component no longer stretches too far down off the bottom of the screen (NG component should no longer be generating a "double" accordion)
- Click the hamburger icon to switch the Module Nav to collapsed mode, then hover the Module Button.  It should generate a tooltip with the text "Standard Module" (comes from the `moduleButtonText` setting previously added)
- Click on child accordion headers to switch demo pages.  Ensure a full page reload doesn't occur on each router link change (this tests accordion settings are being passed properly)
- Check all Module Nav functionality for accuracy.
