### PR TITLE
7822 - Added listcontextmenu event

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 16.7.0 Fixes
 
 - `[Modal]` Added type for icons. ([#1544](https://github.com/infor-design/enterprise-ng/issues/1544))
+- `[ModuleNav]` Added `listcontextmenu` event ([#7822](https://github.com/infor-design/enterprise/issues/7822))
 
 ## 16.6.0
 

--- a/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
@@ -444,6 +444,13 @@ export class SohoDropDownComponent implements AfterViewInit, AfterViewChecked, O
   listOpened$ = new EventEmitter<SohoDropDownEvent>();
 
   /**
+   * Fired when the dropdown list is right clicked.
+   */
+  // eslint-disable-next-line @angular-eslint/no-output-rename
+  @Output('listcontextmenu')
+  listContextMenu$ = new EventEmitter<SohoDropDownEvent>();
+
+  /**
    * This event is fired when a key is pressed
    */
   // eslint-disable-next-line @angular-eslint/no-output-rename, @angular-eslint/no-output-native
@@ -536,7 +543,8 @@ export class SohoDropDownComponent implements AfterViewInit, AfterViewChecked, O
         .on('updated', (event: JQuery.TriggeredEvent) => this.onUpdated(event))
         .on('requestend', (event: JQuery.TriggeredEvent, searchTerm: string, data: any[]) => this.onRequestEnd(event, searchTerm, data))
         .on('listclosed', (event: JQuery.TriggeredEvent, action: SohoDropDownEventActions) => this.onListClosed(event, action))
-        .on('listopened', (event: JQuery.TriggeredEvent) => this.onListOpened(event));
+        .on('listopened', (event: JQuery.TriggeredEvent) => this.onListOpened(event))
+        .on('listcontextmenu', (event: JQuery.TriggeredEvent, delegate: any) => this.onListContextMenu(event, delegate))
 
       this.runUpdatedOnCheck = true;
 
@@ -605,10 +613,7 @@ export class SohoDropDownComponent implements AfterViewInit, AfterViewChecked, O
 
   /**
    * Event handler for the 'changed' event on the 'dropdown' component.
-   *
-   *
    * @param event the standard jQuery event.
-   *
    */
   private onChanged(event: any) {
     // Retrieve the value from the 'dropdown' component.
@@ -632,6 +637,18 @@ export class SohoDropDownComponent implements AfterViewInit, AfterViewChecked, O
       // that up.
       event.data = val;
       this.change$.emit(event);
+    });
+  }
+
+  /**
+   * Event handler for the 'listchanged' event on the 'dropdown' component.
+   * @param event the standard jQuery event.
+   */
+  private onListContextMenu(event: any, delegate: any) {
+    event.delegate = delegate;
+    event.target = delegate.target;
+    this.ngZone.run(() => {
+      this.listContextMenu$.emit(event);
     });
   }
 

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.html
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.html
@@ -13,7 +13,8 @@
     name="module-nav-role-switcher"
     class="dropdown"
     data-automation-id="custom-automation-dropdown-id"
-    (change)="onRoleChange($event)">
+    (change)="onRoleChange($event)"
+    (listcontextmenu)="onListContextMenu($event)">
     <option *ngFor="let role of roles" [value]="role.value">{{role.label}}</option>
   </select>
 </div>

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
@@ -125,7 +125,7 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
   // -------------------------------------------
 
   @Output() rolechange = new EventEmitter<JQuery.TriggeredEvent>();
-
+  @Output() listcontextmenu = new EventEmitter<JQuery.TriggeredEvent>();
   @Output() modulebuttonclick = new EventEmitter<JQuery.TriggeredEvent>();
 
   // -------------------------------------------
@@ -197,9 +197,14 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
     this.modulebuttonclick.emit(event);
   }
 
-  /** Triggered by a Role Dropdown change */
+  /** Triggered by a dropdown change */
   onRoleChange(event: JQuery.TriggeredEvent) {
     this.rolechange.emit(event);
+  }
+
+  /** Triggered by a right click on the dropdown */
+  onListContextMenu(event: JQuery.TriggeredEvent) {
+    this.listcontextmenu.emit(event);
   }
 
   // ------------------------------------------
@@ -230,7 +235,12 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
 
       // @todo - add event binding control so we don't bind if not required.
       this.jQueryElement
-        .on('change', (event: JQuery.TriggeredEvent) => this.onRoleChange(event))
+        .on('change', (event: JQuery.TriggeredEvent) => this.onRoleChange(event));
+      this.jQueryElement
+        .on('listcontextmenu', (event: JQuery.TriggeredEvent, delegate: any) => {
+          event.target = delegate.target;
+          this.onListContextMenu(event);
+        });
     });
   }
 

--- a/src/app/demoapp-nav-container/demoapp-nav-container.ts
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.ts
@@ -192,7 +192,7 @@ export class DemoappNavContainerComponent implements AfterViewInit {
   }
 
   public handleDisplayModeChange(e: SohoModuleNavDisplayModeChangeEvent) {
-    console.info('sup', e);
+    console.info('Display Mode Changed', e);
     this.moduleNavDisplayMode = e.val;
   }
 }

--- a/src/app/dropdown/dropdown.demo.html
+++ b/src/app/dropdown/dropdown.demo.html
@@ -1,12 +1,10 @@
 <div class="example-section">
   <form>
     <div class="row">
-      <h1>Single-Select Dropdown</h1>
-      <span class="code-tag">Live Example</span>
       <div class="row">
         <div class="field">
           <label for="states" class="label">States</label>
-          <select soho-dropdown noSearch name="states" [(ngModel)]="model.single" (change)="onChange($event)" (keydown)="onKeyDown($event)" (listopened)="onListOpened($event)" (listclosed)="onListClosed($event)">
+          <select soho-dropdown noSearch name="states" [(ngModel)]="model.single" (change)="onChange($event)" (listcontextmenu)="onListContextMenu($event)" (listopened)="onListOpened($event)"  (keydown)="onKeyDown($event)" (listclosed)="onListClosed($event)">
             <option value="AL">Alabama</option>
             <option value="CA">California</option>
             <option value="DE" >Delaware</option>

--- a/src/app/dropdown/dropdown.demo.ts
+++ b/src/app/dropdown/dropdown.demo.ts
@@ -58,6 +58,10 @@ export class DropdownDemoComponent {
     console.log(`listclosed: ${e.action}`);
   }
 
+  onListContextMenu(e: SohoDropDownEvent) {
+    console.log(`listcontextmenu`, (e as any).target);
+  }
+
   onListOpened(_e: SohoDropDownEvent) {
     console.log(`listopened`);
   }

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -15,7 +15,8 @@
         [changeIconOnSelect]="false"
         [noSearch]="true"
         (modulebuttonclick)="onModuleButtonClick($event)"
-        (rolechange)="onRoleChange($event)"></soho-module-nav-switcher>
+        (rolechange)="onRoleChange($event)"
+        (listcontextmenu)="onListContextMenu($event)"></soho-module-nav-switcher>
     </div>
 
     <div class="module-nav-search-container accordion-section">

--- a/src/app/module-nav/module-nav.demo.ts
+++ b/src/app/module-nav/module-nav.demo.ts
@@ -53,6 +53,12 @@ export class ModuleNavDemoComponent implements AfterViewInit {
     console.info('Module Nav Role change: ', e.target.value);
   }
 
+  onListContextMenu(e: JQuery.TriggeredEvent) {
+    console.info('Module Context Menu', e.target);
+    const url = $(e.target).text().replace(/^\s+|\s+$/g, '').replace(' ', '').toLocaleLowerCase();
+    $(e.target).attr('href', `https://example.com/${url}`);
+  }
+
   onModuleButtonClick(e: any) {
     console.info('Module Nav Role Button clicked', e);
     this.moduleNavSwitcher?.toggleModuleButtonFocus(true);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds a listcontextmenu event which is used to add data for right click, open in a new window functionality for Landmark.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/issues/7822

**Steps necessary to review your pull request (required)**:
- build branch https://github.com/infor-design/enterprise/pull/7847 and copy it to the node_modules folder
- open http://localhost:4200/ids-enterprise-ng-demo/dropdown
- open the module switcher menu and right click any element (for example Landing Page Designer)
- then open in new tab -> check the url it should be injected with the element name
