### PR TITLE
EP8416 - Added placeholder setting for lookup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 17.6.0
 
+## 17.6.0 Features
+
+- `[Lookup]` Added `placeholder` setting for filter searchfield. ([#8416](https://github.com/infor-design/enterprise/issues/8416))
+
 ## 17.6.0 Fixes
 
 - `[Tabs]` Fixed `beforeactivated` event not cancelling activation of tabs properly. ([#1578](https://github.com/infor-design/enterprise-ng/issues/1578))

--- a/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/lookup/soho-lookup.component.ts
@@ -346,6 +346,8 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
     return this.settings.allowDuplicates;
   }
 
+  @Input() toolbarPlaceholder?: string;
+
   @Input() multiselect = false;
 
   @Input() name?: string;
@@ -353,7 +355,7 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
   // Make sure you bind the context to the function
   @Input() source?: SohoDataGridSourceFunction;
 
-  @Input() toolbar: any;
+  @Input() toolbar?: SohoToolbarOptions;
 
   // Autocomplete template settings
   @Input() autoCompleteSettings?: SohoLookupAutoComplete;
@@ -483,21 +485,27 @@ export class SohoLookupComponent extends BaseControlValueAccessor<any> implement
       // The default options for the data grid, which will
       // be overriden by the options provided by the caller
       // on a field by field basis.
+      const toolbarOptions: SohoToolbarOptions = Object.assign({
+        actions: true,
+        advancedFilter: false,
+        dateFilter: false,
+        fullWidth: true,
+        keywordFilter: true,
+        results: true,
+        rowHeight: true,
+        views: false,
+      }, this.toolbar)
+
+      if (this.toolbarPlaceholder) {
+        toolbarOptions.placeholder = this.toolbarPlaceholder;
+      }
+
       const datagridConfig: SohoDataGridOptions = {
         cellNavigation: false,
         columns: this.columns,
         dataset: dataSet,
         selectable: this.isMultiselect() ? 'multiple' : 'single',
-        toolbar: Object.assign({
-          actions: true,
-          advancedFilter: false,
-          dateFilter: false,
-          fullWidth: true,
-          keywordFilter: true,
-          results: true,
-          rowHeight: true,
-          views: false,
-        }, this.toolbar),
+        toolbar: toolbarOptions,
         source: this.source
       };
 

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -160,7 +160,7 @@ interface SohoDataGridOptions {
   clickToSelect?: boolean;
 
   /** Toolbar options. */
-  toolbar?: boolean | SohoToolbarOptions;
+  toolbar?: SohoToolbarOptions;
 
   /** Can set to false if you will initialize the toolbar yourself. */
   initializeToolbar?: boolean;
@@ -1488,27 +1488,6 @@ interface SohoDataGridSettingsChangedEvent {
 interface SohoDataGridToolbarFilterRowOptions {
   showFilter?: boolean;
   clearFilter?: boolean;
-}
-
-/**
- * Move to toolbar!
- */
-interface SohoToolbarOptions {
-  actions?: any | any[];
-  advancedFilter?: boolean;
-  collapsibleFilter?: boolean;
-  dateFilter?: boolean;
-  filterRow?: boolean | SohoDataGridToolbarFilterRowOptions;
-  keywordFilter?: boolean;
-  personalize?: boolean;
-  results?: boolean;
-  rowHeight?: boolean;
-  title?: string;
-  views?: boolean;
-  resetLayout?: boolean;
-  exportToExcel?: boolean;
-  fullWidth?: boolean;
-  contextualToolbar?: boolean;
 }
 
 /**

--- a/projects/ids-enterprise-typings/lib/toolbar/soho-toolbar.d.ts
+++ b/projects/ids-enterprise-typings/lib/toolbar/soho-toolbar.d.ts
@@ -9,6 +9,41 @@
  * Toolbar options.
  */
 interface SohoToolbarOptions {
+  actions?: any | any[];
+
+  advancedFilter?: boolean;
+
+  collapsibleFilter?: boolean;
+
+  dateFilter?: boolean;
+
+  filterRow?: boolean | SohoDataGridToolbarFilterRowOptions;
+
+  keywordFilter?: boolean;
+
+  personalize?: boolean;
+
+  results?: boolean;
+
+  rowHeight?: boolean;
+
+  title?: string;
+
+  views?: boolean;
+
+  resetLayout?: boolean;
+
+  exportToExcel?: boolean;
+
+  fullWidth?: boolean;
+
+  contextualToolbar?: boolean;
+
+  /**
+   * Placeholder text for searchfield
+   */
+  placeholder?: string;
+
   /**
    * Does the toolbar include the more button?
    */
@@ -101,7 +136,7 @@ interface SohoToolbarMenuItemEvent extends SohoToolbarButtonEvent {
   event: SohoToolbarButtonEvent;
 }
 
-interface SohoToolbarEvent extends JQuery.TriggeredEvent {}
+interface SohoToolbarEvent extends JQuery.TriggeredEvent { }
 
 /**
  * Configuration options.

--- a/src/app/lookup/lookup.demo.html
+++ b/src/app/lookup/lookup.demo.html
@@ -268,6 +268,21 @@
           />
         </div>
 
+        <div class="field">
+          <label soho-label for="toggle-buttons">Custom Placeholder</label>
+          <input soho-lookup
+                 #toggleButtons
+                 [(ngModel)]="model.single"
+                 [columns]="columns_product"
+                 [dataset]="data_product"
+                 field="productId"
+                 title="Products"
+                 [buttons]="customButtons"
+                 name="toggle-buttons"
+                 toolbarPlaceholder="Enter your keywords here!"
+          />
+        </div>
+
       </div>
       <div class="six columns">
         <div class="field">


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Placeholder setting available for toolbar searchfield filter

NEEDS THIS PR TO WORK: https://github.com/infor-design/enterprise/pull/8554

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
https://github.com/infor-design/enterprise/issues/8416

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch https://github.com/infor-design/enterprise/pull/8554 and build IDS, use this version for NG build
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/lookup
- Open `Custom Placeholder` lookup
- Searchfield should have `Enter your keywords here!` placeholder text

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
