### PR TITLE
EP7473 - Updated data type of cell in drilldown click event

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[Module Nav Switcher]` Improve Angular/EP component lifecycle. ([#1477](https://github.com/infor-design/enterprise-ng/issues/1477))
 - `[Datepicker]` Added custom validation for Datepicker component. ([#1512](https://github.com/infor-design/enterprise-ng/issues/1512))
 - `[Datagrid]` Added missing headerTooltip setting. ([#1514](https://github.com/infor-design/enterprise-ng/issues/1514))
+- `[Datagrid]` Updated data type of cell in drilldown click event. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
 
 ## 16.4.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## 16.6.0
+
+### 16.6.0 Fixes
+
+- `[Datagrid]` Updated data type of cell in drilldown click event. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
+
 ## 16.5.0
 
 ### 16.5.0 Fixes
@@ -8,7 +14,6 @@
 - `[Module Nav Switcher]` Improve Angular/EP component lifecycle. ([#1477](https://github.com/infor-design/enterprise-ng/issues/1477))
 - `[Datepicker]` Added custom validation for Datepicker component. ([#1512](https://github.com/infor-design/enterprise-ng/issues/1512))
 - `[Datagrid]` Added missing headerTooltip setting. ([#1514](https://github.com/infor-design/enterprise-ng/issues/1514))
-- `[Datagrid]` Updated data type of cell in drilldown click event. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
 
 ## 16.4.1
 

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -772,8 +772,8 @@ interface SohoDataGridColumnClickData {
   /** Index of the row clicked. */
   row: number;
 
-  /** Element click. */
-  cell: HTMLElement;
+  /** Cell index. */
+  cell: number | null;
 
   /** Row data */
   item: any;

--- a/src/app/datagrid/datagrid-angular-formatter.demo.ts
+++ b/src/app/datagrid/datagrid-angular-formatter.demo.ts
@@ -27,7 +27,7 @@ export class ButtonCellFormatterComponent implements OnDestroy {
   template: '<p>{{args?.value?.price}}</p>'
 })
 export class PriceCellFormatterComponent {
-  constructor(@Inject('args') public args: SohoDataGridPostRenderCellArgs) {}
+  constructor(@Inject('args') public args: SohoDataGridPostRenderCellArgs) { }
 }
 
 @Component({
@@ -36,33 +36,59 @@ export class PriceCellFormatterComponent {
 })
 export class DataGridAngularFormatterDemoComponent {
   public columns: SohoDataGridColumn[] = [
-    { id: 'productId',   name: 'Product Id',   field: 'productId',
+    {
+      id: 'productId',
+      field: 'productId',
+      align: 'center',
+      sortable: false,
+      name: 'Drilldown',
+      filterType: 'integer',
+      formatter: Soho.Formatters.Drilldown,
+      click: (e, args) => {
+        this.numberOnly(args[0].cell !== null ? args[0].cell : 0);
+      }
+    },
+    {
+      id: 'productId', name: 'Product Id', field: 'productId',
       sortable: false, filterType: 'integer',
-      formatter: Soho.Formatters.Readonly },
-    { id: 'button-formatter', name: 'Edit', text: 'Edit Row',
+      formatter: Soho.Formatters.Readonly
+    },
+    {
+      id: 'button-formatter', name: 'Edit', text: 'Edit Row',
       sortable: false, icon: 'edit', align: 'center',
       formatter: Soho.Formatters.Button, click: (_e, args) => this.onClick(args),
-      disabled: this.disableButton },
-    { id: 'button', name: 'Settings',
+      disabled: this.disableButton
+    },
+    {
+      id: 'button', name: 'Settings',
       sortable: false, align: 'center', postRender: true,
       component: ButtonCellFormatterComponent,
-      componentInputs: { value: 'somespecialvalue' } },
-    { id: 'price',  name: 'Price (std fmt)', field: 'price',
+      componentInputs: { value: 'somespecialvalue' }
+    },
+    {
+      id: 'price', name: 'Price (std fmt)', field: 'price',
       sortable: false, filterType: 'decimal',
-      formatter: Soho.Formatters.Decimal },
-    { id: 'price2', name: 'Price (ng fmt)', field: 'price',
+      formatter: Soho.Formatters.Decimal
+    },
+    {
+      id: 'price2', name: 'Price (ng fmt)', field: 'price',
       sortable: false, align: 'center', postRender: true,
-      component: PriceCellFormatterComponent, componentInputs: {} }
+      component: PriceCellFormatterComponent, componentInputs: {}
+    }
   ];
 
   public data = PAGING_DATA;
 
-  constructor() {}
+  constructor() { }
 
   onClick(_args: any) {
     console.log('click');
   }
   disableButton(_row: number, _cell: any, _data: any, _col: SohoDataGridColumn, item: any) {
     return (item.productId === 214221 || item.productId === 214222);
+  }
+
+  numberOnly(num: number) {
+    console.log('Drilldown Click Cell', num);
   }
 }

--- a/src/app/datagrid/datagrid-groupable.demo.html
+++ b/src/app/datagrid/datagrid-groupable.demo.html
@@ -18,22 +18,22 @@
 <div class="row">
   <div class="twelve columns demo" role="main">
 
-    
-    <section class="scrollable contained-scrolling-right-bottom" style="height: 100%">
+
+    <section class="scrollable contained-scrolling-right-bottom" style="height: 50%">
       <div soho-toolbar [maxVisibleButtons]="4">
         <soho-toolbar-title></soho-toolbar-title>
           <soho-toolbar-button-set>
             <input soho-searchfield id="common-toolbar-searchfield" name="common-toolbar-searchfield" />
             <label class="audible" for="common-toolbar-searchfield">Keyword Search</label>
-    
+
             <button id="refresh-item" soho-button="icon" icon="refresh">Refresh</button>
-    
+
             <soho-toolbar-button-set>
                <button soho-button="btn" icon="filter" data-action="{'button':'filter'}">
                   <span>Filter</span>
                 </button>
               </soho-toolbar-button-set>
-    
+
               <soho-toolbar-more-button>
                 <div class="popupmenu-wrapper">
                   <ul soho-popupmenu id="my-popupmenu-element" class="popupmenu">
@@ -43,12 +43,12 @@
                     <li soho-popupmenu-item>
                       <a soho-popupmenu-label href="#" data-option="reset-layout">{{'ResetDefault' | sohoTranslate}}</a>
                     </li>
-    
+
                     <li soho-popupmenu-separator></li>
                     <li soho-popupmenu-item>
                         <a soho-popupmenu-label href="#" data-option="export-to-excel">{{'ExportToExcel' | sohoTranslate}}</a>
                     </li>
-    
+
                     <li soho-popupmenu-separator [singleSelectableSection]="true"></li>
                     <li soho-popupmenu-heading>{{'RowHeight' | sohoTranslate}}
                     </li>
@@ -64,7 +64,7 @@
                     <li soho-popupmenu-item [isSelectable]="true">
                         <a soho-popupmenu-label href="#" data-option="row-large">{{'Large' | sohoTranslate}}</a>
                     </li>
-    
+
                     <li soho-popupmenu-separator></li>
                     <li soho-popupmenu-heading>{{'Filter' | sohoTranslate}}</li>
                     <li soho-popupmenu-item [isIndented]="true">
@@ -76,15 +76,15 @@
                     <li soho-popupmenu-item [isIndented]="true">
                         <a soho-popupmenu-label href="#" data-option="clear-filter">{{'ClearFilter' | sohoTranslate}}</a>
                     </li>
-    
+
                   </ul>
                 </div>
               </soho-toolbar-more-button>
-    
+
           </soho-toolbar-button-set>
         </div>
-      <div soho-datagrid 
-        selectable="true" 
+      <div soho-datagrid
+        selectable="true"
         filterable="true"
         columnReorder="true"
         [toolbar]="{

--- a/src/app/datagrid/datagrid-groupable.demo.html
+++ b/src/app/datagrid/datagrid-groupable.demo.html
@@ -19,7 +19,7 @@
   <div class="twelve columns demo" role="main">
 
 
-    <section class="scrollable contained-scrolling-right-bottom" style="height: 50%">
+    <section class="scrollable contained-scrolling-right-bottom" style="height: 100%">
       <div soho-toolbar [maxVisibleButtons]="4">
         <soho-toolbar-title></soho-toolbar-title>
           <soho-toolbar-button-set>

--- a/src/app/datagrid/datagrid-grouped-header.demo.html
+++ b/src/app/datagrid/datagrid-grouped-header.demo.html
@@ -11,6 +11,9 @@
     </soho-toolbar-button-set>
   </soho-toolbar>
 
-  <div soho-datagrid *ngIf="gridOptions" [gridOptions]="gridOptions"></div>
+  <div soho-datagrid *ngIf="gridOptions" [toolbar]="{
+    results: true,
+    keywordFilter: true
+  }" [gridOptions]="gridOptions"></div>
 
 </div>

--- a/src/app/datagrid/datagrid-grouped-header.demo.html
+++ b/src/app/datagrid/datagrid-grouped-header.demo.html
@@ -11,9 +11,6 @@
     </soho-toolbar-button-set>
   </soho-toolbar>
 
-  <div soho-datagrid *ngIf="gridOptions" [toolbar]="{
-    results: true,
-    keywordFilter: true
-  }" [gridOptions]="gridOptions"></div>
+  <div soho-datagrid *ngIf="gridOptions" [gridOptions]="gridOptions"></div>
 
 </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated data type of cell in drilldown click event to number/null

Based on click here (where click is triggered when clicking drilldown): https://github.com/infor-design/enterprise/blob/main/src/components/datagrid/datagrid.js#L7341

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/7473

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/datagrid-angular-formatter
- Click on drilldown cells
- Check console, should not have errors and should print cell number

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
