### PR TITLE
7804 - Add card fixes and new types

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # What's New with Enterprise-NG
 
+## 16.8.0
+
+### 16.8.0 Fixes
+
+- `[ModuleNav]` Added types for new mobile setting. ([#7804](https://github.com/infor-design/enterprise/issues/7804))
+- `[Cards]` Fixed an issue with initialization. ([#7804](https://github.com/infor-design/enterprise/issues/7804))
+
 ## 16.7.0
 
 ### 16.7.0 Fixes
@@ -11,9 +18,9 @@
 
 ### 16.6.0 Fixes
 
-- `[Datagrid]` Updated data type of cell in drilldown click event. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
+- `[Datagrid]` Updated data type of cell in `drilldown` click event. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
 - `[Dropdown]` Fixed icons not rendering properly in Dropdown. ([#1425](https://github.com/infor-design/enterprise-ng/issues/1425))
-- `[Popupmenu]` Added Example for Multiselect and Singleselect. ([EP#7556](https://github.com/infor-design/enterprise/issues/7556))
+- `[Popupmenu]` Added Example for `Multiselect` and `Singleselect`. ([EP#7556](https://github.com/infor-design/enterprise/issues/7556))
 - `[Datagrid]` Added tooltipOptions for Column Settings. ([EP#7473](https://github.com/infor-design/enterprise/issues/7473))
 - `[Module Nav]` Add `enableOutsideClick` for collapse/hide of menu when content is clicked. ([EP#7786](https://github.com/infor-design/enterprise/issues/7786))
 - `[Module Nav Switcher]` Added noSearch setting to pass through to nav switcher ([#1535](https://github.com/infor-design/enterprise-ng/issues/1535))
@@ -24,7 +31,7 @@
 
 - `[Homepage/Widget]` Added card settings in widget component. ([#1502](https://github.com/infor-design/enterprise-ng/issues/1502))
 - `[Module Nav Switcher]` Improve Angular/EP component lifecycle. ([#1477](https://github.com/infor-design/enterprise-ng/issues/1477))
-- `[Datepicker]` Added custom validation for Datepicker component. ([#1512](https://github.com/infor-design/enterprise-ng/issues/1512))
+- `[Datepicker]` Added custom validation for Date picker component. ([#1512](https://github.com/infor-design/enterprise-ng/issues/1512))
 - `[Datagrid]` Added missing headerTooltip setting. ([#1514](https://github.com/infor-design/enterprise-ng/issues/1514))
 
 ## 16.4.1
@@ -34,7 +41,7 @@
 - `[General]` Added 4.84.0 EP version.
 - `[Module Nav]` Add Module Nav Component wrappers and replace the app menu with the Module Nav menu. ([#1477](https://github.com/infor-design/enterprise-ng/issues/1477))
 - `[Images]` Added an example page for Image with click handler. ([EP#7007](https://github.com/infor-design/enterprise/issues/7007))
-- `[Lookup]` Updated example page for datagrid editor. ([#7403](https://github.com/infor-design/enterprise/issues/7403))
+- `[Lookup]` Updated example page for `datagrid` editor. ([#7403](https://github.com/infor-design/enterprise/issues/7403))
 - `[General]` Added 4.84.0 EP version.
 - `[General] Added 4.84.0 EP version.
 - `[ProcessIndicator]` Added process indicator demo. ([EP#7583](https://github.com/infor-design/enterprise/issues/75837007))
@@ -75,7 +82,7 @@
 - `[Homepage/Widget]` Added card settings in widget component. ([#1502](https://github.com/infor-design/enterprise-ng/issues/1502))
 - `[Module Nav]` Add Module Nav Component wrappers and replace the app menu with the Module Nav menu. ([#1477](https://github.com/infor-design/enterprise-ng/issues/1477))
 - `[Module Nav Switcher]` Improve Angular/EP component lifecycle. ([#1477](https://github.com/infor-design/enterprise-ng/issues/1477))
-- `[Datepicker]` Added custom validation for Datepicker component. ([#1512](https://github.com/infor-design/enterprise-ng/issues/1512))
+- `[Datepicker]` Added custom validation for `Datepicker` component. ([#1512](https://github.com/infor-design/enterprise-ng/issues/1512))
 - `[Datagrid]` Added missing headerTooltip setting. ([#1514](https://github.com/infor-design/enterprise-ng/issues/1514))
 
 ## 15.4.1
@@ -90,10 +97,10 @@
 ### 15.3.0 Fixes
 
 - `[ApplicationMenu]` Changed the app menu hamburger icon. ([1470](https://github.com/infor-design/enterprise/issues/1470))
-- `[Modal]` Added Example Page with Datepicker. ([EP#7144](https://github.com/infor-design/enterprise/issues/7144))
+- `[Modal]` Added Example Page with `Datepicker`. ([EP#7144](https://github.com/infor-design/enterprise/issues/7144))
 - `[Pager]` Fixes a bug hiding and showing the page size selector. ([#1459](https://github.com/infor-design/enterprise/issues/1459))
-- `[Textarea]` Added Example Page with Textarea Toggle Dirty. ([#1429](https://github.com/infor-design/enterprise-ng/issues/1429))
-- `[Timepicker]` Added Timepicker in Example Page of Validator. ([#1435](https://github.com/infor-design/enterprise-ng/issues/1435))
+- `[Textarea]` Added Example Page with `Textarea` Toggle Dirty. ([#1429](https://github.com/infor-design/enterprise-ng/issues/1429))
+- `[Timepicker]` Added `Timepicker` in Example Page of Validator. ([#1435](https://github.com/infor-design/enterprise-ng/issues/1435))
 - `[Tooltip]` Added settings for popover `appendTo` settings. ([EP#7220](https://github.com/infor-design/enterprise/issues/7220))
 
 ## 15.1.0
@@ -144,13 +151,13 @@
 ### 15.0.0 Features
 
 - `[Chart]` Added example page for chart colors. ([EP#7084](https://github.com/infor-design/enterprise/issues/7084))
-- `[Datagrid]` Added a setting to set the color of the header in datagrid (`dark` or `light`). ([#7008](https://github.com/infor-design/enterprise/issues/7008)) `EA`
+- `[Datagrid]` Added a setting to set the color of the header in `datagrid` (`dark` or `light`). ([#7008](https://github.com/infor-design/enterprise/issues/7008)) `EA`
 - `[General]` Updated to NG 15 d made small fixes. See the `UPGRADING.md` guide for details. ([#1316](https://github.com/infor-design/enterprise-ng/issues/1316))
 - `[Icons]` Merge old, new and "colorful" empty state icons into `SohoIconsEmptyComponent`, with the ability to force the use of colorful icons. ([#1418](https://github.com/infor-design/enterprise-ng/issues/1418))
 
 ### 15.0.0 Fixes
 
-- `[Datepicker]` Added empty string value check in datepicker range. ([#1397](https://github.com/infor-design/enterprise-ng/issues/1397))
+- `[Datepicker]` Added empty string value check in `datepicker` range. ([#1397](https://github.com/infor-design/enterprise-ng/issues/1397))
 
 ## 14.8.2
 

--- a/projects/ids-enterprise-ng/src/lib/card/soho-card.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/card/soho-card.component.ts
@@ -285,23 +285,21 @@ export class SohoCardComponent implements AfterViewInit, OnDestroy, OnInit {
     this.ngZone.runOutsideAngular(() => {
       this.jQueryElement = jQuery(this.element.nativeElement);
 
-      this.jQueryElement.cards(this.options);
+      this.options.id = this.id;
+      this.options.expandableHeader = this.expandableHeader;
+      this.options.expanded = !this.closed,
+        this.options.verticalButtonAction = this.verticalButtonAction;
+      this.options.attributes = this.options.attributes
+      this.options.bordered = this.bordered;
+      this.options.noHeader = this.noHeader;
+      this.options.contentPaddingX = this.contentPaddingX;
+      this.options.contentPaddingY = this.contentPaddingY;
+      this.options.noShadow = this.noShadow;
+      this.options.detailRefId = this.detailRefId;
 
       // Add listeners to emit events
       // Initiate the element via jQuery
-      this.jQueryElement.cards({
-        id: this.id,
-        expandableHeader: this.expandableHeader,
-        expanded: !this.closed,
-        verticalButtonAction: this.verticalButtonAction,
-        attributes: this.options.attributes,
-        bordered: this.bordered,
-        noHeader: this.noHeader,
-        contentPaddingX: this.contentPaddingX,
-        contentPaddingY: this.contentPaddingY,
-        noShadow: this.noShadow,
-        detailRefId: this.detailRefId,
-      });
+      this.jQueryElement.cards(this.options);
 
       if (this.toggle) {
         this.toggle.subscribe(value => this.toggleOpen(value));

--- a/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav/soho-module-nav.component.ts
@@ -36,11 +36,14 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   private _options: SohoModuleNavOptions = {
     accordionSettings: {},
     displayMode: false,
-    enableOutsideClick: false,
     initChildren: true,
     filterable: false,
     pinSections: false,
     showDetailView: false,
+    mobileBehavior: true,
+    breakpoint: 'phone-to-tablet',
+    showOverlay: true,
+    enableOutsideClick: false,
   };
 
   /** Internal use flags */
@@ -70,6 +73,31 @@ export class SohoModuleNavComponent implements AfterViewInit, AfterViewChecked, 
   }
   public get displayMode(): SohoModuleNavDisplayMode | undefined {
     return this.modulenav?.settings.displayMode || this._options.displayMode;
+  }
+
+  // Mobile Options
+  @Input() set mobileBehavior(val: boolean) {
+    this._options.mobileBehavior = val;
+    this.updated({ mobileBehavior: this._options.mobileBehavior });
+  }
+  public get mobileBehavior(): boolean {
+    return this.modulenav?.settings.mobileBehavior || this._options.mobileBehavior || false;
+  }
+
+  @Input() set breakpoint(val: SohoModuleNavBreakPoint) {
+    this._options.breakpoint = val;
+    this.updated({ breakpoint: this._options.breakpoint });
+  }
+  public get breakpoint(): SohoModuleNavBreakPoint {
+    return this.modulenav?.settings.breakpoint || this._options.breakpoint || 'phone-to-tablet';
+  }
+
+  @Input() set showOverlay(val: boolean) {
+    this._options.showOverlay = val;
+    this.updated({ showOverlay: this._options.showOverlay });
+  }
+  public get showOverlay(): boolean {
+    return this.modulenav?.settings.showOverlay || this._options.showOverlay || false;
   }
 
   @Input() set enableOutsideClick(val: boolean) {

--- a/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
+++ b/projects/ids-enterprise-typings/lib/module-nav/soho-module-nav.d.ts
@@ -6,15 +6,27 @@ interface SohoModuleNavDisplayModeChangeEvent {
   val: SohoModuleNavDisplayMode
 }
 
+type SohoModuleNavBreakPoint =
+  'phone' |
+  'slim' |
+  'phablet' |
+  'phone-to-tablet' |
+  'wide-tablet' |
+  'tablet-to-desktop' |
+  'desktop-to-extralarge' | undefined;
+
 /** Defines options present in the Soho Module Nav */
 interface SohoModuleNavOptions {
   accordionSettings?: SohoAccordionOptions;
   displayMode?: SohoModuleNavDisplayMode;
-  enableOutsideClick?: boolean;
   filterable?: boolean;
   initChildren?: boolean;
   pinSections?: boolean;
   showDetailView?: boolean;
+  mobileBehavior?: boolean;
+  breakpoint?: SohoModuleNavBreakPoint,
+  showOverlay?: boolean;
+  enableOutsideClick?: boolean;
 }
 
 /** Public API for Soho Module Nav JS component */

--- a/src/app/cards/cards-expandable.demo.html
+++ b/src/app/cards/cards-expandable.demo.html
@@ -6,8 +6,7 @@
       [attributes]="model.attributes">
 
       <soho-card-header>
-        <p class="heading">Tuesday, 21st September</p>
-        <p class="sub-heading">8:40AM-2:00PM</p>
+        <p class="heading">Tuesday, 21st September <br><span class="sub-heading">8:40AM-2:00PM</span></p>
         <button soho-button="icon" icon="more" soho-context-menu menu="action-popupmenu" trigger="click"
           class="btn-actions"></button>
         <ul soho-popupmenu id="action-popupmenu" (selected)="onSelected($event)" (beforeopen)="onBeforeOpen($event)"

--- a/src/app/demoapp-nav-container/demoapp-nav-container.html
+++ b/src/app/demoapp-nav-container/demoapp-nav-container.html
@@ -32,7 +32,6 @@
       [ngClass]="{ 'module-nav': true }"
       [accordionSettings]="{ 'rerouteOnLinkClick': false, 'expanderDisplay': 'classic' }"
       [displayMode]="'expanded'"
-      [enableOutsideClick]="true"
       [filterable]="true"
       [pinSections]="true"
       (appMenuTriggerClick)="toggleModuleNavDisplayMode()"


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added new types that go with https://github.com/infor-design/enterprise/pull/7983
Also fixed a bug that the expandable card didnt work.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/pull/7983

**Steps necessary to review your pull request (required)**:
- take branch https://github.com/infor-design/enterprise/pull/7983 and build and copy to node_modules/ids-enterprise (or npm link)
- run the page `npm run build:lib && npm run start`
- go to http://localhost:4200/ids-enterprise-ng-demo/ and test the mobile behavior of expand and collapse is the same as https://github.com/infor-design/enterprise/pull/7983
- test that http://localhost:4200/ids-enterprise-ng-demo/cards-expandable works again and you can click it to expand collapse