### PR TITLE
1677 - Fix on roles not updating

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise-NG
 
+## 18.1.0
+
+## 18.1.0 Fixes
+
+- `[Module Nav]` Fixed roles not being updated when changed before `AfterViewInit`. ([#1686](https://github.com/infor-design/enterprise-ng/issues/1677))
+
 ## 18.0.0
 
 ## 18.0.0 Fixes
@@ -7,7 +13,6 @@
 - `[Card]` Added missing `selected` and `deselected` events. ([#1684](https://github.com/infor-design/enterprise-ng/issues/1684))
 - `[Datepicker]` Fixed readonly state when called from disabled method. ([#1702](https://github.com/infor-design/enterprise-ng/issues/1702))
 - `[Mask]` Fixed placeholder value being duplicated on number input. ([#1686](https://github.com/infor-design/enterprise-ng/issues/1686))
-- `[Module Nav]` Fixed roles not being updated when changed before `AfterViewInit`. ([#1686](https://github.com/infor-design/enterprise-ng/issues/1677))
 - `[Monthview]` Fixed `monthview` not updating after changing activeDate. ([#1659](https://github.com/infor-design/enterprise-ng/issues/1659))
 - `[Monthview]` Fixed monthview not updating after changing activeDate. ([#1659](https://github.com/infor-design/enterprise-ng/issues/1659))
 - `[Popupmenu]` Updated example page to fix multiselect. ([#8623](https://github.com/infor-design/enterprise-ng/issues/8623))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,18 +2,19 @@
 
 ## 18.0.0
 
-## 17.8.0 Notes
-
-- `[General]` Added new dependencies and updated to NG 18. And made dependencies peer dependencies. ([#1705](https://github.com/infor-design/enterprise-ng/issues/1705))
-
 ## 18.0.0 Fixes
 
 - `[Card]` Added missing `selected` and `deselected` events. ([#1684](https://github.com/infor-design/enterprise-ng/issues/1684))
 - `[Datepicker]` Fixed readonly state when called from disabled method. ([#1702](https://github.com/infor-design/enterprise-ng/issues/1702))
 - `[Mask]` Fixed placeholder value being duplicated on number input. ([#1686](https://github.com/infor-design/enterprise-ng/issues/1686))
+- `[Module Nav]` Fixed roles not being updated when changed before `AfterViewInit`. ([#1686](https://github.com/infor-design/enterprise-ng/issues/1677))
 - `[Monthview]` Fixed `monthview` not updating after changing activeDate. ([#1659](https://github.com/infor-design/enterprise-ng/issues/1659))
 - `[Monthview]` Fixed monthview not updating after changing activeDate. ([#1659](https://github.com/infor-design/enterprise-ng/issues/1659))
 - `[Popupmenu]` Updated example page to fix multiselect. ([#8623](https://github.com/infor-design/enterprise-ng/issues/8623))
+
+## 17.8.0 Notes
+
+- `[General]` Added new dependencies and updated to NG 18. And made dependencies peer dependencies. ([#1705](https://github.com/infor-design/enterprise-ng/issues/1705))
 
 ## 17.8.0 Features
 

--- a/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/module-nav-switcher/soho-module-nav-switcher.component.ts
@@ -89,7 +89,6 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
   }
 
   @Input() set noSearch(val: boolean | undefined) {
-    console.log(val);
     this._options.noSearch = val;
     this.updated({ noSearch: this._options.noSearch });
   }
@@ -241,6 +240,10 @@ export class SohoModuleNavSwitcherComponent implements AfterViewInit, AfterViewC
 
       this.jQueryElement.modulenavswitcher(this._options);
       this.modulenavswitcher = this.jQueryElement.data('modulenavswitcher');
+
+      if (this._options.roles) {
+        this.setRoles(this._options.roles);
+      }
 
       // @todo - add event binding control so we don't bind if not required.
       this.jQueryElement

--- a/src/app/module-nav/module-nav.demo.html
+++ b/src/app/module-nav/module-nav.demo.html
@@ -14,6 +14,7 @@
         [generate]="false"
         [changeIconOnSelect]="false"
         [noSearch]="true"
+        [roles]="(Roles$ | async)!"
         (modulebuttonclick)="onModuleButtonClick($event)"
         (rolechange)="onRoleChange($event)"
         (listcontextmenu)="onListContextMenu($event)"></soho-module-nav-switcher>

--- a/src/app/module-nav/module-nav.demo.ts
+++ b/src/app/module-nav/module-nav.demo.ts
@@ -13,6 +13,8 @@ import {
   SohoModuleNavSwitcherComponent,
   SohoModuleNavSettingsComponent
 } from 'ids-enterprise-ng';
+import { Observable } from 'rxjs/internal/Observable';
+import { of } from 'rxjs/internal/observable/of';
 
 const defaultRoles: Array<SohoModuleNavSwitcherRoleRecord> = [
   { text: 'Admin', value: 'admin', icon: 'app-ac' },
@@ -29,24 +31,22 @@ const defaultRoles: Array<SohoModuleNavSwitcherRoleRecord> = [
   templateUrl: 'module-nav.demo.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ModuleNavDemoComponent implements AfterViewInit {
+export class ModuleNavDemoComponent {
   @ViewChild(SohoAccordionComponent) accordion!: SohoAccordionComponent;
   @ViewChild(SohoSearchFieldComponent) searchfield?: SohoSearchFieldComponent;
   @ViewChild(SohoModuleNavSwitcherComponent) moduleNavSwitcher?: SohoModuleNavSwitcherComponent;
   @ViewChild(SohoModuleNavSettingsComponent, { static: true }) moduleNavSettings?: SohoModuleNavSettingsComponent;
-
-
-  /**
-   * Constructor.
-   * @param ngZone - zone access.
-   */
-  constructor(private ngZone: NgZone) { }
+  public Roles$: Observable<Array<SohoModuleNavSwitcherRoleRecord>>;
 
   public searchfieldOptions: SohoSearchFieldOptions = {}
 
-  public model = {
-    selectedRole: 'admin',
-    roles: defaultRoles
+  public model: SohoModuleNavSwitcherOptions = {
+    roles: []
+  }
+
+  public getRoles(val: Array<SohoModuleNavSwitcherRoleRecord>): Observable<Array<SohoModuleNavSwitcherRoleRecord>> {
+    const roles = of(val);
+    return roles;
   }
 
   onRoleChange(e: JQuery.TriggeredEvent) {
@@ -104,10 +104,12 @@ export class ModuleNavDemoComponent implements AfterViewInit {
   // Lifecycle Events
   // ------------------------------------------
 
-  ngAfterViewInit() {
-    this.ngZone.runOutsideAngular(() => {
-      this.moduleNavSwitcher?.setRoles(this.model.roles);
-    });
+  /**
+   * Constructor.
+   * @param ngZone - zone access.
+   */
+  constructor(private ngZone: NgZone) {
+    this.Roles$ = this.getRoles(defaultRoles);
   }
 
   // ------------------------------------------
@@ -117,11 +119,15 @@ export class ModuleNavDemoComponent implements AfterViewInit {
   customRoles: boolean = false;
 
   public resetRoles() {
-    this.model.roles = defaultRoles;
+    this.getRoles(defaultRoles).subscribe(val => {
+      this.model.roles = val;
+    })
   }
 
   public setCustomRoles(val: Array<SohoModuleNavSwitcherRoleRecord>) {
-    this.model.roles = val;
+    this.getRoles(val).subscribe(val => {
+      this.model.roles = val;
+    });
   }
 
   private toggleCustomRoles() {
@@ -148,6 +154,6 @@ export class ModuleNavDemoComponent implements AfterViewInit {
       console.info('Disable custom roles');
       this.resetRoles();
     }
-    this.moduleNavSwitcher?.setRoles(this.model.roles);
+    this.moduleNavSwitcher?.setRoles(this.model.roles ? this.model.roles : []);
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Module nav switcher hasn't been initialized when trying to update roles on the constructor, this is also why the setRoles work on ngAfterViewInit based on the commented out line in stackblitz. Added check on ngAfterViewInit to see if it should call setRoles or not.

Updated nav switcher in NG Demo to use an Observable for roles to test

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1677 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo
- Roles on nav switcher should show

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
