### PR TITLE
Added hidden tag to Soho Wizard Button Bar

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-buttonbar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-buttonbar.component.ts
@@ -23,21 +23,21 @@ import { SohoWizardComponent } from './soho-wizard.component';
         <ng-container *ngFor="let button of buttons" >
           <button *ngIf="button.position==='left'"
             [soho-button]="button?.type" [icon]="button?.icon" [id]='button?.id' [disabled]="button?.disabled()"
-            (click)='button?.click()'>{{button?.text}}</button>
+            [hidden]="button?.hidden()" (click)='button?.click()'>{{button?.text}}</button>
         </ng-container>
       </div>
       <div class="middle">
       <ng-container *ngFor="let button of buttons" >
         <button *ngIf="button.position==='middle'"
           [soho-button]="button?.type" [icon]="button?.icon" [id]='button?.id' [disabled]="button?.disabled()"
-          (click)='button?.click()'>{{button?.text}}</button>
+          [hidden]="button?.hidden()" (click)='button?.click()'>{{button?.text}}</button>
       </ng-container>
       </div>
       <div class="right">
         <ng-container *ngFor="let button of buttons" >
           <button *ngIf="button.position==='right'"
             [soho-button]="button?.type" [icon]="button?.icon" [id]='button?.id' [disabled]="button?.disabled()"
-            (click)='button?.click()'>{{button?.text}}</button>
+            [hidden]="button?.hidden()" (click)='button?.click()'>{{button?.text}}</button>
         </ng-container>
         <ng-content></ng-content>
       </div>
@@ -81,6 +81,7 @@ export class SohoWizardButtonbarComponent {
       text: Soho.Locale.translate('Previous'),
       click: () => this.wizard.previous(),
       disabled: () => !this.wizard.hasPrevious(),
+      hidden: () => false,
       position: 'middle'
     },
     {
@@ -90,6 +91,7 @@ export class SohoWizardButtonbarComponent {
         this.wizard.next();
       },
       disabled: () => !this.wizard.hasNext(),
+      hidden: () => false,
       isDefault: true,
       position: 'middle'
     },
@@ -100,6 +102,7 @@ export class SohoWizardButtonbarComponent {
         this.wizard.finish();
       },
       disabled: () => this.wizard.hasFinished(),
+      hidden: () => false,
       position: 'right'
     }];
 

--- a/src/app/wizard/wizard.demo.ts
+++ b/src/app/wizard/wizard.demo.ts
@@ -18,6 +18,7 @@ export class WizardDemoComponent {
       text: Soho.Locale.translate('Previous'),
       click: () => this.wizard.previous(),
       disabled: () => !this.wizard.hasPrevious(),
+      hidden: () => false,
       position: 'middle'
     },
     {
@@ -26,6 +27,7 @@ export class WizardDemoComponent {
       click: () => this.wizard.next(),
       isDefault: true,
       disabled: () => this.nextButtonDisabled(),
+      hidden: () => false,
       position: 'middle'
     },
     {
@@ -33,6 +35,7 @@ export class WizardDemoComponent {
       text: 'Finish', // Soho.Locale.translate('Finish'),
       click: () => this.wizard.finish(),
       disabled: () => !this.wizard.hasFinished(),
+      hidden: () => false,
       position: 'middle'
     }
   ];
@@ -50,7 +53,7 @@ export class WizardDemoComponent {
   }
 
   nextButtonDisabled() {
-    return this.wizard.currentTickId === 'confirmation';
+    return this.wizard.currentTickId === 'result';
   }
 
   onBeforeActivated(e: Event) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added the hidden property to the buttons part of the Soho-Wizard-Buttonbar to allow buttons to be hidden when required.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1583

**Steps necessary to review your pull request (required)**:

1. go to http://localhost:4200/ids-enterprise-ng-demo/wizard
2. You should be able to see the "Previous", "Next" and "Finish" buttons.
3. This fix will allow (if the hidden value is set to true), for example, to hide the "Finish" button till the user gets to the the "Result" page (if required). Gives the ability to use either disabled or hidden.
