### PR TITLE
1554 - Update pager's dataset through the settings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 17.3.0 Fixes
 
 - `[BusyIndicator]` Added optional settings in the updated method. ([#1602](https://github.com/infor-design/enterprise-ng/issues/1602))
+- `[Pager]` Fixed dataset not updated correctly. ([#1554](https://github.com/infor-design/enterprise-ng/issues/1554))
 
 ## 17.1.0
 

--- a/projects/ids-enterprise-ng/src/lib/pager/soho-standalone-pager.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/pager/soho-standalone-pager.component.ts
@@ -21,6 +21,9 @@ export class SohoStandalonePagerComponent implements AfterViewInit, AfterViewChe
 
   @Input() set dataset(dataset: any[]) {
     this.options.dataset = dataset;
+    if (this.pager) {
+      this.pager.settings.dataset = dataset;
+    }
     this.updateRequired = !!this.pager;
   }
 

--- a/src/app/pager/pager-standalone.demo.html
+++ b/src/app/pager/pager-standalone.demo.html
@@ -97,7 +97,7 @@
     <div class="twelve columns">
       <hr>
       <button soho-button (click)="toggleModel()">{{showModel ? 'Hide' : 'Show'}} Model</button>
-      <button soho-button="primary" (click)="changeDataset()">Change dataset</button>
+      <button soho-button="primary" (click)="changeDataset()">Change Dataset</button>
       <h3 *ngIf="showModel">
         <pre>{{ model | json }}</pre>
       </h3>

--- a/src/app/pager/pager-standalone.demo.html
+++ b/src/app/pager/pager-standalone.demo.html
@@ -97,6 +97,7 @@
     <div class="twelve columns">
       <hr>
       <button soho-button (click)="toggleModel()">{{showModel ? 'Hide' : 'Show'}} Model</button>
+      <button soho-button="primary" (click)="changeDataset()">Change dataset</button>
       <h3 *ngIf="showModel">
         <pre>{{ model | json }}</pre>
       </h3>

--- a/src/app/pager/pager-standalone.demo.ts
+++ b/src/app/pager/pager-standalone.demo.ts
@@ -35,7 +35,7 @@ export class PagerStandaloneDemoComponent {
     pageSizes: [5, 10, 15, 20],
   };
 
-  model_new = {
+  modelNew = {
     dataset: PAGING_DATA.slice(80),
     hideFirstButton: false,
     hidePreviousButton: false,
@@ -84,6 +84,6 @@ export class PagerStandaloneDemoComponent {
   }
 
   changeDataset() {
-    this.model = this.model_new;
+    this.model = this.modelNew;
   }
 }

--- a/src/app/pager/pager-standalone.demo.ts
+++ b/src/app/pager/pager-standalone.demo.ts
@@ -35,6 +35,28 @@ export class PagerStandaloneDemoComponent {
     pageSizes: [5, 10, 15, 20],
   };
 
+  model_new = {
+    dataset: PAGING_DATA.slice(80),
+    hideFirstButton: false,
+    hidePreviousButton: false,
+    hideNextButton: false,
+    hideLastButton: false,
+    disableFirstButton: false,
+    disableLastButton: false,
+    disablePreviousButton: false,
+    disableNextButton: false,
+    firstPageTooltip: 'click to got to the first page of records',
+    lastPageTooltip: 'click to got to the last page of records',
+    previousPageTooltip: 'click to got to the previous page of records',
+    nextPageTooltip: 'click to got to the last page of records',
+    hidePageSelectorInput: false,
+    hidePageSizeSelector: false,
+    useSmallPageSizeSelector: false,
+    pageSizeMenuSettings: { attachToBody: false },
+    pageSize: 10,
+    pageSizes: [5, 10, 15, 20],
+  };
+
   showModel = false;
 
   onFirstPage(_: any) {
@@ -59,5 +81,9 @@ export class PagerStandaloneDemoComponent {
 
   toggleModel() {
     this.showModel = !this.showModel;
+  }
+
+  changeDataset() {
+    this.model = this.model_new;
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Update pager's settings dataset in the component's dataset setter

**Related github/jira issue (required)**:
Closes #1554 

**Steps necessary to review your pull request (required)**:
- pull this branch, build and run the app
- go to http://localhost:4200/ids-enterprise-ng-demo/pager-standalone
- click Show Modal button and check the dataset
- click Change dataset button
- see the dataset has been changed and pager has been updated
