### PR TITLE
EP8779 - Added promise parameter to beforeClose

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 18.3.0 Features
 
 - `[Datagrid]` Added `inlineEditor` property to `SohoDataGridColumn`. ([#1701](https://github.com/infor-design/enterprise-ng/issues/1701))
+- `[Modal]` Added promise parameter to `beforeClose`. ([EP#8779](https://github.com/infor-design/enterprise/issues/8779))
 - `[Notification]` Added `closeCallback` property to `NotificationOptions`. ([#1761](https://github.com/infor-design/enterprise/issues/1761))
 
 ## 18.3.0 Fixes

--- a/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
+++ b/projects/ids-enterprise-ng/src/lib/modal-dialog/soho-modal-dialog.ref.ts
@@ -611,6 +611,7 @@ export class SohoModalDialogRef<T> {
    * Registers a before close guard.
    *
    * @param eventFn - the function to call before closing the dialog.
+   * @param isAsync - if callback is asynchronous or not
    */
   beforeClose(eventFn: SohoModalDialogEventVetoFunction<T>): SohoModalDialogRef<T> {
     (this.eventGuard as any).beforeClose = eventFn;
@@ -789,7 +790,7 @@ export type SohoModalDialogEventFunction<T> = (result: any, dialogRef: SohoModal
  *
  * @param dialogRef - the dialog reference; never null.
  */
-export type SohoModalDialogEventVetoFunction<T> = (dialogRef: SohoModalDialogRef<T>) => boolean;
+export type SohoModalDialogEventVetoFunction<T> = (dialogRef: SohoModalDialogRef<T>) => boolean | Promise<boolean>;
 
 /**
  * Contract for all SohoModalDialogComponents.

--- a/src/app/modal-dialog/modal-dialog.demo.html
+++ b/src/app/modal-dialog/modal-dialog.demo.html
@@ -6,7 +6,7 @@
       <button id="open-nested-btn" soho-button (click)="openNested()">Nested</button>
       <button id="open-message-btn" soho-button (click)="openMessage()">Message</button>
       <button id="open-vetoable-btn" soho-button (click)="openVetoable()">Vetoable</button>
-      <button id="open-vetoable-simple-btn" soho-button (click)="openVetoableSimple()">Vetoable Simple</button>
+      <button id="open-promise-btn" soho-button (click)="openPromise()">Promise</button>
       <button id="open-dialog-result-btn" soho-button (click)="openDialogResult()">Dialog Result</button>
       <button id="open-dialog-datagrid-btn" soho-button (click)="openDialogDataGrid()">Dialog with DataGrid</button>
       <button id="open-dialog-picker-btn" soho-button (click)="openDialogPicker()">Dialog with Picker</button>

--- a/src/app/modal-dialog/modal-dialog.demo.html
+++ b/src/app/modal-dialog/modal-dialog.demo.html
@@ -6,6 +6,7 @@
       <button id="open-nested-btn" soho-button (click)="openNested()">Nested</button>
       <button id="open-message-btn" soho-button (click)="openMessage()">Message</button>
       <button id="open-vetoable-btn" soho-button (click)="openVetoable()">Vetoable</button>
+      <button id="open-vetoable-simple-btn" soho-button (click)="openVetoableSimple()">Vetoable Simple</button>
       <button id="open-dialog-result-btn" soho-button (click)="openDialogResult()">Dialog Result</button>
       <button id="open-dialog-datagrid-btn" soho-button (click)="openDialogDataGrid()">Dialog with DataGrid</button>
       <button id="open-dialog-picker-btn" soho-button (click)="openDialogPicker()">Dialog with Picker</button>

--- a/src/app/modal-dialog/modal-dialog.demo.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.ts
@@ -178,7 +178,7 @@ export class ModalDialogDemoComponent {
       });
   }
 
-  openVetoableSimple() {
+  openPromise() {
     const beforeClose = (ref: any) => {
       return new Promise<boolean>((resolve) => {
         setTimeout(() => {

--- a/src/app/modal-dialog/modal-dialog.demo.ts
+++ b/src/app/modal-dialog/modal-dialog.demo.ts
@@ -179,12 +179,20 @@ export class ModalDialogDemoComponent {
   }
 
   openVetoableSimple() {
+    const beforeClose = (ref: any) => {
+      return new Promise<boolean>((resolve) => {
+        setTimeout(() => {
+          resolve(ref.dialogResult === 'CANCEL');
+        }, 1000);
+      });
+    }
+
     const dialogRef = this.modalService
       .message('<span class="message">Are you sure you want to delete this page?</span>')
       .buttons(
         [
           {
-            text: 'Cancel', click: () => {
+            text: 'Cancel Slowly', click: () => {
               dialogRef.close('CANCEL');
             }
           },
@@ -196,7 +204,7 @@ export class ModalDialogDemoComponent {
         ])
       .title(this.title)
       .open()
-      .beforeClose((ref: any) => ref.dialogResult === 'CANCEL')
+      .beforeClose(beforeClose)
       .afterClose((result: any) => {
         this.closeResult = result;
       });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added promise option for beforeClose, should be able to use boolean or Promise<boolean> as a return value.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/8779

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4200/ids-enterprise-ng-demo/modal-dialog
- Click on Promise button
- On modal, click on "Cancel Slowly"
- Should close in 1 second

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
