### PR TITLE
1761 - Updated parameters in setActiveCell

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 18.3.0
 
-## 18.4.0 Features
+## 18.3.0 Features
 
 - `[Datagrid]` Added `inlineEditor` property to `SohoDataGridColumn`. ([#1701](https://github.com/infor-design/enterprise-ng/issues/1701))
 - `[Notification]` Added `closeCallback` property to `NotificationOptions`. ([#1761](https://github.com/infor-design/enterprise/issues/1761))
@@ -11,6 +11,7 @@
 
 - `[ContextMenu]` Fixed position on angular wrapper for lazy load. ([#1670](https://github.com/infor-design/enterprise-ng/issues/1670))
 - `[Datagrid]` Removed cellchange Generic Type. ([#1757](https://github.com/infor-design/enterprise-ng/issues/1757))
+- `[Datagrid]` Updated parameters in `setActiveCell`. ([#1761](https://github.com/infor-design/enterprise-ng/issues/1761))
 - `[Tests]` Changed test framework to playwright. ([#8549](https://github.com/infor-design/enterprise/issues/8549))
 - `[Datagrid]` Added columnChange event type. ([#1734](https://github.com/infor-design/enterprise-ng/issues/1734))
 

--- a/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/datagrid/soho-datagrid.component.ts
@@ -2273,7 +2273,7 @@ export class SohoDataGridComponent implements OnInit, AfterViewInit, OnDestroy, 
    */
   public scrollRowIntoView(idx: number): void {
     this.ngZone.runOutsideAngular(() => {
-      this.datagrid?.setActiveCell(idx, 0);
+      this.datagrid?.setActiveCell(idx, 0, true);
     });
   }
 

--- a/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
+++ b/projects/ids-enterprise-typings/lib/datagrid/soho-datagrid.d.ts
@@ -1229,7 +1229,8 @@ interface SohoDataGridStatic {
   */
   toggleRowSelection(idx: number): void;
 
-  setActiveCell(idx: number, idx2: number): void;
+  /** Set active cell. nodeFocus to true to force focus on cell, default is false */
+  setActiveCell(row: number, cell: number, nodeFocus?: boolean): void;
 
   /* Gets info about the currently activated cell */
   activeCell: any;

--- a/src/app/datagrid/datagrid-fixedheader.demo.html
+++ b/src/app/datagrid/datagrid-fixedheader.demo.html
@@ -8,6 +8,7 @@
     <soho-toolbar-button-set>
       <button soho-button="icon" icon="process" id="validate-btn" class="btn-icon" title="Validate" (click)="onClick()"></button>
       <button soho-button="icon" icon="delete" id="delete-btn" class="btn-icon" title="Delete"></button>
+      <button soho-button="icon" icon="arrow-down" id="scroll-btn" class="btn-icon" title="Scroll" (click)="onClickDown()"></button>
     </soho-toolbar-button-set>
   </soho-toolbar>
 

--- a/src/app/datagrid/datagrid-fixedheader.demo.ts
+++ b/src/app/datagrid/datagrid-fixedheader.demo.ts
@@ -51,6 +51,10 @@ export class DataGridFixedHeaderDemoComponent implements AfterViewChecked, OnIni
     this.gridOptions = { ...this.gridOptions, rowHeight: 'large' }
   }
 
+  onClickDown() {
+    this.sohoDataGridComponent?.scrollRowIntoView(99);
+  }
+
   private buildGridOptions(): SohoDataGridOptions {
     return {
       columns: this.datagridPagingService?.getColumns(),


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Focusing cell is not the default behavior for setActiveCell in IDS anymore. Added all the new parameters and set focus to true for scrollRowIntoView

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #1761 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/datagrid-fixedheader
- Click on the arrow down button
- Should scroll down

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
