### PR TITLE
1425 - Dropdown Icons and Colors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 16.6.0 Fixes
 
 - `[Datagrid]` Updated data type of cell in drilldown click event. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
+- `[Dropdown]` Fixed icons not rendering properly in Dropdown. ([#1425](https://github.com/infor-design/enterprise-ng/issues/1425))
 
 ## 16.5.0
 

--- a/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
@@ -539,6 +539,11 @@ export class SohoDropDownComponent implements AfterViewInit, AfterViewChecked, O
         .on('listopened', (event: JQuery.TriggeredEvent) => this.onListOpened(event));
 
       this.runUpdatedOnCheck = true;
+
+      // Angular Lifecycle checks earlier when the select component is not fully created..
+      setTimeout(() => {
+        this.dropdown?.setListIcon();
+      }, 50);
     });
   }
 

--- a/projects/ids-enterprise-typings/lib/dropdown/soho-dropdown.d.ts
+++ b/projects/ids-enterprise-typings/lib/dropdown/soho-dropdown.d.ts
@@ -251,6 +251,11 @@ interface SohoDropDownStatic {
    * Set the selected option on the dropdown.
    */
   selectValue(value: any): void;
+
+  /**
+   * Set the selected option with icon.
+   */
+  setListIcon(): void;
 }
 
 /**

--- a/src/app/dropdown/dropdown-simple.demo.html
+++ b/src/app/dropdown/dropdown-simple.demo.html
@@ -7,7 +7,15 @@
           <select soho-dropdown soho-busyindicator noSearch name="states1"
             (update)="onUpdated($event)"
             (change)="onChange($event)">
-            <option *ngFor="let option of options" [value]="option.value">{{option.label}}</option>
+            <option *ngFor="let option of options" [attr.data-icon]="option.icon" [value]="option.value">{{option.label}}</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="statesWithIcon" class="label">Simple Dropdown with Icons and Colors</label>
+          <select soho-dropdown soho-busyindicator noSearch name="statesWithIcon"
+            (update)="onUpdated($event)"
+            (change)="onChange($event)">
+            <option *ngFor="let option of optionWithIcons" [attr.data-icon]="option.icon" [value]="option.value">{{option.label}}</option>
           </select>
         </div>
         <div class="field">

--- a/src/app/dropdown/dropdown-simple.demo.ts
+++ b/src/app/dropdown/dropdown-simple.demo.ts
@@ -19,6 +19,20 @@ export class DropdownSimpleDemoComponent implements AfterViewInit {
   /** Used the html to comntrol the options. */
   options: any = [];
 
+  /** Used the html to comntrol the options with icons. */
+  optionWithIcons: any = [
+    { value: 'AK', label: 'Alaska', icon: 'mail' },
+    { value: 'AZ', label: 'Arizona', icon: "{icon: 'camera', class: 'good'}" },
+    { value: 'CA', label: 'California', icon: "{icon: 'send', class: 'info'}" },
+    { value: 'CO', label: 'Colorado', icon: "{icon: 'notes', class: 'alert'}" },
+    { value: 'MN', label: 'Minnesota', icon: 'add-grid-record' },
+    { value: 'ND', label: 'North Dakota', icon: 'language' },
+    { value: 'OR', label: 'Oregon', icon: 'search-folder' },
+    { value: 'WA', label: 'Washington', icon: 'technology' },
+    { value: 'WY', label: 'Wyoming', icon: 'spreadsheet' }
+  ];
+
+
   readOnly = true;
 
   ngAfterViewInit() {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix icons not rendering properly in Dropdown.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1425

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/dropdown-simple
- See the dropdown `Simple Dropdown with Icons and Colors`
- Open it, it should have icons with colors

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

