### PR TITLE
7556 - Popupmenu Closing Behavior

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datagrid]` Updated data type of cell in drilldown click event. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
 - `[Dropdown]` Fixed icons not rendering properly in Dropdown. ([#1425](https://github.com/infor-design/enterprise-ng/issues/1425))
+- `[Popupmenu]` Added Example for Multiselect and Singleselect. ([EP#7556](https://github.com/infor-design/enterprise/issues/7556))
 
 ## 16.5.0
 

--- a/src/app/popupmenu/popupmenu.demo.html
+++ b/src/app/popupmenu/popupmenu.demo.html
@@ -122,6 +122,7 @@
 
 <div class="row top-padding">
   <div class="twelve columns">
+    <span class="label">Popup Menu Multiselect Singleselect</span>
     <button soho-menu-button [menu]="'mock-menu'" [id]="'mock-button'" [hideMenuArrow]="false">Menu</button>
     <ul soho-popupmenu id="mock-menu">
       <li soho-popupmenu-separator [multiSelectableSection]="true"></li>

--- a/src/app/popupmenu/popupmenu.demo.html
+++ b/src/app/popupmenu/popupmenu.demo.html
@@ -119,3 +119,50 @@
     <button soho-button="primary" (click)="onClick()">Selected Items</button>
   </div>
 </div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <button soho-menu-button [menu]="'mock-menu'" [id]="'mock-button'" [hideMenuArrow]="false">Menu</button>
+    <ul soho-popupmenu id="mock-menu">
+      <li soho-popupmenu-separator [multiSelectableSection]="true"></li>
+      <li soho-popupmenu-item [isChecked]="true" class="is-multiselectable">
+        <a soho-popupmenu-label>Menu Option #1</a>
+      </li>
+
+      <li soho-popupmenu-item [isChecked]="false" class="is-multiselectable">
+        <a soho-popupmenu-label>Menu Option #2</a>
+      </li>
+
+      <li soho-popupmenu-separator [singleSelectableSection]="true"></li>
+
+      <li soho-popupmenu-item [subMenu]="true" [isSelectable]="false">
+        <a href="">Menu Option #3</a>
+        <ul soho-popupmenu>
+          <li soho-popupmenu-heading>Primary</li>
+          <li soho-popupmenu-item [isSelectable]="true" [isChecked]="true">
+            <a soho-popupmenu-label>Option 1</a>
+          </li>
+          <li class="hotdog" soho-popupmenu-item [isSelectable]="true" [isChecked]="false">
+            <a soho-popupmenu-label>Option 2</a>
+          </li>
+          <li soho-popupmenu-item [isSelectable]="true">
+            <a soho-popupmenu-label>Option 3</a>
+          </li>
+
+          <li soho-popupmenu-separator [singleSelectableSection]="true"></li>
+
+          <li soho-popupmenu-heading>Secondary</li>
+          <li soho-popupmenu-item [isSelectable]="true" [isChecked]="true">
+            <a soho-popupmenu-label>Option 1</a>
+          </li>
+          <li soho-popupmenu-item [isSelectable]="true">
+            <a soho-popupmenu-label>Option 2</a>
+          </li>
+          <li soho-popupmenu-item [isSelectable]="true">
+            <a soho-popupmenu-label>Option 3</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix the behavior of the component when having submenus in NG.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7556

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/popupmenu
- Under `Popup Menu Multiselect Singleselect`
- Open the `Menu`
- Click `Menu Option #3` and it should close
- Open the `Menu` again
- Click an item in the submenu `Menu Option #3`
- See that the whole popupmenu closes

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

