### PR TITLE
1735 - Fixed readonly in datepicker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## 18.1.0 Fixes
 
 - `[Datagrid]` Added all existing properties in `SohoDataGridCellChangeEvent`. ([#1199](https://github.com/infor-design/enterprise-ng/issues/1199))
+- `[Datepicker]` Fixed readonly not updating when datepicker is in form. ([#1735](https://github.com/infor-design/enterprise-ng/issues/1735))
 - `[Module Nav]` Fixed roles not being updated when changed before `AfterViewInit`. ([#1686](https://github.com/infor-design/enterprise-ng/issues/1677))
 - `[Popupmenu]` Updated example page to test bug on popupmenu title. ([#1700](https://github.com/infor-design/enterprise-ng/issues/1700))
 - `[Tabs]` Fix on `beforeCloseCallback` and updated example page. ([#1697](https://github.com/infor-design/enterprise-ng/issues/1697))

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -388,6 +388,11 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
         this.datepicker?.disable();
         this.isReadOnly = true;
       });
+    } else if (this.isReadOnly) {
+      this.ngZone.runOutsideAngular(() => {
+        this.datepicker?.readonly();
+        this.isReadOnly = true;
+      });
     } else {
       this.ngZone.runOutsideAngular(() => {
         this.datepicker?.enable();
@@ -409,14 +414,13 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
     // as enable() is called by both disabled()
     // and readonly().
     if (this.datepicker == null) {
-      this.isReadOnly = false;
       return;
     }
 
     // Set the status locally (for refreshing)
     this.isReadOnly = value === undefined || value === null ? false : value;
 
-    if (value) {
+    if (this.isReadOnly) {
       this.ngZone.runOutsideAngular(() => this.datepicker?.readonly());
     } else {
       this.ngZone.runOutsideAngular(() => {
@@ -542,6 +546,8 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
       if (this.internalValue) {
         this.datepicker?.setValue(this.internalValue, false);
       }
+
+      this.isReadOnly = this.datepicker?.element.prop('readonly');
       this.runUpdatedOnCheck = true;
     });
   }

--- a/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datepicker/soho-datepicker.component.ts
@@ -414,6 +414,7 @@ export class SohoDatePickerComponent extends BaseControlValueAccessor<string | n
     // as enable() is called by both disabled()
     // and readonly().
     if (this.datepicker == null) {
+      this.isReadOnly = false;
       return;
     }
 

--- a/src/app/form/form-reactive-form.demo.html
+++ b/src/app/form/form-reactive-form.demo.html
@@ -24,6 +24,12 @@
       </div>
 
       <div class="field">
+        <label for="standard-readonly" class="label">Standard Date (Readonly)</label>
+        <input soho-datepicker name="standard-readonly" dateFormat="MM/dd/yyyy" mode="standard" placeholder="MM/dd/yyyy"
+          formControlName="datepick" (change)="onChange($event)" [attr.readonly]="readOnly ? 'readonly' : null"/>
+      </div>
+
+      <div class="field">
         <label for="standardtime" class="label">Standard Time</label>
         <input soho-timepicker name="standardtime" formControlName="timepick" (change)="onChange($event)" />
       </div>

--- a/src/app/form/form-reactive-form.demo.ts
+++ b/src/app/form/form-reactive-form.demo.ts
@@ -46,6 +46,8 @@ export class FormReactiveFormDemoComponent implements AfterViewInit {
 
   public lookupData = productsData;
 
+  public readOnly = true;
+
   // @ts-ignore
   constructor(private formBuilder: UntypedFormBuilder) {
     // tslint:disable-next-line:max-line-length


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated isReadOnly value on init and on set disable

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1735 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/form-reactive
- Standard Date (Readonly) should be readonly

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
