### PR TITLE
1641 - Field Filter Reset Field

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ## 17.7.0 Fixes
 
-- `[Spinbox]` Updated type for step and fixed increase/decrease buttons not getting disabled when value passed with ngControl was matching min/max value. ([EP#1680](https://github.com/infor-design/enterprise-ng/issues/1680))
-- `[Dropdown]` Fix setFocus method to work also when there is no label associated with the dropdown. ([EP#1673](https://github.com/infor-design/enterprise-ng/issues/1673))
+- `[Dropdown]` Fixed setFocus method to work also when there is no label associated with the dropdown. ([#1673](https://github.com/infor-design/enterprise-ng/issues/1673))
+- `[FieldFilter]` Fixed field filter reset method not clearing on NG. ([#1641](https://github.com/infor-design/enterprise-ng/issues/1641))
+- `[Spinbox]` Updated type for step and fixed increase/decrease buttons not getting disabled when value passed with ngControl was matching min/max value. ([#1680](https://github.com/infor-design/enterprise-ng/issues/1680))
 
 ## 17.6.0
 

--- a/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
+++ b/projects/ids-enterprise-ng/src/lib/field-filter/soho-field-filter.directive.ts
@@ -114,7 +114,7 @@ export class SohoFieldFilterDirective implements AfterViewChecked, AfterViewInit
    * param {number|string} value to be set, index or value.
    * returns {void}
    */
-  public setFilterType(value: SohoFieldFilterOperator | number) {
+  public setFilterType(value: SohoFieldFilterOperator | number | string) {
     if (!value) {
       return;
     }

--- a/projects/ids-enterprise-typings/lib/field-filter/soho-field-filter.d.ts
+++ b/projects/ids-enterprise-typings/lib/field-filter/soho-field-filter.d.ts
@@ -46,22 +46,22 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
 
 type SohoFieldFilterOperator =
   'end-with' | 'does-not-end-with' |
- 'start-with' | 'does-not-start-with' |
- 'equals' | 'does-not-equal' |
- 'contains' | 'does-not-contain' |
- 'calendar' | 'in-range' |
- 'is-empty' | 'is-not-empty' |
- 'less-equals' | 'less-than' |
- 'greater-equals' | 'greater-than' |
- 'between' | 'selected-notselected' |
- 'selected' | 'not-selected' |
- 'sort-a-to-z' | 'sort-z-to-a';
+  'start-with' | 'does-not-start-with' |
+  'equals' | 'does-not-equal' |
+  'contains' | 'does-not-contain' |
+  'calendar' | 'in-range' |
+  'is-empty' | 'is-not-empty' |
+  'less-equals' | 'less-than' |
+  'greater-equals' | 'greater-than' |
+  'between' | 'selected-notselected' |
+  'selected' | 'not-selected' |
+  'sort-a-to-z' | 'sort-z-to-a';
 
 interface SohoFieldFilterOption {
   value: SohoFieldFilterOperator;
   text: string;
   icon: string;
-  selected ?: boolean;
+  selected?: boolean;
 }
 
 interface SohoFieldFilteredEvent extends JQuery.TriggeredEvent {

--- a/src/app/field-filter/field-filter.demo.html
+++ b/src/app/field-filter/field-filter.demo.html
@@ -21,6 +21,9 @@
       <p>Value: {{model.text.value}} <br> FilterType: {{model.text.filterType}}</p>
     </div>
 
+    <button soho-button (click)="onResetDefault()">Reset Default</button>
+    <br><br>
+
     <div class="field">
       <label soho-label for="example-dropdown">Dropdown</label>
       <select soho-dropdown soho-field-filter [fieldSettings]="filterSettings" id="example-dropdown" name="example-dropdown" class="input-mm" [(ngModel)]="model.dropdown.value" (filtered)="onFiltered($event)">

--- a/src/app/field-filter/field-filter.demo.ts
+++ b/src/app/field-filter/field-filter.demo.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { SohoFieldFilterDirective } from 'ids-enterprise-ng';
 
 /**
  * This example shows basic field filter functionality on input elements
@@ -8,6 +9,8 @@ import { Component } from '@angular/core';
   templateUrl: 'field-filter.demo.html'
 })
 export class FieldFilterDemoComponent {
+
+  @ViewChild(SohoFieldFilterDirective) sohoFieldFilter?: SohoFieldFilterDirective;
 
   public model = {
     text: {
@@ -38,12 +41,12 @@ export class FieldFilterDemoComponent {
 
   public filterSettings: SohoFieldFilterSettings = {
     dataset: [
-    { value: 'equals', text: 'Equals', icon: 'filter-equals' },
-    { value: 'does-not-equal', text: 'Does Not Equal', icon: 'filter-does-not-equal' },
-    { value: 'less-than', text: 'Less Than', icon: 'filter-less-than' },
-    { value: 'less-equals', text: 'Less Or Equals', icon: 'filter-less-equals', selected: true },
-    { value: 'greater-than', text: 'Greater Than', icon: 'filter-greater-than' },
-    { value: 'greater-equals', text: 'Greater Or Equals', icon: 'filter-greater-equals' }]
+      { value: 'equals', text: 'Equals', icon: 'filter-equals' },
+      { value: 'does-not-equal', text: 'Does Not Equal', icon: 'filter-does-not-equal' },
+      { value: 'less-than', text: 'Less Than', icon: 'filter-less-than' },
+      { value: 'less-equals', text: 'Less Or Equals', icon: 'filter-less-equals', selected: true },
+      { value: 'greater-than', text: 'Greater Than', icon: 'filter-greater-than' },
+      { value: 'greater-equals', text: 'Greater Or Equals', icon: 'filter-greater-equals' }]
   };
 
   public fieldDropdownDataSet = [
@@ -56,21 +59,28 @@ export class FieldFilterDemoComponent {
   ];
 
   public filterOperator = 'equals';
+  public defaultFilterOperator = 'equals';
 
   public filterSettingsWithRange: SohoFieldFilterSettings = {
     dataset: [
-    { value: 'equals', text: 'Equals', icon: 'filter-equals' },
-    { value: 'in-range', text: 'In Range', icon: 'filter-in-range' },
-    { value: 'does-not-equal', text: 'Does Not Equal', icon: 'filter-does-not-equal', selected: true },
-    { value: 'less-than', text: 'Less Than', icon: 'filter-less-than' },
-    { value: 'less-equals', text: 'Less Or Equals', icon: 'filter-less-equals' },
-    { value: 'greater-than', text: 'Greater Than', icon: 'filter-greater-than' },
-    { value: 'greater-equals', text: 'Greater Or Equals', icon: 'filter-greater-equals' }]
+      { value: 'equals', text: 'Equals', icon: 'filter-equals' },
+      { value: 'in-range', text: 'In Range', icon: 'filter-in-range' },
+      { value: 'does-not-equal', text: 'Does Not Equal', icon: 'filter-does-not-equal', selected: true },
+      { value: 'less-than', text: 'Less Than', icon: 'filter-less-than' },
+      { value: 'less-equals', text: 'Less Or Equals', icon: 'filter-less-equals' },
+      { value: 'greater-than', text: 'Greater Than', icon: 'filter-greater-than' },
+      { value: 'greater-equals', text: 'Greater Or Equals', icon: 'filter-greater-equals' }]
   };
 
   public dateMode = 'standard';
 
   constructor() { }
+
+  onResetDefault() {
+    (this.model.text as any).value = '';
+    (this.model.text as any).selectedFilterType = this.defaultFilterOperator;
+    this.sohoFieldFilter?.setFilterType(this.defaultFilterOperator);
+  }
 
   onFiltered(event: SohoFieldFilteredEvent) {
     const targetElement = event.target as Element;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix field filter reset method not clearing on NG.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1641

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4200/ids-enterprise-ng-demo/field-filter
- Change the filter type of `Text Field` to `>`
- Click the `Reset Default`
- It should go back to `=`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

