### PR TITLE
1559 - Added fixes for containment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### 16.7.0 Fixes
 
 - `[Modal]` Added type for icons. ([#1544](https://github.com/infor-design/enterprise-ng/issues/1544))
-- `[ModuleNav]` Added `listcontextmenu` event ([#7822](https://github.com/infor-design/enterprise/issues/7822))
+- `[ModuleNav]` Added `listcontextmenu` event. ([#7822](https://github.com/infor-design/enterprise/issues/7822))
+- `[ModuleNav]` Changed targeting of `soho-accordion`` display rules. ([#1559](https://github.com/infor-design/enterprise-ng/issues/1559))
 
 ## 16.6.0
 

--- a/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.css
+++ b/projects/ids-enterprise-ng/src/lib/accordion/soho-accordion.component.css
@@ -1,3 +1,4 @@
-:host {
+/* Needed for scrolling to work when contained in soho-module-nav */
+.module-nav-bar :host {
   display: contents;
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Changed the display rule to target the module nav.

**Related github/jira issue (required)**:
Fixes [#1553 ](https://github.com/infor-design/enterprise-ng/issues/1559)

**Steps necessary to review your pull request (required)**:
- `npm run build:lib && npm run start`
- go to http://localhost:4200/ids-enterprise-ng-demo/accordion
- expand the module nav and make sure it scrolls ok
- inspect the don on soho-accordion (not in module nav) and ensure it does not have `display: contents`
