### PR TITLE
8639 - Add `buttonsetTextWidth` setting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 17.7.0
 
+## 17.7.0 Features
+
+- `[Modal]` Added `buttonsetTextWidth` option to specify width of the buttonset text in the modal. ([EP#8639](https://github.com/infor-design/enterprise/issues/8639))
+
 ## 17.7.0 Fixes
 
 - `[Dropdown]` Fixed setFocus method to work also when there is no label associated with the dropdown. ([#1673](https://github.com/infor-design/enterprise-ng/issues/1673))

--- a/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
@@ -159,6 +159,19 @@ export class SohoModalDialogRef<T> {
   }
 
   /**
+   * Optional width to set the text of the buttonset.
+   * 
+   * @param buttonsetTextWidth - The width of buttonset text.
+   */
+  buttonsetTextWidth(buttonsetTextWidth: number | string): SohoModalDialogRef<T> {
+    this._options.buttonsetTextWidth = buttonsetTextWidth;
+    if (this.modal) {
+      this.modal.settings.buttonsetTextWidth = buttonsetTextWidth;
+    }
+    return this;
+  }
+
+  /**
    * Sets the title of the modal dialog.
    *
    * @param title - the title of the dialog.

--- a/projects/ids-enterprise-typings/lib/modal-dialog/soho-modal-dialog.d.ts
+++ b/projects/ids-enterprise-typings/lib/modal-dialog/soho-modal-dialog.d.ts
@@ -80,6 +80,9 @@ interface SohoModalOptions {
   // The maximum width to show for the modal, regardless of content.
   maxWidth?: number;
 
+  // Optional width to set the text of the buttonset.
+  buttonsetTextWidth?: number | string;
+
   // Force the modal to go full size.
   fullsize?: SohoModalFullSize;
 

--- a/src/app/modal-dialog/modal-dialog.demo.html
+++ b/src/app/modal-dialog/modal-dialog.demo.html
@@ -11,7 +11,10 @@
       <button id="open-dialog-picker-btn" soho-button (click)="openDialogPicker()">Dialog with Picker</button>
     </div>
     <div class="field">
-      <button id="open-dialog-picker-btn" soho-button (click)="openDialogDatepicker()">Dialog with Datepicker</button>
+      <button id="open-modal-buttonset-text" soho-button (click)="openModalButtonsetText()">Modal with buttonset text</button>
+    </div>
+    <div class="field">
+      <button id="open-dialog-picker-btn-1" soho-button (click)="openDialogDatepicker()">Dialog with Datepicker</button>
     </div>
   </div>
 </div>

--- a/src/app/modal-dialog/modal-dialog.demo.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.ts
@@ -279,4 +279,28 @@ export class ModalDialogDemoComponent {
         }])
       .open();
   }
+
+  openModalButtonsetText() {
+    const dialogRef = this.modalService
+      .message('<span class="message">Are you sure you want to delete this page?</span>')
+      .buttons(
+        [
+          {
+            text: 'Click here to explore our comprehensive collection of innovative solutions for optimizing your workflow and boosting productivity.', click: () => {
+              dialogRef.close('CANCEL');
+            }
+          },
+          {
+            text: 'Submit', click: () => {
+              dialogRef.close('SUBMIT');
+            }, isDefault: true
+          }
+        ])
+      .buttonsetTextWidth('auto')
+      .title(this.title)
+      .open()
+      .afterClose((result: any) => {
+        this.closeResult = result;
+      });
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds `buttonsetTextWidth` setting.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/8639

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Need to build the EP dist in EP main and this PR fix as well https://github.com/infor-design/enterprise/pull/8682
- Go to http://localhost:4200/ids-enterprise-ng-demo/modal-dialog
- Open `Modal with buttonset text`
- When you hover on button with long text, it should show tooltip
- Check the element `span` in buttonset. It should have inline width `auto`

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
