### PR TITLE
add .gitlab-ci.yml file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+stages:
+  - build
+  - test
+
+variables:
+  GIT_STRATEGY: fetch
+  GIT_CLEAN_FLAGS: "-xdfq --exclude=dist --exclude=node_modules"
+
+build:
+  stage: build
+  tags:
+    - dsa
+    - DIND
+  image: node:20
+  script:
+    - npm ci
+    - npm run build
+
+test:
+  stage: test
+  tags:
+    - dsa
+    - DIND
+  image: node:20
+  script:
+    - npm run lint
+    - npm run test


### PR DESCRIPTION
@tmcconechy You are getting this error however, like before, we don't have linux runners.

```shell
[0KRunning with gitlab-runner 17.1.0 (fe451d5a)[0;m
[0K  on ids-ios-run-1-ip-10-117-15-60.ec2.internal D4dXB2UqT, system ID: s_c68a08999a03[0;m
[0K  feature flags: FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR:true[0;m
[0K[36;1mResolving secrets[0;m[0;m
section_start:1720034230:prepare_executor
[0K[0K[36;1mPreparing the "docker" executor[0;m[0;m
[0KUsing Docker executor with image node:20 ...[0;m
[0KPulling docker image node:20 ...[0;m
[0KUsing docker image sha256:ae8076b16688a3523c14cde678df66f66973bf80338b8ac96c0aad82afb807d5 for node:20 with digest node@sha256:93d2e801dabc677ea0b30b47d3d729fab63ecb20be7ac0ab204cc3c65731297a ...[0;m
[0KNot using umask - FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR is set![0;m
section_end:1720034232:prepare_executor
[0Ksection_start:1720034232:prepare_script
[0K[0K[36;1mPreparing environment[0;m[0;m
Running on runner-d4dxb2uqt-project-26608-concurrent-0 via ip-10-117-15-60.ec2.internal...
section_end:1720034232:prepare_script
[0Ksection_start:1720034232:get_sources
[0K[0K[36;1mGetting source from Git repository[0;m[0;m
[32;1mFetching changes with git depth set to 20...[0;m
Reinitialized existing Git repository in /builds/infor-design/enterprise-ng/.git/
[32;1mChecking out 26684444 as detached HEAD (ref is fix/oxford-ci)...[0;m

[32;1mSkipping Git submodules setup[0;m
section_end:1720034234:get_sources
[0Ksection_start:1720034234:step_script
[0K[0K[36;1mExecuting "step_script" stage of the job script[0;m[0;m
[0KUsing docker image sha256:ae8076b16688a3523c14cde678df66f66973bf80338b8ac96c0aad82afb807d5 for node:20 with digest node@sha256:93d2e801dabc677ea0b30b47d3d729fab63ecb20be7ac0ab204cc3c65731297a ...[0;m
[32;1m$ npm run lint[0;m

> lint
> npx ng lint && npm run mdlint


Linting "ids-enterprise-ng-app"...

All files pass linting.


Linting "ids-enterprise-ng"...

All files pass linting.


> mdlint
> npm run mdlint:docs && npm run mdlint:src


> mdlint:docs
> npx markdownlint docs/ && npx markdownlint README.md


> mdlint:src
> npx markdownlint ./projects/ids-enterprise-ng/src/

[32;1m$ npm run test[0;m

> test
> npx ng test ids-enterprise-ng --code-coverage --watch=false

- Generating browser application bundles (phase: setup)...
03 07 2024 19:17:37.970:ERROR [config]: Error in config file!
  Error: Could not find Chrome (ver. 126.0.6478.63). This can occur if either
 1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or
 2. your cache path is incorrectly configured (which is: /root/.cache/puppeteer).
For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.
    at ChromeLauncher.resolveExecutablePath (/builds/infor-design/enterprise-ng/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ProductLauncher.js:295:27)
    at ChromeLauncher.executablePath (/builds/infor-design/enterprise-ng/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ChromeLauncher.js:209:25)
    at PuppeteerNode.executablePath (/builds/infor-design/enterprise-ng/node_modules/puppeteer-core/lib/cjs/puppeteer/node/PuppeteerNode.js:160:31)
    at Object.<anonymous> (/builds/infor-design/enterprise-ng/projects/ids-enterprise-ng/karma.conf.js:4:47)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
/builds/infor-design/enterprise-ng/node_modules/rxjs/dist/cjs/internal/util/reportUnhandledError.js:13
            throw err;
            ^

Error: Error in config file!
  Error: Could not find Chrome (ver. 126.0.6478.63). This can occur if either
 1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or
 2. your cache path is incorrectly configured (which is: /root/.cache/puppeteer).
For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.
    at ChromeLauncher.resolveExecutablePath (/builds/infor-design/enterprise-ng/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ProductLauncher.js:295:27)
    at ChromeLauncher.executablePath (/builds/infor-design/enterprise-ng/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ChromeLauncher.js:209:25)
    at PuppeteerNode.executablePath (/builds/infor-design/enterprise-ng/node_modules/puppeteer-core/lib/cjs/puppeteer/node/PuppeteerNode.js:160:31)
    at Object.<anonymous> (/builds/infor-design/enterprise-ng/projects/ids-enterprise-ng/karma.conf.js:4:47)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
    at fail (/builds/infor-design/enterprise-ng/node_modules/karma/lib/config.js:409:19)
    at Object.parseConfig (/builds/infor-design/enterprise-ng/node_modules/karma/lib/config.js:447:14)
    at /builds/infor-design/enterprise-ng/node_modules/@angular-devkit/build-angular/src/builders/karma/index.js:132:54

Node.js v20.15.0
section_end:1720034258:step_script
[0Ksection_start:1720034258:cleanup_file_variables
[0K[0K[36;1mCleaning up project directory and file based variables[0;m[0;m
section_end:1720034258:cleanup_file_variables
[0K[31;1mERROR: Job failed: exit code 1
[0;m
```