### PR TITLE
1477 - fix remaining issues

### DIFF
--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
@@ -38,6 +38,9 @@ interface SohoModuleNavSwitcherStatic {
   /** Reference to the Module Button's Container Element */
   moduleButtonContainerEl?: HTMLElement;
 
+  /** Reference to the Module Button's Icon Element */
+  moduleButtonIconEl?: HTMLElement | SVGElement;
+
   /** Reference to the Module Button element */
   moduleButtonEl?: HTMLElement;
 

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -8,6 +8,7 @@
     <div class="module-nav-header accordion-section">
       <soho-module-nav-switcher
         class="module-nav-switcher"
+        [icon]="'database'"
         [moduleButtonText]="'Standard Module'"
         [roleDropdownLabel]="'Module Roles'"
         [generate]="false"

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -8,7 +8,7 @@
     <div class="module-nav-header accordion-section">
       <soho-module-nav-switcher
         class="module-nav-switcher"
-        [icon]="'database'"
+        [icon]="'https://randomuser.me/api/portraits/lego/1.jpg'"
         [moduleButtonText]="'Standard Module'"
         [roleDropdownLabel]="'Module Roles'"
         [generate]="false"

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -1,6 +1,6 @@
 <div class="module-nav-bar">
   <soho-accordion
-    [allowOnePane]="false"
+    [allowOnePane]="true"
     [hasPanels]="true"
     [moduleNav]="true"
     [rerouteOnLinkClick]="false"

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -8,7 +8,7 @@
     <div class="module-nav-header accordion-section">
       <soho-module-nav-switcher
         class="module-nav-switcher"
-        [icon]="'https://randomuser.me/api/portraits/lego/1.jpg'"
+        [icon]="'database'"
         [moduleButtonText]="'Standard Module'"
         [roleDropdownLabel]="'Module Roles'"
         [generate]="false"


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR provides the Angular portion of Module Nav improvements found in infor-design/enterprise#7714

**Related github/jira issue (required)**:
- Related to #1477
- Related to infor-design/enterprise#7694
- Closes #1523

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run.  Ensure infor-design/enterprise#7714 is merged, or `npm link`-ed to this repository locally.
- Open http://localhost:4200/ids-enterprise-ng-demo/
- Observe the Module Nav Switcher's button has an IDS icon present instead of the standard purple/$ icon.
- Try using the accordion inside the Module Nav.  It should no longer allow multiple panes to be open unless filtering occurs.