### PR TITLE
EP#8767 - add closeCallback in typing definition

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 18.3.0
 
+## 18.4.0 Features
+
+- `[Notification]` Added `closeCallback` property to `NotificationOptions`. ([#1761](https://github.com/infor-design/enterprise/issues/8767))
+
 ## 18.3.0 Fixes
 
 - `[Datagrid]` Removed cellchange Generic Type. ([#1757](https://github.com/infor-design/enterprise-ng/issues/1757))

--- a/projects/ids-enterprise-typings/lib/notification/soho-notification.d.ts
+++ b/projects/ids-enterprise-typings/lib/notification/soho-notification.d.ts
@@ -31,6 +31,9 @@ interface SohoNotificationOptions {
   /** The text to show in the hyperlink. Leave empty for no link. */
   linkText?: string;
 
+  /* The closeCallback function to call when the notification is closed. */
+  closeCallback?: Function;
+
   /** Add extra attributes like id's to the component **/
   attributes?: Array<Object> | Object;
 }

--- a/src/app/notification/notification.demo.ts
+++ b/src/app/notification/notification.demo.ts
@@ -18,7 +18,7 @@ export class NotificationDemoComponent implements OnInit {
   ngOnInit() { }
 
   showNotification(type: SohoNotificationType = SohoNotificationService.INFO) {
-    this.notificationService.show({ id: `notif-${this.counter++}`, message: `${this.counter}) This is a Notification Message`, type });
+    this.notificationService.show({ id: `notif-${this.counter++}`, closeCallback: this.callbackFunc, message: `${this.counter}) This is a Notification Message`, type });
   }
 
   closeFirstNotification() {
@@ -31,6 +31,10 @@ export class NotificationDemoComponent implements OnInit {
         this.current = 0;
       }
     }
+  }
+
+  callbackFunc(): void {
+    console.log('Notification closed');
   }
 
   closeLatestNotification() {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds `closeCallback` setting in the typing definition of Notification.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/8767

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Build the dist from EP on this PR https://github.com/infor-design/enterprise/pull/8941 then replace the dist in node_modules/ids-enterprise
- Go to http://localhost:4200/ids-enterprise-ng-demo/notification
- Click `Show Notification Alert` button
- Close the notification via close icon
- Check the console tab and it should show a message `Notification closed`

<!-- 
Also Remember to...
- Update the changelog (if needed)
- Check back to make sure tests pass CI Checks
-->
