### PR TITLE
Add SohoWizardButtonBarButton typings and optional settings

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-buttonbar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-buttonbar.component.ts
@@ -6,7 +6,7 @@ import {
   Input,
 } from '@angular/core';
 
-import { SohoWizardComponent } from './soho-wizard.component';
+import {SohoWizardComponent} from './soho-wizard.component';
 
 /**
  * Angular wrapper for the soho wizard buttonbar.
@@ -23,21 +23,21 @@ import { SohoWizardComponent } from './soho-wizard.component';
         <ng-container *ngFor="let button of buttons" >
           <button *ngIf="button.position==='left'"
             [soho-button]="button?.type" [icon]="button?.icon" [id]='button?.id' [disabled]="button?.disabled()"
-            [hidden]="button?.hidden()" (click)='button?.click()'>{{button?.text}}</button>
+            [hidden]="button?.hidden?.()" (click)='button?.click?.()'>{{button?.text}}</button>
         </ng-container>
       </div>
       <div class="middle">
       <ng-container *ngFor="let button of buttons" >
         <button *ngIf="button.position==='middle'"
-          [soho-button]="button?.type" [icon]="button?.icon" [id]='button?.id' [disabled]="button?.disabled()"
-          [hidden]="button?.hidden()" (click)='button?.click()'>{{button?.text}}</button>
+          [soho-button]="button?.type" [icon]="button?.icon" [id]='button?.id' [disabled]="button?.disabled?.()"
+          [hidden]="button?.hidden?.()" (click)='button?.click?.()'>{{button?.text}}</button>
       </ng-container>
       </div>
       <div class="right">
         <ng-container *ngFor="let button of buttons" >
           <button *ngIf="button.position==='right'"
-            [soho-button]="button?.type" [icon]="button?.icon" [id]='button?.id' [disabled]="button?.disabled()"
-            [hidden]="button?.hidden()" (click)='button?.click()'>{{button?.text}}</button>
+            [soho-button]="button?.type" [icon]="button?.icon" [id]='button?.id' [disabled]="button?.disabled?.()"
+            [hidden]="button?.hidden?.()" (click)='button?.click?.()'>{{button?.text}}</button>
         </ng-container>
         <ng-content></ng-content>
       </div>
@@ -73,15 +73,13 @@ import { SohoWizardComponent } from './soho-wizard.component';
 })
 export class SohoWizardButtonbarComponent {
 
-  // @todo need types for these button, these seem to be different from SohoButtonOptions
   @Input()
-  public buttons: any[] = [
+  public buttons: SohoWizardButtonBarButton[] = [
     {
       id: 'previous',
       text: Soho.Locale.translate('Previous'),
       click: () => this.wizard.previous(),
       disabled: () => !this.wizard.hasPrevious(),
-      hidden: () => false,
       position: 'middle'
     },
     {
@@ -102,7 +100,6 @@ export class SohoWizardButtonbarComponent {
         this.wizard.finish();
       },
       disabled: () => this.wizard.hasFinished(),
-      hidden: () => false,
       position: 'right'
     }];
 

--- a/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-header.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/wizard/soho-wizard-header.component.ts
@@ -27,9 +27,6 @@ import { SohoWizardTickComponent } from './soho-wizard-tick.component';
 export class SohoWizardHeaderComponent {
   /**
    * List of ticks in the control.
-   *
-   *
-   *
    */
   @ContentChildren(SohoWizardTickComponent) steps?: QueryList<SohoWizardTickComponent>;
 

--- a/projects/ids-enterprise-typings/lib/wizard/soho-wizard.d.ts
+++ b/projects/ids-enterprise-typings/lib/wizard/soho-wizard.d.ts
@@ -5,11 +5,39 @@
  * interface of the Soho jQuery wizard control.
  */
 
- /**
-  * Soho Widget model for a tick
-  */
- interface SohoWizardTick {
+/**
+ * Soho ButtonBar button definition
+ */
+interface SohoWizardButtonBarButton {
+  /** the button's unique element id */
+  id: string, // e.g. 'next',
 
+  /** the button's text */
+  text: string, // Soho.Locale.translate('Next'),
+
+  /** the button's icon */
+  icon?: string, // the name of the icon to use
+
+  /** the click callback for the button */
+  click: () => void,
+
+  /** an optional disable callback, return true if the button is disabled */
+  disabled?: () => boolean,
+
+  /** an optional hidden callback, return true if the button is hidden */
+  hidden?: () => boolean,
+
+  /** an optional isDefault flag, true if the button is displayed as the default */
+  isDefault?: boolean, // defaults to false
+
+  /** the relative position of the button */
+  position?: string
+}
+
+/**
+ * Soho Widget model for a tick
+ */
+interface SohoWizardTick {
   /**
    * Sets the ng-click event for AngularJS.
    *
@@ -35,7 +63,7 @@
    *
    */
   label?: string;
- }
+}
 
 /**
  * Wizard options.
@@ -43,9 +71,6 @@
 interface SohoWizardOptions {
   /**
    * Optional model driven list of ticks to display.
-   *
-   *
-   *
    */
   ticks?: SohoWizardTick[];
 }

--- a/src/app/wizard/wizard.demo.ts
+++ b/src/app/wizard/wizard.demo.ts
@@ -3,14 +3,14 @@ import {
   ViewChild,
 } from '@angular/core';
 
-import { SohoWizardComponent } from 'ids-enterprise-ng';
+import {SohoWizardComponent} from 'ids-enterprise-ng';
 
 @Component({
   selector: 'demo-wizard-demo',
   templateUrl: 'wizard.demo.html',
 })
 export class WizardDemoComponent {
-  @ViewChild(SohoWizardComponent, { static: true }) wizard!: SohoWizardComponent;
+  @ViewChild(SohoWizardComponent, {static: true}) wizard!: SohoWizardComponent;
 
   public buttons = [
     {
@@ -18,7 +18,7 @@ export class WizardDemoComponent {
       text: Soho.Locale.translate('Previous'),
       click: () => this.wizard.previous(),
       disabled: () => !this.wizard.hasPrevious(),
-      hidden: () => false,
+      // hidden: () => false,
       position: 'middle'
     },
     {
@@ -27,7 +27,6 @@ export class WizardDemoComponent {
       click: () => this.wizard.next(),
       isDefault: true,
       disabled: () => this.nextButtonDisabled(),
-      hidden: () => false,
       position: 'middle'
     },
     {
@@ -37,6 +36,13 @@ export class WizardDemoComponent {
       disabled: () => !this.wizard.hasFinished(),
       hidden: () => false,
       position: 'middle'
+    },
+    {
+      id: 'hidden',
+      text: 'Hidden', // Soho.Locale.translate('Finish'),
+      disabled: () => !this.wizard.hasFinished(),
+      hidden: () => true,
+      position: 'right'
     }
   ];
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added SohoWizardButtonBarButton typings.

Made settings optional for click, disabled and hidden.

```typescript
/**
 * Soho ButtonBar button definition
 */
interface SohoWizardButtonBarButton {
  /** the button's unique element id */
  id: string, // e.g. 'next',

  /** the button's text */
  text: string, // Soho.Locale.translate('Next'),

  /** the button's icon */
  icon?: string, // the name of the icon to use

  /** the click callback for the button */
  click: () => void,

  /** an optional disable callback, return true if the button is disabled */
  disabled?: () => boolean,

  /** an optional hidden callback, return true if the button is hidden */
  hidden?: () => boolean,

  /** an optional isDefault flag, true if the button is displayed as the default */
  isDefault?: boolean, // defaults to false

  /** the relative position of the button */
  position?: string
}
```
(the position could be "left" | "middle" | "right" | undefined?)

**Related github/jira issue (required)**:

Closes #1598

**Steps necessary to review your pull request (required)**:

```powershell
npm run build
npm run start
```

Navigate to the wizard demo and check the wizard displays and navigates