### PR TITLE
1507 - Added tooltipOption for Datagrid Column

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## 16.7.0
+
+### 16.7.0 Fixes
+
+- `[Datagrid]` Added tooltipOptions for Column Settings. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
+
 ## 16.6.0
 
 ### 16.6.0 Fixes

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -829,6 +829,9 @@ interface SohoDataGridColumn {
   /** Tooltip for the column header. */
   headerTooltip?: string;
 
+  /** Tooltip Options for the columns of the datagrid */
+  tooltipOptions?: SohoTooltipOptions;
+
   /** Column formatter function or a string.  */
   formatter?: SohoDataGridColumnFormatterFunction | string;
 

--- a/src/app/datagrid/datagrid-add-row.demo.ts
+++ b/src/app/datagrid/datagrid-add-row.demo.ts
@@ -21,6 +21,13 @@ export class DataGridAddRowDemoComponent implements OnInit {
 
   public options!: SohoDataGridOptions;
   public newRowData!: string;
+  public tooltipOptions: SohoTooltipOptions = {
+    placement: 'top'
+  }
+
+  public tooltipCompressor: SohoTooltipOptions = {
+    placement: 'bottom'
+  }
 
   constructor() { }
 
@@ -34,19 +41,39 @@ export class DataGridAddRowDemoComponent implements OnInit {
         id: 'name',
         name: 'Name',
         field: 'name',
-        width: 150,
+        // width: 80, 
         sortable: true,
+        headerTooltip: 'Name Column',
+        tooltipOptions: this.tooltipOptions,
+        formatter: Soho.Formatters.Ellipsis,
+      },
+      {
+        id: 'compressor',
+        name: 'Compressor',
+        field: 'compressor',
+        // width: 80,
+        sortable: true,
+        headerTooltip: 'Compressor Column',
+        tooltipOptions: this.tooltipCompressor,
+        formatter: Soho.Formatters.Ellipsis,
+      },
+      {
+        id: 'quantity',
+        name: 'Quantity',
+        field: 'quantity',
+        // width: 80,
+        sortable: true,
+        headerTooltip: 'Quantity Column',
+        tooltipOptions: this.tooltipOptions,
         formatter: Soho.Formatters.Ellipsis,
       },
       {
         id: 'open',
         name: 'Actions',
-        width: 80,
+        // width: 80,
+        sortable: false,
         formatter: Soho.Formatters.Button,
         icon: 'info',
-        headerTooltip: 'Actions',
-        resizable: false,
-        sortable: false,
         menuId: 'card-options',
         click: (_: Event, data: SohoDataGridColumnClickData[]) => {
           console.info(data);
@@ -55,8 +82,9 @@ export class DataGridAddRowDemoComponent implements OnInit {
       },
     ];
     this.options = {
-      dataset: [{ name: 'Foo' }],
+      dataset: [{ name: 'Lorem', compressor: 'Compressor 1', quantity: 24 }],
       columns,
+      enableTooltips: true
     };
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will add tooltipOptions for Column Settings in Datagrid.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1507

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-add-row
- Hover the first three columns

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

