### PR TITLE
1535 - Added no search setting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 16.7.0 Fixes
 
 - `[Datagrid]` Added tooltipOptions for Column Settings. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
+- `[Module Nav Switcher]` Added noSearch setting to pass through to nav switcher ([#1535](https://github.com/infor-design/enterprise-ng/issues/1535))
 
 ## 16.6.0
 

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
@@ -36,6 +36,7 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
     generate: false,
     icon: undefined,
     changeIconOnSelect: true,
+    noSearch: false,
     moduleButtonText: undefined,
     roleDropdownLabel: undefined,
     roles: []
@@ -70,6 +71,14 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
     return this.modulenavswitcher?.settings.generate || this._options.generate;
   }
 
+  @Input() set changeIconOnSelect(val: boolean | undefined) {
+    this._options.changeIconOnSelect = val;
+    this.updated({ changeIconOnSelect: this._options.changeIconOnSelect });
+  }
+  public get changeIconOnSelect(): boolean | undefined {
+    return this.modulenavswitcher?.settings.changeIconOnSelect || this._options.changeIconOnSelect;
+  }
+
   @Input() set icon(val: SohoModuleNavSwitcherIconSetting) {
     this._options.icon = val;
     this.updated({ icon: this._options.icon });
@@ -78,12 +87,13 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
     return this.modulenavswitcher?.settings.icon || this._options.icon;
   }
 
-  @Input() set changeIconOnSelect(val: boolean | undefined) {
-    this._options.changeIconOnSelect = val;
-    this.updated({ changeIconOnSelect: this._options.changeIconOnSelect });
+  @Input() set noSearch(val: boolean | undefined) {
+    console.log(val);
+    this._options.noSearch = val;
+    this.updated({ noSearch: this._options.noSearch });
   }
-  public get changeIconOnSelect(): boolean | undefined {
-    return this.modulenavswitcher?.settings.changeIconOnSelect || this._options.changeIconOnSelect;
+  public get noSearch(): boolean | undefined {
+    return this.modulenavswitcher?.settings.noSearch || this._options.noSearch;
   }
 
   @Input() set moduleButtonText(val: string | undefined) {
@@ -185,6 +195,9 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
     this.ngZone.runOutsideAngular(() => {
       // Initialize/store instance
       this.jQueryElement = jQuery(this.elementRef.nativeElement);
+      if (this._options.noSearch)
+        this.jQueryElement.find('select').attr('data-options', `{ noSearch: true}`);
+
       this.jQueryElement.modulenavswitcher(this._options);
       this.modulenavswitcher = this.jQueryElement.data('modulenavswitcher');
 

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav-switcher.d.ts
@@ -19,6 +19,7 @@ interface SohoModuleNavSwitcherOptions {
   moduleButtonText?: string;
   roleDropdownLabel?: string;
   changeIconOnSelect?: boolean;
+  noSearch?: boolean;
   roles?: Array<SohoModuleNavSwitcherRoleRecord>;
 }
 

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -13,6 +13,7 @@
         [roleDropdownLabel]="'Module Roles'"
         [generate]="false"
         [changeIconOnSelect]="false"
+        [noSearch]="true"
         (modulebuttonclick)="onModuleButtonClick($event)"
         (rolechange)="onRoleChange($event)"></soho-module-nav-switcher>
     </div>
@@ -288,7 +289,6 @@
         <div class="accordion-header"><a [routerLink]="['mask-legacy']"><span>Mask Legacy</span></a></div>
         <div class="accordion-header"><a [routerLink]="['menu-button']"><span>Menu Button</span></a></div>
         <div class="accordion-header"><a [routerLink]="['message']"><span>Message</span></a></div>
-        <div class="accordion-header"><a [routerLink]="['module-nav']"><span>Module Nav</span></a></div>
         <div class="accordion-header"><a [routerLink]="['modal-dialog']"><span>Modal Dialog</span></a></div>
         <div class="accordion-header"><a [routerLink]="['monthview']">Monthview</a></div>
         <div class="accordion-header"><a [routerLink]="['monthview-inpage']">Monthview - In Page</a></div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds noSearch type to the search field. Requires https://github.com/infor-design/enterprise/pull/7771

**Related github/jira issue (required)**:
Fixes #1533

Patching to 4.85.6

**Steps necessary to review your pull request (required)**:
- checkout https://github.com/infor-design/enterprise/pull/7771 and do an `npm run build` then copy to node_modules so you have those changes
- `npm run build:lib && npm run start`
- go to http://localhost:4200/ids-enterprise-ng-demo/
- open the dropdown and try to type -> should not be able to
