### PR TITLE
1540 - Timepicker Disable states

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+
+## 16.10.0
+
+### 16.10.0 Fixes
+- `[TimePicker]` Fix timepicker to allow icon button to be clickable after re-enabling
+
 ## 16.9.0
 
 ### 16.9.0 Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## 16.10.0
 
 ### 16.10.0 Fixes
-- `[TimePicker]` Fix timepicker to allow icon button to be clickable after re-enabling ([#1567] (https://github.com/infor-design/enterprise-ng/issues/1567))
+- `[TimePicker]` Fix timepicker to allow icon button to be clickable after re-enabling ([#1567](https://github.com/infor-design/enterprise-ng/issues/1567))
 
 ## 16.9.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,10 @@
 # What's New with Enterprise-NG
 
-
 ## 16.10.0
 
 ### 16.10.0 Fixes
-- `[TimePicker]` Fix timepicker to allow icon button to be clickable after re-enabling ([#1567](https://github.com/infor-design/enterprise-ng/issues/1567))
+
+- `[TimePicker]` Fix timepicker to allow icon button to be clickable after reenabling ([#1567](https://github.com/infor-design/enterprise-ng/issues/1567))
 
 ## 16.9.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## 16.10.0
 
 ### 16.10.0 Fixes
-- `[TimePicker]` Fix timepicker to allow icon button to be clickable after re-enabling
+- `[TimePicker]` Fix timepicker to allow icon button to be clickable after re-enabling ([#1567] (https://github.com/infor-design/enterprise-ng/issues/1567))
 
 ## 16.9.0
 

--- a/projects/ids-enterprise-ng/src/lib/timepicker/soho-timepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/timepicker/soho-timepicker.component.ts
@@ -172,6 +172,7 @@ export class SohoTimePickerComponent extends BaseControlValueAccessor<any> imple
     } else {
       this.ngZone.runOutsideAngular(() => {
         (this.timepicker as any).enable();
+        (this.timepicker as any).trigger.prop('disabled', false);
         this.isReadOnly = false;
       });
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed timepicker disable state where the clock button cannot be reenabled

**Related github/jira issue (required)**:

Closes #1567 

**Steps necessary to review your pull request (required)**:

1. go to http://localhost:4200/ids-enterprise-ng-demo/timepicker
2. disable and re-enable the timepicker
3. click on the clock icon button to double check that it's still clickable
