### PR TITLE
1697 - Fix on beforeCloseCallback and updated example page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 18.1.0 Fixes
 
 - `[Module Nav]` Fixed roles not being updated when changed before `AfterViewInit`. ([#1686](https://github.com/infor-design/enterprise-ng/issues/1677))
+- `[Tabs]` Fix on `beforeCloseCallback` and updated example page. ([#1697](https://github.com/infor-design/enterprise-ng/issues/1697))
 
 ## 18.0.0
 

--- a/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/tabs/soho-tabs.component.ts
@@ -930,11 +930,11 @@ export class SohoTabsComponent implements AfterViewInit, AfterViewChecked, OnDes
     this.ngZone.run(() => {
       event.tab = tab[0];
       this.beforeClose.emit(event);
-
-      if (this.beforeCloseCallback) {
-        return this.beforeCloseCallback(event, tab);
-      }
     });
+
+    if (this.beforeCloseCallback) {
+      return this.beforeCloseCallback(event, tab);
+    }
   }
 
   private onClose(event: SohoTabsEvent, tab: any) {

--- a/src/app/tabs/tabs-dismissible.demo.ts
+++ b/src/app/tabs/tabs-dismissible.demo.ts
@@ -6,9 +6,10 @@ import { Component } from '@angular/core';
 })
 export class TabsDismissibleDemoComponent {
   onBeforeClose(_event: any, tab: any) {
-    if ($(tab).children('a').attr('href') === '#tabs-dismissible-ie') {
+    if (tab.attr('href') === '#tabs-dismissible-ie') {
       console.log('can\'t dismiss this tab');
       return false;
     }
+    return true;
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fix on beforeCloseCallback and updated example page. beforeCloseCallback returned undefined if it was in the run outside Angular block. Also the element being passed in the event is already the <a> element, not list item, so there is no need to search for the children (that will also return empty/undefined).

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1697 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/tabs-dismissible
- Tab 3 should not be dismissed when clicking the close icon

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
