### PR TITLE
1540 - datepicker component states

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## 16.8.0
+
+### 16.8.0 Fixes
+
+- `[Datepicker]` Fixed readonly state when called from disabled method. ([#1540](https://github.com/infor-design/enterprise-ng/issues/1540))
+
 ## 16.7.0
 
 ### 16.7.0 Fixes

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -386,6 +386,7 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
     if (value) {
       this.ngZone.runOutsideAngular(() => {
         this.datepicker?.disable();
+        this.isReadOnly = true;
       });
     } else {
       this.ngZone.runOutsideAngular(() => {
@@ -557,8 +558,8 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
     if (this._validation) {
       // @ts-ignore
       Soho.Validation.rules[this._validation.validator.id] = this._validation.validator;
-      this.datepicker?.element.attr({'data-validate': this._validation.validator.id})
-      this.datepicker?.element.attr({'data-validation-events': {[this._validation.validator.id]: this._validation.validatorEvents}});
+      this.datepicker?.element.attr({ 'data-validate': this._validation.validator.id })
+      this.datepicker?.element.attr({ 'data-validation-events': { [this._validation.validator.id]: this._validation.validatorEvents } });
     }
 
     if (this.runUpdatedOnCheck) {

--- a/src/app/datepicker/datepicker.demo.html
+++ b/src/app/datepicker/datepicker.demo.html
@@ -10,6 +10,7 @@
         <input soho-datepicker name="statechangerange" dateFormat="MM/dd/yyyy" mode="standard" placeholder="MM/dd/yyyy" [range]="rangeOptions" [(ngModel)]="model.range2" (change)="onChange($event)" class="input-mm" #rangedate/>
       </div>
       <div>
+        <button soho-button (click)="getStates()">Get States</button>
         <button soho-button [disabled]="datepickerReadOnly" (click)="setReadonly()">Read Only</button>
         <button soho-button [disabled]="datepickerDisabled" (click)="setDisable()">Disable</button>
         <button soho-button [disabled]="!datepickerDisabled && !datepickerReadOnly" (click)="setEnable()">Enable</button>

--- a/src/app/datepicker/datepicker.demo.ts
+++ b/src/app/datepicker/datepicker.demo.ts
@@ -86,18 +86,18 @@ export class DatepickerDemoComponent implements OnInit {
   };
 
   public customValidator: SohoDatePickerValidator = {
-       validator: {
-         check: (value: any, field: any, grid: any) => {
-           if (value == "") {
-             return true;
-           }
-           return new Date(value) > new Date();
-         },
-         id: 'myCustomValidator',
-         type: 'error',
-         message: 'My Custom Error Message!',
-       },
-       validatorEvents: 'change blur enter'
+    validator: {
+      check: (value: any, field: any, grid: any) => {
+        if (value == "") {
+          return true;
+        }
+        return new Date(value) > new Date();
+      },
+      id: 'myCustomValidator',
+      type: 'error',
+      message: 'My Custom Error Message!',
+    },
+    validatorEvents: 'change blur enter'
   };
 
   public legend$ = this.legendSubject.asObservable().pipe(
@@ -151,6 +151,11 @@ export class DatepickerDemoComponent implements OnInit {
     (this.datepicker as any).disabled = true;
     (this.rdatepicker as any).disabled = true;
     this.datepickerDisabled = (this.datepicker as any).disabled;
+  }
+
+  getStates() {
+    console.log("readonly", (this.datepicker as any).readonly);
+    console.log("disabled", (this.datepicker as any).disabled);
   }
 
   setReadonly() {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix readonly state when called from disabled method.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1540

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/datepicker
- Open `Developer Console`
- Click the `Read Only` and `Disable` button
- Click the `Get States` button
- See the states on the console
- Click the `Enable` button
- Click the `Get States` button
- See the states on the console

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

