### PR TITLE
1578 - Tabs Vetoable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## 17.6.0
+
+## 17.6.0 Fixes
+
+- `[Tabs]` Fixed `beforeactivated` event not cancelling activation of tabs properly. ([#1578](https://github.com/infor-design/enterprise-ng/issues/1578))
+
 ## 17.5.0
 
 ## 17.5.0 Fixes

--- a/src/app/tabs/tabs-basic.demo.html
+++ b/src/app/tabs/tabs-basic.demo.html
@@ -1,14 +1,28 @@
 <div class="row">
   <div class="twelve columns">
 
+    <h2 class="fieldset-title">Tabs Example: "beforeactivated, activated and afteractivated" Event</h2>
+
+    <p>Provides a visual example of the Tabs "beforeactivated, activated and afteractivated" event and its firing timing.</p>
+
+    <p><strong>Vetoed Tabs: Opportunities and Notes</strong></p>
+
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
     <div soho-tabs
-         registerForEvents="activated"
+         registerForEvents="beforeActivated activated afterActivated"
+         (beforeActivated)="onBeforeTabActivated($event)"
          (activated)="onTabActivated($event)"
+         (afterActivated)="onAfterTabActivated($event)"
     >
       <div soho-tab-list-container>
         <ul soho-tab-list>
           <li soho-tab><a soho-tab-title tabId="tabs-normal-contracts">Contracts</a></li>
-          <li soho-tab><a soho-tab-title tabId="tabs-normal-opportunities">Opportunites</a></li>
+          <li soho-tab><a soho-tab-title tabId="tabs-normal-opportunities">Opportunities</a></li>
           <li soho-tab selected="true"><a soho-tab-title tabId="tabs-normal-attachments">Attachments</a></li>
           <li soho-tab><a soho-tab-title tabId="tabs-normal-contacts">Contacts</a></li>
           <li soho-tab><a soho-tab-title tabId="tabs-normal-notes">Notes</a></li>
@@ -18,9 +32,11 @@
 
     <div soho-tab-panel-container>
       <div soho-tab-panel tabId="tabs-normal-contracts">
+        <p>Contracts</p>
         <p>Facilitate cultivate monetize, seize e-services peer-to-peer content integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower relationships, solutions, metrics architectures.</p>
       </div>
       <div soho-tab-panel tabId="tabs-normal-opportunities">
+        <p>Opportunities</p>
         <p>Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.</p>
         <div class="field">
           <label class="required" for="text-normal-opportunities">Text</label>
@@ -32,9 +48,11 @@
         </div>
       </div>
       <div soho-tab-panel tabId="tabs-normal-attachments">
+        <p>Attachments</p>
         <p>Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive: granular morph.</p>
       </div>
       <div soho-tab-panel tabId="tabs-normal-contacts">
+        <p>Contacts</p>
         <p>Exploit niches; enable A-list web-enabled holistic end-to-end. Exploit experiences value-added tagclouds, open-source cross-platform e-tailers, user-contributed, implement! Convergence, solutions front-end, "synergize markets initiatives integrateAJAX-enabled platforms; wireless, supply-chains reinvent, mindshare, synergies implement, drive evolve!" Post incentivize; rich-clientAPIs customized revolutionize 24/365 killer incentivize integrate intuitive utilize!</p>
         <br>
         <div class="field">
@@ -51,6 +69,7 @@
         </div>
       </div>
       <div soho-tab-panel tabId="tabs-normal-notes">
+        <p>Notes</p>
         <p> Post incentivize; rich-clientAPIs customized revolutionize 24/365 killer incentivize integrate intuitive utilize!</p>
         <div class="field">
           <label class="required" for="name-normal-notes">Name</label>

--- a/src/app/tabs/tabs-basic.demo.ts
+++ b/src/app/tabs/tabs-basic.demo.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { SohoToastService } from 'ids-enterprise-ng';
 
 /**
  * This example:
@@ -9,7 +10,40 @@ import { Component } from '@angular/core';
   templateUrl: 'tabs-basic.demo.html',
 })
 export class TabsBasicDemoComponent {
+  constructor(private toastService: SohoToastService) { }
+
+  private title: any = '';
+  private message: any = '';
+
+  showToast(type: any, anchorId: any, anchorName: any, isVeto: boolean = false, position: SohoToastPosition = SohoToastService.TOP_RIGHT,) {
+    this.message = 'The "<b>' + anchorName + '</b>" tab was clicked or triggered!';
+    this.title = 'tab <span style="color:#aa1111; font-weight: bold;">' + anchorId + '</span> [' + type + '] triggered!';
+    if (isVeto) {
+      this.message = 'The "<b>' + anchorName + '</b>" tab was blocked!';
+      this.title = 'tab <span style="color:#aa1111; font-weight: bold;">' + anchorId + '</span> [' + type + '] blocked!';
+    }
+
+    this.toastService.show({ title: this.title, message: this.message, position });
+  }
+
+  onBeforeTabActivated(event: any) {
+    console.log(event.tab + ' TabsBasicDemoComponent.onBeforeTabActivated');
+    if (event.tab.innerText === 'Opportunities' || event.tab.innerText === 'Notes') {
+      this.showToast(event.type, event.tab.attributes[3].value, event.tab.innerText, true);
+      event.result = false;
+      return false;
+    }
+
+    this.showToast(event.type, event.tab.attributes[3].value, event.tab.innerText);
+  }
+
   onTabActivated(event: any) {
     console.log(event.tab + ' TabsBasicDemoComponent.onTabActivated');
+    this.showToast(event.type, event.tab.attributes[3].value, event.tab.innerText);
+  }
+
+  onAfterTabActivated(event: any) {
+    console.log(event.tab + ' TabsBasicDemoComponent.onAfterTabActivated');
+    this.showToast(event.type, event.tab.attributes[3].value, event.tab.innerText);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix `beforeactivated` event not cancelling activation of tabs properly.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1578

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/tabs-basic
- The vetoable tabs are `Opportunities` and `Notes`
- Try to click these two, it should block tab activation

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

