### PR TITLE
1673 - Fix setFocus method to work also when there is no label associated with the dropdown.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 17.7.0 Fixes
 
 - `[Spinbox]` Updated type for step and fixed increase/decrease buttons not getting disabled when value passed with ngControl was matching min/max value. ([EP#1680](https://github.com/infor-design/enterprise-ng/issues/1680))
+- `[Dropdown]` Fix setFocus method to work also when there is no label associated with the dropdown. ([EP#1673](https://github.com/infor-design/enterprise-ng/issues/1673))
 
 ## 17.6.0
 

--- a/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/dropdown/soho-dropdown.component.ts
@@ -718,12 +718,14 @@ export class SohoDropDownComponent implements AfterViewInit, AfterViewChecked, O
    * @description
    *
    * Soho-dropdown is not a native element - need this to set focus programmatically.
-   * 'name' attribute must be set on the control for this to work correctly.
    */
   public setFocus(): void {
-    if (this.jQueryElement) {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement?.blur();
+    }
+    if (this.dropdown) {
       this.ngZone.runOutsideAngular(() => {
-        this.jQueryElement?.trigger('activated');
+        this.dropdown?.activate();
       });
     }
   }

--- a/projects/ids-enterprise-typings/lib/dropdown/soho-dropdown.d.ts
+++ b/projects/ids-enterprise-typings/lib/dropdown/soho-dropdown.d.ts
@@ -268,6 +268,11 @@ interface SohoDropDownStatic {
    * Set the selected option with icon.
    */
   setListIcon(): void;
+
+  /**
+   * Focus the input element. Since the select is hidden this is needed over normal focus()
+   */
+  activate(): void;
 }
 
 /**

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -303,6 +303,7 @@ import { DemoappNavContainerComponent } from './demoapp-nav-container/demoapp-na
 import { DataGridUpdateDatasetDemoComponent } from './datagrid/datagrid-update-dataset.demo';
 import { DataGridVerticalScrollListDemoComponent } from './datagrid/datagrid-vertical-scroll-to-end-list.demo';
 import { DataGridCustomComponent } from './datagrid/datagrid-custom-component.demo';
+import { DropdownFocusComponent } from './dropdown/dropdown-focus';
 
 @NgModule({
   declarations: [
@@ -437,6 +438,7 @@ import { DataGridCustomComponent } from './datagrid/datagrid-custom-component.de
     DropdownAsyncBusyDemoComponent,
     DropdownAsyncDemoComponent,
     DropdownDemoComponent,
+    DropdownFocusComponent,
     DropdownMultiselectDemoComponent,
     DropdownMultiselectLandmarkDemoComponent,
     DropdownReactiveDemoComponent,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -250,6 +250,7 @@ import { DonutColorsDemoComponent } from './donut/donut-colors.demo';
 import { DataGridUpdateDatasetDemoComponent } from './datagrid/datagrid-update-dataset.demo';
 import { DataGridVerticalScrollListDemoComponent } from './datagrid/datagrid-vertical-scroll-to-end-list.demo';
 import { DataGridCustomComponent } from './datagrid/datagrid-custom-component.demo';
+import { DropdownFocusComponent } from './dropdown/dropdown-focus';
 
 export const routes: Routes = [
   { path: '', redirectTo: '', pathMatch: 'full' }, // default
@@ -370,6 +371,7 @@ export const routes: Routes = [
   { path: 'dropdown', component: DropdownDemoComponent },
   { path: 'dropdown-async-busy', component: DropdownAsyncBusyDemoComponent },
   { path: 'dropdown-async', component: DropdownAsyncDemoComponent },
+  { path: 'dropdown-focus', component: DropdownFocusComponent },
   { path: 'dropdown-multi', component: DropdownMultiselectDemoComponent },
   { path: 'dropdown-multi-landmark', component: DropdownMultiselectLandmarkDemoComponent },
   { path: 'dropdown-multi-attributes', component: DropdownMultiselectAttributesDemoComponent },

--- a/src/app/dropdown/dropdown-focus.html
+++ b/src/app/dropdown/dropdown-focus.html
@@ -1,0 +1,70 @@
+<div class="example-section">
+  <div class="row">
+    <div class="twelve columns m-top-10 m-bottom-10">
+        <p>
+            This is an example of programatically focusing dropdown. It also showcases the focusing when another input was focused before.
+            <br>
+            1. In 'Focus dropdown' type either 1, 2 or 3 and click Enter. The entered dropdown should focus.
+            <br>
+            2. Click 'Focus' button next to any dropdown. This dropdown should get focused.
+            <br>
+        </p>
+    </div>
+</div>
+  <form>
+    <div class="field m-left-20">
+      <label for="example-input">Focus dropdown</label>
+      <input soho-input name="example-input" (change)="focus($event.target.value)" />
+    </div>
+
+    <table style="border-spacing: 20px 10px">
+      <tr>
+        <th><label>States</label></th>
+        <th></th>
+      </tr>
+      <tr>
+        <td>
+          <select soho-dropdown noSearch name="states-1" [(ngModel)]="model.one">
+          <option value="AL">Alabama</option>
+          <option value="CA">California</option>
+          <option value="DE" >Delaware</option>
+          <option value="NY">New York</option>
+          <option value="WY">Wyoming</option>
+        </select>
+      </td>
+      <td style="vertical-align: top;">
+        <button soho-button="primary" (click)="focus(1)">Focus</button>
+      </td>
+      </tr>
+      <tr>
+        <td>
+          <select soho-dropdown name="states-2" [(ngModel)]="model.two">
+            <option value="AL">Alabama</option>
+            <option value="CA">California</option>
+            <option value="DE" >Delaware</option>
+            <option value="NY">New York</option>
+            <option value="WY">Wyoming</option>
+          </select>
+        </td>
+        <td style="vertical-align: top;">
+          <button soho-button="primary" (click)="focus(2)">Focus</button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <select soho-dropdown noSearch name="states-3" [(ngModel)]="model.three">
+            <option value="AL">Alabama</option>
+            <option value="CA">California</option>
+            <option value="DE" >Delaware</option>
+            <option value="NY">New York</option>
+            <option value="WY">Wyoming</option>
+          </select>
+        </td>
+        <td  style="vertical-align: top;">
+          <button soho-button="primary" (click)="focus(3)">Focus</button>
+        </td>
+      </tr>
+    </table>
+  </form>
+</div>
+

--- a/src/app/dropdown/dropdown-focus.ts
+++ b/src/app/dropdown/dropdown-focus.ts
@@ -1,0 +1,40 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  QueryList,
+  ViewChildren
+} from '@angular/core';
+// @ts-ignore
+import { SohoDropDownComponent } from 'ids-enterprise-ng';
+
+@Component({
+  selector: 'app-dropdown-focus',
+  templateUrl: 'dropdown-focus.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DropdownFocusComponent {
+  @ViewChildren(SohoDropDownComponent) dropDowns?: QueryList<SohoDropDownComponent>;
+
+  public options: Array<Object> = [
+    { value: 'AL', text: 'Alabama' },
+    { value: 'CA', text: 'California' },
+    { value: 'DE', text: 'Delaware' },
+    { value: 'NY', text: 'New York' },
+    { value: 'WY', text: 'Wyoming' },
+  ];
+  sourceoptions: Array<Object> = [];
+  public counter = 0;
+  public model = {
+    one: '',
+    two: 'AL',
+    three: 'DE'
+  };
+
+
+  focus(index: number) {
+    console.log(`Focus ${index}`);
+    this.dropDowns?.get(index - 1)?.setFocus();
+  }
+
+
+}

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -188,6 +188,7 @@
         <div class="accordion-header"><a [routerLink]="['drag']"><span>Drag</span></a></div>
         <div class="accordion-header"><a [routerLink]="['dropdown-async']"><span>Dropdown - Async</span></a></div>
         <div class="accordion-header"><a [routerLink]="['dropdown-async-busy']"><span>Dropdown - Async Busy</span></a></div>
+        <div class="accordion-header"><a [routerLink]="['dropdown-focus']"><span>Dropdown - Focus</span></a></div>
         <div class="accordion-header"><a [routerLink]="['dropdown-multi']"><span>Dropdown - Multi-Select</span></a></div>
         <div class="accordion-header"><a [routerLink]="['dropdown-multi-landmark']"><span>Dropdown - Multi-Select (Keep Selected)</span></a></div>
         <div class="accordion-header"><a [routerLink]="['dropdown-multi-attributes']"><span>Dropdown - Multi-Select (Attributes)</span></a></div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Dropdown#setFocus now uses activate method instead of triggering 'activated' event which was depending on label being associated with the dropdown. Also document.activeElement is blurred to allow focusing dropdown from already focused input.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1673

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

Pull this branch, build and run the app
Go to: http://localhost:4200/ids-enterprise-ng-demo/dropdown-focus
Follow steps described on the page
<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
