### PR TITLE
EP 7786: SohoModuleNav - Add `enableOutsideClick` setting to enable collapse/hide when content is clicked

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[Dropdown]` Fixed icons not rendering properly in Dropdown. ([#1425](https://github.com/infor-design/enterprise-ng/issues/1425))
 - `[Popupmenu]` Added Example for Multiselect and Singleselect. ([EP#7556](https://github.com/infor-design/enterprise/issues/7556))
 - `[Datagrid]` Added tooltipOptions for Column Settings. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
+- `[Module Nav]` Add `enableOutsideClick` for collapse/hide of menu when content is clicked. ([EP#7786](https://github.com/infor-design/enterprise/issues/7786))
 - `[Module Nav Switcher]` Added noSearch setting to pass through to nav switcher ([#1535](https://github.com/infor-design/enterprise-ng/issues/1535))
 
 ## 16.5.0

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
@@ -36,6 +36,7 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   private _options: SohoModuleNavOptions = {
     accordionSettings: {},
     displayMode: false,
+    enableOutsideClick: false,
     initChildren: true,
     filterable: false,
     pinSections: false,
@@ -71,6 +72,14 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
     return this.modulenav?.settings.displayMode || this._options.displayMode;
   }
 
+  @Input() set enableOutsideClick(val: boolean) {
+    this._options.enableOutsideClick = val;
+    this.updated({ enableOutsideClick: this._options.enableOutsideClick });
+  }
+  public get enableOutsideClick(): boolean {
+    return this.modulenav?.settings.enableOutsideClick || this._options.enableOutsideClick || false;
+  }
+
   @Input() set filterable(val: boolean) {
     this._options.filterable = val;
     this.updated({ filterable: this._options.filterable });
@@ -102,6 +111,12 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   public get showDetailView(): boolean {
     return this.modulenav?.settings.showDetailView || this._options.showDetailView || false;
   }
+
+  // -------------------------------------------
+  // Component Output
+  // -------------------------------------------
+
+  @Output() displaymodechange = new EventEmitter<SohoModuleNavDisplayModeChangeEvent>();
 
   // -------------------------------------------
   // Public API
@@ -170,9 +185,13 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   ngAfterViewInit() {
     this.ngZone.runOutsideAngular(() => {
       // Initialize/store instance
-      this.jQueryElement = jQuery(this.elementRef.nativeElement);
+      this.jQueryElement = jQuery(this.elementRef.nativeElement)!;
       this.jQueryElement.modulenav(this._options);
       this.modulenav = this.jQueryElement.data('modulenav');
+
+      // bind to jquery events and emit as angular events
+      this.jQueryElement.on('displaymodechange', (e: JQuery.TriggeredEvent, val: SohoModuleNavDisplayMode) =>
+        this.ngZone.run(() => this.displaymodechange.emit({ e, val })));
     });
   }
 

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
@@ -1,10 +1,16 @@
 /// <reference path='./soho-module-nav-common.d.ts' />
 /// <reference path='../accordion/soho-accordion.d.ts' />
 
+interface SohoModuleNavDisplayModeChangeEvent {
+  e: JQuery.TriggeredEvent,
+  val: SohoModuleNavDisplayMode
+}
+
 /** Defines options present in the Soho Module Nav */
 interface SohoModuleNavOptions {
   accordionSettings?: SohoAccordionOptions;
   displayMode?: SohoModuleNavDisplayMode;
+  enableOutsideClick?: boolean;
   filterable?: boolean;
   initChildren?: boolean;
   pinSections?: boolean;

--- a/src/app/demoapp-nav-container/demoapp-nav-container.html
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.html
@@ -32,9 +32,11 @@
       [ngClass]="{ 'module-nav': true }"
       [accordionSettings]="{ 'rerouteOnLinkClick': false, 'expanderDisplay': 'classic' }"
       [displayMode]="'expanded'"
+      [enableOutsideClick]="true"
       [filterable]="true"
       [pinSections]="true"
-      (appMenuTriggerClick)="toggleModuleNavDisplayMode()">
+      (appMenuTriggerClick)="toggleModuleNavDisplayMode()"
+      (displaymodechange)="handleDisplayModeChange($event)">
       <module-nav-demo></module-nav-demo>
     </soho-module-nav>
     <div class="page-container no-scroll has-module-nav-offset">

--- a/src/app/demoapp-nav-container/demoapp-nav-container.ts
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.ts
@@ -118,7 +118,7 @@ export class DemoappNavContainerComponent implements AfterViewInit {
       localStorage.setItem(this.MODULE_NAV_DISPLAY_MODE_KEY, displayMode);
     }
 
-    if (this.moduleNavContainer) {
+    if (this.moduleNavDisplayMode !== displayMode && this.moduleNavContainer) {
       this.moduleNav?.updated({ displayMode });
     }
   }
@@ -187,9 +187,12 @@ export class DemoappNavContainerComponent implements AfterViewInit {
     if (this.applicationMenu) {
       this.isApplicationMenuOpen = !this.isApplicationMenuOpen;
     }
-    if (this.moduleNavContainer) {
-      this.toggleModuleNavDisplayMode();
-    }
+    this.toggleModuleNavDisplayMode();
     this.renderVisibility();
+  }
+
+  public handleDisplayModeChange(e: SohoModuleNavDisplayModeChangeEvent) {
+    console.info('sup', e);
+    this.moduleNavDisplayMode = e.val;
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR provides TypeScript types and Angular API hooks for the new `enableOutsideClick` setting in the Module Nav component.

**Related github/jira issue (required)**:
- Related to infor-design/enterprise#7786
- Related to infor-design/enterprise#7794

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run.  Ensure the branch attached to [EP #7794](https://github.com/infor-design/enterprise/pull/7794) is linked to your local copy 
- Open http://localhost:4200/ids-enterprise-ng-demo/
- Click the page content area. The Module Nav bar should hide completely (hidden is the "previously-used" default for display mode)
- Click the hamburger button twice, once to switch to "collapsed" display mode, once more to switch to "expanded" display mode.
- Click into the content area.  The Module Nav bar should collapse.